### PR TITLE
(feat) close the ‘fsync’ and ‘wal’ config of rheakv by default

### DIFF
--- a/jraft-rheakv/rheakv-core/src/main/java/com/alipay/sofa/jraft/rhea/options/RocksDBOptions.java
+++ b/jraft-rheakv/rheakv-core/src/main/java/com/alipay/sofa/jraft/rhea/options/RocksDBOptions.java
@@ -23,7 +23,13 @@ package com.alipay.sofa.jraft.rhea.options;
  */
 public class RocksDBOptions {
 
-    private boolean sync                              = true;
+    // The raft log used fsync by default, and the correctness of
+    // state-machine data with rheakv depends on the raft log + snapshot,
+    // so we do not need to fsync.
+    private boolean sync                              = false;
+    // For the same reason(See the comment of ‘sync’ field), we also
+    // don't need WAL, which can improve performance.
+    private boolean disableWAL                        = true;
     private boolean fastSnapshot                      = false;
     private boolean openStatisticsCollector           = true;
     private long    statisticsCallbackIntervalSeconds = 0;
@@ -51,6 +57,14 @@ public class RocksDBOptions {
      */
     public void setSync(boolean sync) {
         this.sync = sync;
+    }
+
+    public boolean isDisableWAL() {
+        return disableWAL;
+    }
+
+    public void setDisableWAL(boolean disableWAL) {
+        this.disableWAL = disableWAL;
     }
 
     public boolean isFastSnapshot() {

--- a/jraft-rheakv/rheakv-core/src/main/java/com/alipay/sofa/jraft/rhea/storage/AbstractKVStoreSnapshotFile.java
+++ b/jraft-rheakv/rheakv-core/src/main/java/com/alipay/sofa/jraft/rhea/storage/AbstractKVStoreSnapshotFile.java
@@ -96,8 +96,10 @@ public abstract class AbstractKVStoreSnapshotFile implements KVStoreSnapshotFile
         final String writerPath = writer.getPath();
         final String outputFile = Paths.get(writerPath, SNAPSHOT_ARCHIVE).toString();
         try {
-            try (final ZipOutputStream out = new ZipOutputStream(new FileOutputStream(outputFile))) {
-                ZipUtil.compressDirectoryToZipFile(writerPath, SNAPSHOT_DIR, out);
+            try (final FileOutputStream fOut = new FileOutputStream(outputFile);
+                    final ZipOutputStream zOut = new ZipOutputStream(fOut)) {
+                ZipUtil.compressDirectoryToZipFile(writerPath, SNAPSHOT_DIR, zOut);
+                fOut.getFD().sync();
             }
             if (writer.addFile(SNAPSHOT_ARCHIVE, meta)) {
                 done.run(Status.OK());

--- a/jraft-rheakv/rheakv-core/src/main/java/com/alipay/sofa/jraft/rhea/storage/RocksRawKVStore.java
+++ b/jraft-rheakv/rheakv-core/src/main/java/com/alipay/sofa/jraft/rhea/storage/RocksRawKVStore.java
@@ -153,7 +153,7 @@ public class RocksRawKVStore extends BatchRawKVStore<RocksDBOptions> {
             this.cfDescriptors.add(new ColumnFamilyDescriptor(BytesUtil.writeUtf8("RHEA_FENCING"), cfOptions));
             this.writeOptions = new WriteOptions();
             this.writeOptions.setSync(opts.isSync());
-            this.writeOptions.setDisableWAL(false);
+            this.writeOptions.setDisableWAL(opts.isDisableWAL());
             // Delete existing data, relying on raft's snapshot and log playback
             // to reply to the data is the correct behavior.
             destroyRocksDB(opts);

--- a/jraft-rheakv/rheakv-core/src/test/resources/benchmark/conf/rhea_test_cluster_1.yaml
+++ b/jraft-rheakv/rheakv-core/src/test/resources/benchmark/conf/rhea_test_cluster_1.yaml
@@ -9,7 +9,6 @@ placementDriverOptions:
 
 storeEngineOptions:
   rocksDBOptions:
-    sync: true
     dbPath: rhea_db/
   raftDataPath: rhea_raft/
   serverAddress:

--- a/jraft-rheakv/rheakv-core/src/test/resources/benchmark/conf/rhea_test_cluster_2.yaml
+++ b/jraft-rheakv/rheakv-core/src/test/resources/benchmark/conf/rhea_test_cluster_2.yaml
@@ -9,7 +9,6 @@ placementDriverOptions:
 
 storeEngineOptions:
   rocksDBOptions:
-    sync: true
     dbPath: rhea_db/
   raftDataPath: rhea_raft/
   serverAddress:

--- a/jraft-rheakv/rheakv-core/src/test/resources/benchmark/conf/rhea_test_cluster_3.yaml
+++ b/jraft-rheakv/rheakv-core/src/test/resources/benchmark/conf/rhea_test_cluster_3.yaml
@@ -9,7 +9,6 @@ placementDriverOptions:
 
 storeEngineOptions:
   rocksDBOptions:
-    sync: true
     dbPath: rhea_db/
   raftDataPath: rhea_raft/
   serverAddress:

--- a/jraft-rheakv/rheakv-core/src/test/resources/conf/rhea_test_cluster_1.yaml
+++ b/jraft-rheakv/rheakv-core/src/test/resources/conf/rhea_test_cluster_1.yaml
@@ -9,7 +9,6 @@ placementDriverOptions:
 
 storeEngineOptions:
   rocksDBOptions:
-    sync: true
     dbPath: rhea_db/
   raftDataPath: rhea_raft/
   serverAddress:

--- a/jraft-rheakv/rheakv-core/src/test/resources/conf/rhea_test_cluster_2.yaml
+++ b/jraft-rheakv/rheakv-core/src/test/resources/conf/rhea_test_cluster_2.yaml
@@ -9,7 +9,6 @@ placementDriverOptions:
 
 storeEngineOptions:
   rocksDBOptions:
-    sync: true
     dbPath: rhea_db/
   raftDataPath: rhea_raft/
   serverAddress:

--- a/jraft-rheakv/rheakv-core/src/test/resources/pd_conf/rhea_pd_test_1.yaml
+++ b/jraft-rheakv/rheakv-core/src/test/resources/pd_conf/rhea_pd_test_1.yaml
@@ -10,7 +10,6 @@ placementDriverOptions:
 
 storeEngineOptions:
   rocksDBOptions:
-    sync: true
     dbPath: rhea_pd_db/
   raftDataPath: rhea_pd_raft/
   serverAddress:

--- a/jraft-rheakv/rheakv-core/src/test/resources/pd_conf/rhea_pd_test_2.yaml
+++ b/jraft-rheakv/rheakv-core/src/test/resources/pd_conf/rhea_pd_test_2.yaml
@@ -10,7 +10,6 @@ placementDriverOptions:
 
 storeEngineOptions:
   rocksDBOptions:
-    sync: true
     dbPath: rhea_pd_db/
   raftDataPath: rhea_pd_raft/
   serverAddress:

--- a/jraft-rheakv/rheakv-core/src/test/resources/pd_conf/rhea_pd_test_3.yaml
+++ b/jraft-rheakv/rheakv-core/src/test/resources/pd_conf/rhea_pd_test_3.yaml
@@ -10,7 +10,6 @@ placementDriverOptions:
 
 storeEngineOptions:
   rocksDBOptions:
-    sync: true
     dbPath: rhea_pd_db/
   raftDataPath: rhea_pd_raft/
   serverAddress:

--- a/jraft-rheakv/rheakv-pd/src/test/resources/pd/pd_1.yaml
+++ b/jraft-rheakv/rheakv-pd/src/test/resources/pd/pd_1.yaml
@@ -8,7 +8,6 @@ rheaKVStoreOptions:
 
   storeEngineOptions:
     rocksDBOptions:
-      sync: true
       dbPath: pd_db/
     raftDataPath: pd_raft/
     serverAddress:

--- a/jraft-rheakv/rheakv-pd/src/test/resources/pd/pd_2.yaml
+++ b/jraft-rheakv/rheakv-pd/src/test/resources/pd/pd_2.yaml
@@ -8,7 +8,6 @@ rheaKVStoreOptions:
 
   storeEngineOptions:
     rocksDBOptions:
-      sync: true
       dbPath: pd_db/
     raftDataPath: pd_raft/
     serverAddress:

--- a/jraft-rheakv/rheakv-pd/src/test/resources/pd/pd_3.yaml
+++ b/jraft-rheakv/rheakv-pd/src/test/resources/pd/pd_3.yaml
@@ -8,7 +8,6 @@ rheaKVStoreOptions:
 
   storeEngineOptions:
     rocksDBOptions:
-      sync: true
       dbPath: pd_db/
     raftDataPath: pd_raft/
     serverAddress:


### PR DESCRIPTION
### Motivation:

The raft log used fsync by default, and the correctness of state-machine data with rheakv depends on the raft log + snapshot, so we do not need to fsync.
For the same reason, we also don't need WAL, which can improve performance.

### Modification:

Close the ‘fsync’ and ‘wal’ config of rheakv by default

### Result:

Fixes #155 


