### PR TITLE
(feat) add pooled buf allocator

### DIFF
--- a/jraft-core/src/main/java/com/alipay/sofa/jraft/core/NodeMetrics.java
+++ b/jraft-core/src/main/java/com/alipay/sofa/jraft/core/NodeMetrics.java
@@ -62,6 +62,15 @@ public class NodeMetrics {
     }
 
     /**
+     * Whether metric is enabled.
+     *
+     * @return true if metric is enabled
+     */
+    public boolean isEnabled() {
+        return this.metrics != null;
+    }
+
+    /**
      * Records operation times.
      * @param key
      * @param times

--- a/jraft-core/src/main/java/com/alipay/sofa/jraft/core/Replicator.java
+++ b/jraft-core/src/main/java/com/alipay/sofa/jraft/core/Replicator.java
@@ -50,9 +50,10 @@ import com.alipay.sofa.jraft.rpc.RpcRequests.TimeoutNowResponse;
 import com.alipay.sofa.jraft.rpc.RpcResponseClosure;
 import com.alipay.sofa.jraft.rpc.RpcResponseClosureAdapter;
 import com.alipay.sofa.jraft.storage.snapshot.SnapshotReader;
-import com.alipay.sofa.jraft.util.AdaptiveBufAllocator;
 import com.alipay.sofa.jraft.util.ByteBufferCollector;
 import com.alipay.sofa.jraft.util.OnlyForTest;
+import com.alipay.sofa.jraft.util.Recyclable;
+import com.alipay.sofa.jraft.util.RecyclableByteBufferList;
 import com.alipay.sofa.jraft.util.RecycleUtil;
 import com.alipay.sofa.jraft.util.Requires;
 import com.alipay.sofa.jraft.util.ThreadId;
@@ -61,7 +62,6 @@ import com.codahale.metrics.Gauge;
 import com.codahale.metrics.Metric;
 import com.codahale.metrics.MetricRegistry;
 import com.codahale.metrics.MetricSet;
-import com.google.protobuf.ByteString;
 import com.google.protobuf.Message;
 import com.google.protobuf.ZeroByteStringHelper;
 
@@ -74,53 +74,51 @@ import com.google.protobuf.ZeroByteStringHelper;
 @ThreadSafe
 public class Replicator implements ThreadId.OnError {
 
-    private static final Logger               LOG                    = LoggerFactory.getLogger(Replicator.class);
+    private static final Logger              LOG                    = LoggerFactory.getLogger(Replicator.class);
 
-    private final RaftClientService           rpcService;
+    private final RaftClientService          rpcService;
     // Next sending log index
-    private volatile long                     nextIndex;
-    private int                               consecutiveErrorTimes  = 0;
-    private boolean                           hasSucceeded;
-    private long                              timeoutNowIndex;
-    private volatile long                     lastRpcSendTimestamp;
-    private volatile long                     heartbeatCounter       = 0;
-    private volatile long                     appendEntriesCounter   = 0;
-    private volatile long                     installSnapshotCounter = 0;
-    protected Stat                            statInfo               = new Stat();
-    private ScheduledFuture<?>                blockTimer;
+    private volatile long                    nextIndex;
+    private int                              consecutiveErrorTimes  = 0;
+    private boolean                          hasSucceeded;
+    private long                             timeoutNowIndex;
+    private volatile long                    lastRpcSendTimestamp;
+    private volatile long                    heartbeatCounter       = 0;
+    private volatile long                    appendEntriesCounter   = 0;
+    private volatile long                    installSnapshotCounter = 0;
+    protected Stat                           statInfo               = new Stat();
+    private ScheduledFuture<?>               blockTimer;
 
     // Cached the latest RPC in-flight request.
-    private Inflight                          rpcInFly;
+    private Inflight                         rpcInFly;
     // Heartbeat RPC future
-    private Future<Message>                   heartbeatInFly;
+    private Future<Message>                  heartbeatInFly;
     // Timeout request RPC future
-    private Future<Message>                   timeoutNowInFly;
+    private Future<Message>                  timeoutNowInFly;
     // In-flight RPC requests, FIFO queue
-    private final ArrayDeque<Inflight>        inflights              = new ArrayDeque<>();
+    private final ArrayDeque<Inflight>       inflights              = new ArrayDeque<>();
 
-    private long                              waitId                 = -1L;
-    protected ThreadId                        id;
-    private final ReplicatorOptions           options;
-    private final RaftOptions                 raftOptions;
+    private long                             waitId                 = -1L;
+    protected ThreadId                       id;
+    private final ReplicatorOptions          options;
+    private final RaftOptions                raftOptions;
 
-    private ScheduledFuture<?>                heartbeatTimer;
-    private volatile SnapshotReader           reader;
-    private CatchUpClosure                    catchUpClosure;
-    private final TimerManager                timerManager;
-    private final NodeMetrics                 nodeMetrics;
-    private volatile State                    state;
+    private ScheduledFuture<?>               heartbeatTimer;
+    private volatile SnapshotReader          reader;
+    private CatchUpClosure                   catchUpClosure;
+    private final TimerManager               timerManager;
+    private final NodeMetrics                nodeMetrics;
+    private volatile State                   state;
 
     // Request sequence
-    private int                               reqSeq                 = 0;
+    private int                              reqSeq                 = 0;
     // Response sequence
-    private int                               requiredNextSeq        = 0;
+    private int                              requiredNextSeq        = 0;
     // Replicator state reset version
-    private int                               version                = 0;
+    private int                              version                = 0;
 
     // Pending response queue;
-    private final PriorityQueue<RpcResponse>  pendingResponses       = new PriorityQueue<>(50);
-
-    private final AdaptiveBufAllocator.Handle adaptiveAllocator      = AdaptiveBufAllocator.DEFAULT.newHandle();
+    private final PriorityQueue<RpcResponse> pendingResponses       = new PriorityQueue<>(50);
 
     private int getAndIncrementReqSeq() {
         final int prev = this.reqSeq;
@@ -653,8 +651,8 @@ public class Replicator implements ThreadId.OnError {
     }
 
     boolean prepareEntry(final long nextSendingIndex, final int offset, final RaftOutter.EntryMeta.Builder emb,
-                         final ByteBufferCollector dateBuffer) {
-        if (dateBuffer.capacity() >= this.raftOptions.getMaxBodySize()) {
+                         final RecyclableByteBufferList dateBuffer) {
+        if (dateBuffer.getByteNumber() >= this.raftOptions.getMaxBodySize()) {
             return false;
         }
         final long logIndex = nextSendingIndex + offset;
@@ -684,8 +682,8 @@ public class Replicator implements ThreadId.OnError {
         final int remaining = entry.getData() != null ? entry.getData().remaining() : 0;
         emb.setDataLen(remaining);
         if (entry.getData() != null) {
-            //should slice entry data
-            dateBuffer.put(entry.getData().slice());
+            // should slice entry data
+            dateBuffer.add(entry.getData().slice());
         }
         return true;
     }
@@ -1356,37 +1354,39 @@ public class Replicator implements ThreadId.OnError {
             return false;
         }
 
+        ByteBufferCollector dataBuf = null;
         final int maxEntriesSize = this.raftOptions.getMaxEntriesSize();
-        final ByteBufferCollector dataBuffer = this.adaptiveAllocator.allocateByRecyclers();
-        recordByteBufferCollectorMetric(dataBuffer);
-        for (int i = 0; i < maxEntriesSize; i++) {
-            final RaftOutter.EntryMeta.Builder emb = RaftOutter.EntryMeta.newBuilder();
-            if (!prepareEntry(nextSendingIndex, i, emb, dataBuffer)) {
-                break;
+        final RecyclableByteBufferList byteBufList = RecyclableByteBufferList.newInstance();
+        try {
+            for (int i = 0; i < maxEntriesSize; i++) {
+                final RaftOutter.EntryMeta.Builder emb = RaftOutter.EntryMeta.newBuilder();
+                if (!prepareEntry(nextSendingIndex, i, emb, byteBufList)) {
+                    break;
+                }
+                rb.addEntries(emb.build());
             }
-            rb.addEntries(emb.build());
-        }
-        if (rb.getEntriesCount() == 0) {
-            if (nextSendingIndex < this.options.getLogManager().getFirstLogIndex()) {
-                installSnapshot();
+            if (rb.getEntriesCount() == 0) {
+                if (nextSendingIndex < this.options.getLogManager().getFirstLogIndex()) {
+                    installSnapshot();
+                    return false;
+                }
+                // _id is unlock in _wait_more
+                waitMoreEntries(nextSendingIndex);
                 return false;
             }
-            // _id is unlock in _wait_more
-            waitMoreEntries(nextSendingIndex);
-            return false;
+            if (byteBufList.getByteNumber() > 0) {
+                dataBuf = ByteBufferCollector.allocateByRecyclers(byteBufList.getByteNumber());
+                for (final ByteBuffer b : byteBufList) {
+                    dataBuf.put(b);
+                }
+                final ByteBuffer buf = dataBuf.getBuffer();
+                buf.flip();
+                rb.setData(ZeroByteStringHelper.wrap(buf));
+            }
+        } finally {
+            RecycleUtil.recycle(byteBufList);
         }
 
-        if (dataBuffer.capacity() > 0) {
-            final ByteBuffer buf = dataBuffer.getBuffer();
-            buf.flip();
-            final int remaining = buf.remaining();
-            this.adaptiveAllocator.record(remaining);
-            if (remaining > 0) {
-                rb.setData(ZeroByteStringHelper.wrap(buf));
-            } else {
-                rb.setData(ByteString.EMPTY);
-            }
-        }
         final AppendEntriesRequest request = rb.build();
         if (LOG.isDebugEnabled()) {
             LOG.debug(
@@ -1399,6 +1399,7 @@ public class Replicator implements ThreadId.OnError {
         this.statInfo.firstLogIndex = rb.getPrevLogIndex() + 1;
         this.statInfo.lastLogIndex = rb.getPrevLogIndex() + rb.getEntriesCount();
 
+        final Recyclable recyclable = dataBuf;
         final int v = this.version;
         final long monotonicSendTimeMs = Utils.monotonicMs();
         final int seq = getAndIncrementReqSeq();
@@ -1407,7 +1408,7 @@ public class Replicator implements ThreadId.OnError {
 
                 @Override
                 public void run(final Status status) {
-                    RecycleUtil.recycle(dataBuffer);
+                    RecycleUtil.recycle(recyclable);
                     onRpcReturned(Replicator.this.id, RequestType.AppendEntries, status, request, getResponse(), seq,
                         v, monotonicSendTimeMs);
                 }
@@ -1417,17 +1418,6 @@ public class Replicator implements ThreadId.OnError {
             seq, rpcFuture);
         return true;
 
-    }
-
-    private void recordByteBufferCollectorMetric(final ByteBufferCollector collector) {
-        if (this.nodeMetrics.isEnabled()) {
-            final String threadName = Thread.currentThread().getName();
-            this.nodeMetrics.recordSize("buffer-collector-thread-local-capacity-" + threadName,
-                ByteBufferCollector.threadLocalCapacity());
-            this.nodeMetrics.recordSize("buffer-collector-thread-local-size-" + threadName,
-                ByteBufferCollector.threadLocalSize());
-            this.nodeMetrics.recordSize("buffer-collector-capacity", collector.capacity());
-        }
     }
 
     public static void sendHeartbeat(final ThreadId id, final RpcResponseClosure<AppendEntriesResponse> closure) {

--- a/jraft-core/src/main/java/com/alipay/sofa/jraft/core/Replicator.java
+++ b/jraft-core/src/main/java/com/alipay/sofa/jraft/core/Replicator.java
@@ -1357,7 +1357,7 @@ public class Replicator implements ThreadId.OnError {
         }
 
         final int maxEntriesSize = this.raftOptions.getMaxEntriesSize();
-        final ByteBufferCollector dataBuffer = this.adaptiveAllocator.allocateRecycleRequired();
+        final ByteBufferCollector dataBuffer = this.adaptiveAllocator.allocateByRecyclers();
         for (int i = 0; i < maxEntriesSize; i++) {
             final RaftOutter.EntryMeta.Builder emb = RaftOutter.EntryMeta.newBuilder();
             if (!prepareEntry(nextSendingIndex, i, emb, dataBuffer)) {

--- a/jraft-core/src/main/java/com/alipay/sofa/jraft/core/Replicator.java
+++ b/jraft-core/src/main/java/com/alipay/sofa/jraft/core/Replicator.java
@@ -53,6 +53,7 @@ import com.alipay.sofa.jraft.storage.snapshot.SnapshotReader;
 import com.alipay.sofa.jraft.util.AdaptiveBufAllocator;
 import com.alipay.sofa.jraft.util.ByteBufferCollector;
 import com.alipay.sofa.jraft.util.OnlyForTest;
+import com.alipay.sofa.jraft.util.RecycleUtil;
 import com.alipay.sofa.jraft.util.Requires;
 import com.alipay.sofa.jraft.util.ThreadId;
 import com.alipay.sofa.jraft.util.Utils;
@@ -1356,7 +1357,7 @@ public class Replicator implements ThreadId.OnError {
         }
 
         final int maxEntriesSize = this.raftOptions.getMaxEntriesSize();
-        final ByteBufferCollector dataBuffer = this.adaptiveAllocator.allocate();
+        final ByteBufferCollector dataBuffer = this.adaptiveAllocator.allocateRecycleRequired();
         for (int i = 0; i < maxEntriesSize; i++) {
             final RaftOutter.EntryMeta.Builder emb = RaftOutter.EntryMeta.newBuilder();
             if (!prepareEntry(nextSendingIndex, i, emb, dataBuffer)) {
@@ -1405,6 +1406,7 @@ public class Replicator implements ThreadId.OnError {
 
                 @Override
                 public void run(final Status status) {
+                    RecycleUtil.recycle(dataBuffer);
                     onRpcReturned(Replicator.this.id, RequestType.AppendEntries, status, request, getResponse(), seq,
                         v, monotonicSendTimeMs);
                 }

--- a/jraft-core/src/main/java/com/alipay/sofa/jraft/core/Replicator.java
+++ b/jraft-core/src/main/java/com/alipay/sofa/jraft/core/Replicator.java
@@ -652,7 +652,7 @@ public class Replicator implements ThreadId.OnError {
 
     boolean prepareEntry(final long nextSendingIndex, final int offset, final RaftOutter.EntryMeta.Builder emb,
                          final RecyclableByteBufferList dateBuffer) {
-        if (dateBuffer.getByteNumber() >= this.raftOptions.getMaxBodySize()) {
+        if (dateBuffer.getCapacity() >= this.raftOptions.getMaxBodySize()) {
             return false;
         }
         final long logIndex = nextSendingIndex + offset;
@@ -1374,8 +1374,8 @@ public class Replicator implements ThreadId.OnError {
                 waitMoreEntries(nextSendingIndex);
                 return false;
             }
-            if (byteBufList.getByteNumber() > 0) {
-                dataBuf = ByteBufferCollector.allocateByRecyclers(byteBufList.getByteNumber());
+            if (byteBufList.getCapacity() > 0) {
+                dataBuf = ByteBufferCollector.allocateByRecyclers(byteBufList.getCapacity());
                 for (final ByteBuffer b : byteBufList) {
                     dataBuf.put(b);
                 }

--- a/jraft-core/src/main/java/com/alipay/sofa/jraft/util/AdaptiveBufAllocator.java
+++ b/jraft-core/src/main/java/com/alipay/sofa/jraft/util/AdaptiveBufAllocator.java
@@ -1,0 +1,198 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alipay.sofa.jraft.util;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * The code comes from https://github.com/netty/netty/blob/4.1/transport/src/main/java/io/netty/channel/AdaptiveRecvByteBufAllocator.java
+ *
+ * @author jiachun.fjc
+ */
+public class AdaptiveBufAllocator {
+
+    private static final int                 DEFAULT_MINIMUM = 64;
+    private static final int                 DEFAULT_INITIAL = 512;
+    private static final int                 DEFAULT_MAXIMUM = 524288;
+
+    private static final int                 INDEX_INCREMENT = 4;
+    private static final int                 INDEX_DECREMENT = 1;
+
+    private static final int[]               SIZE_TABLE;
+
+    static {
+        final List<Integer> sizeTable = new ArrayList<>();
+        for (int i = 16; i < 512; i += 16) {
+            sizeTable.add(i);
+        }
+
+        for (int i = 512; i > 0; i <<= 1) {
+            sizeTable.add(i);
+        }
+
+        SIZE_TABLE = new int[sizeTable.size()];
+        for (int i = 0; i < SIZE_TABLE.length; i++) {
+            SIZE_TABLE[i] = sizeTable.get(i);
+        }
+    }
+
+    public static final AdaptiveBufAllocator DEFAULT         = new AdaptiveBufAllocator();
+
+    private static int getSizeTableIndex(final int size) {
+        for (int low = 0, high = SIZE_TABLE.length - 1;;) {
+            if (high < low) {
+                return low;
+            }
+            if (high == low) {
+                return high;
+            }
+
+            final int mid = low + high >>> 1;
+            final int a = SIZE_TABLE[mid];
+            final int b = SIZE_TABLE[mid + 1];
+            if (size > b) {
+                low = mid + 1;
+            } else if (size < a) {
+                high = mid - 1;
+            } else if (size == a) {
+                return mid;
+            } else {
+                return mid + 1;
+            }
+        }
+    }
+
+    public interface Handle {
+
+        /**
+         * Creates a new buffer whose capacity is probably large enough to write all outbound data and small
+         * enough not to waste its space.
+         */
+        ByteBufferCollector allocate();
+
+        /**
+         * Similar to {@link #allocate()} except that it does not allocate anything but
+         * just tells the capacity.
+         */
+        int guess();
+
+        /**
+         * Records the the actual number of wrote bytes in the previous write operation so that the allocator
+         * allocates the buffer with potentially more correct capacity.
+         *
+         * @param actualWroteBytes the actual number of wrote bytes in the previous allocate operation
+         */
+        void record(final int actualWroteBytes);
+    }
+
+    private static final class HandleImpl implements Handle {
+
+        private final int minIndex;
+        private final int maxIndex;
+        private int       index;
+        private int       nextAllocateBufSize;
+        private boolean   decreaseNow;
+
+        HandleImpl(int minIndex, int maxIndex, int initial) {
+            this.minIndex = minIndex;
+            this.maxIndex = maxIndex;
+
+            this.index = getSizeTableIndex(initial);
+            this.nextAllocateBufSize = SIZE_TABLE[this.index];
+        }
+
+        @Override
+        public ByteBufferCollector allocate() {
+            return ByteBufferCollector.allocate(guess());
+        }
+
+        @Override
+        public int guess() {
+            return this.nextAllocateBufSize;
+        }
+
+        @Override
+        public void record(final int actualWroteBytes) {
+            if (actualWroteBytes <= SIZE_TABLE[Math.max(0, this.index - INDEX_DECREMENT - 1)]) {
+                if (this.decreaseNow) {
+                    this.index = Math.max(this.index - INDEX_DECREMENT, this.minIndex);
+                    this.nextAllocateBufSize = SIZE_TABLE[this.index];
+                    this.decreaseNow = false;
+                } else {
+                    this.decreaseNow = true;
+                }
+            } else if (actualWroteBytes >= this.nextAllocateBufSize) {
+                this.index = Math.min(this.index + INDEX_INCREMENT, this.maxIndex);
+                this.nextAllocateBufSize = SIZE_TABLE[this.index];
+                this.decreaseNow = false;
+            }
+        }
+    }
+
+    private final int minIndex;
+    private final int maxIndex;
+    private final int initial;
+
+    /**
+     * Creates a new predictor with the default parameters.  With the default
+     * parameters, the expected buffer size starts from {@code 512}, does not
+     * go down below {@code 64}, and does not go up above {@code 524288}.
+     */
+    private AdaptiveBufAllocator() {
+        this(DEFAULT_MINIMUM, DEFAULT_INITIAL, DEFAULT_MAXIMUM);
+    }
+
+    /**
+     * Creates a new predictor with the specified parameters.
+     *
+     * @param minimum the inclusive lower bound of the expected buffer size
+     * @param initial the initial buffer size when no feed back was received
+     * @param maximum the inclusive upper bound of the expected buffer size
+     */
+    public AdaptiveBufAllocator(int minimum, int initial, int maximum) {
+        if (minimum <= 0) {
+            throw new IllegalArgumentException("minimum: " + minimum);
+        }
+        if (initial < minimum) {
+            throw new IllegalArgumentException("initial: " + initial);
+        }
+        if (maximum < initial) {
+            throw new IllegalArgumentException("maximum: " + maximum);
+        }
+
+        int minIndex = getSizeTableIndex(minimum);
+        if (SIZE_TABLE[minIndex] < minimum) {
+            this.minIndex = minIndex + 1;
+        } else {
+            this.minIndex = minIndex;
+        }
+
+        int maxIndex = getSizeTableIndex(maximum);
+        if (SIZE_TABLE[maxIndex] > maximum) {
+            this.maxIndex = maxIndex - 1;
+        } else {
+            this.maxIndex = maxIndex;
+        }
+
+        this.initial = initial;
+    }
+
+    public Handle newHandle() {
+        return new AdaptiveBufAllocator.HandleImpl(this.minIndex, this.maxIndex, this.initial);
+    }
+}

--- a/jraft-core/src/main/java/com/alipay/sofa/jraft/util/AdaptiveBufAllocator.java
+++ b/jraft-core/src/main/java/com/alipay/sofa/jraft/util/AdaptiveBufAllocator.java
@@ -176,24 +176,18 @@ public class AdaptiveBufAllocator {
      * @param maximum the inclusive upper bound of the expected buffer size
      */
     public AdaptiveBufAllocator(int minimum, int initial, int maximum) {
-        if (minimum <= 0) {
-            throw new IllegalArgumentException("minimum: " + minimum);
-        }
-        if (initial < minimum) {
-            throw new IllegalArgumentException("initial: " + initial);
-        }
-        if (maximum < initial) {
-            throw new IllegalArgumentException("maximum: " + maximum);
-        }
+        Requires.requireTrue(minimum > 0, "minimum: " + minimum);
+        Requires.requireTrue(initial >= minimum, "initial: " + initial);
+        Requires.requireTrue(initial <= maximum, "maximum: " + maximum);
 
-        int minIndex = getSizeTableIndex(minimum);
+        final int minIndex = getSizeTableIndex(minimum);
         if (SIZE_TABLE[minIndex] < minimum) {
             this.minIndex = minIndex + 1;
         } else {
             this.minIndex = minIndex;
         }
 
-        int maxIndex = getSizeTableIndex(maximum);
+        final int maxIndex = getSizeTableIndex(maximum);
         if (SIZE_TABLE[maxIndex] > maximum) {
             this.maxIndex = maxIndex - 1;
         } else {

--- a/jraft-core/src/main/java/com/alipay/sofa/jraft/util/AdaptiveBufAllocator.java
+++ b/jraft-core/src/main/java/com/alipay/sofa/jraft/util/AdaptiveBufAllocator.java
@@ -86,6 +86,12 @@ public class AdaptiveBufAllocator {
         ByteBufferCollector allocate();
 
         /**
+         * Gets a buffer from recyclers whose capacity is probably large enough to write all outbound data and
+         * small enough not to waste its space.
+         */
+        ByteBufferCollector allocateRecycleRequired();
+
+        /**
          * Similar to {@link #allocate()} except that it does not allocate anything but
          * just tells the capacity.
          */
@@ -119,6 +125,11 @@ public class AdaptiveBufAllocator {
         @Override
         public ByteBufferCollector allocate() {
             return ByteBufferCollector.allocate(guess());
+        }
+
+        @Override
+        public ByteBufferCollector allocateRecycleRequired() {
+            return ByteBufferCollector.allocateRecycleRequired(guess());
         }
 
         @Override

--- a/jraft-core/src/main/java/com/alipay/sofa/jraft/util/AdaptiveBufAllocator.java
+++ b/jraft-core/src/main/java/com/alipay/sofa/jraft/util/AdaptiveBufAllocator.java
@@ -87,9 +87,9 @@ public class AdaptiveBufAllocator {
 
         /**
          * Gets a buffer from recyclers whose capacity is probably large enough to write all outbound data and
-         * small enough not to waste its space.
+         * small enough not to waste its space, recycling is needed.
          */
-        ByteBufferCollector allocateRecycleRequired();
+        ByteBufferCollector allocateByRecyclers();
 
         /**
          * Similar to {@link #allocate()} except that it does not allocate anything but
@@ -128,8 +128,8 @@ public class AdaptiveBufAllocator {
         }
 
         @Override
-        public ByteBufferCollector allocateRecycleRequired() {
-            return ByteBufferCollector.allocateRecycleRequired(guess());
+        public ByteBufferCollector allocateByRecyclers() {
+            return ByteBufferCollector.allocateByRecyclers(guess());
         }
 
         @Override

--- a/jraft-core/src/main/java/com/alipay/sofa/jraft/util/ByteBufferCollector.java
+++ b/jraft-core/src/main/java/com/alipay/sofa/jraft/util/ByteBufferCollector.java
@@ -74,6 +74,14 @@ public final class ByteBufferCollector implements Recyclable {
         return allocateByRecyclers(Utils.RAFT_DATA_BUF_SIZE);
     }
 
+    public static int threadLocalCapacity() {
+        return recyclers.threadLocalCapacity();
+    }
+
+    public static int threadLocalSize() {
+        return recyclers.threadLocalSize();
+    }
+
     private void reset(final int expectSize) {
         if (this.buffer == null) {
             this.buffer = Utils.allocate(expectSize);

--- a/jraft-core/src/main/java/com/alipay/sofa/jraft/util/ByteBufferCollector.java
+++ b/jraft-core/src/main/java/com/alipay/sofa/jraft/util/ByteBufferCollector.java
@@ -86,7 +86,6 @@ public final class ByteBufferCollector implements Recyclable {
         if (this.buffer == null) {
             this.buffer = Utils.allocate(expectSize);
         } else {
-            this.buffer.flip();
             if (this.buffer.capacity() < expectSize) {
                 this.buffer = Utils.allocate(expectSize);
             }
@@ -121,6 +120,9 @@ public final class ByteBufferCollector implements Recyclable {
     @Override
     public boolean recycle() {
         // TODO If the size is too large, it should not be reused?
+        if (this.buffer != null) {
+            this.buffer.clear();
+        }
         return recyclers.recycle(this, handle);
     }
 

--- a/jraft-core/src/main/java/com/alipay/sofa/jraft/util/ByteBufferCollector.java
+++ b/jraft-core/src/main/java/com/alipay/sofa/jraft/util/ByteBufferCollector.java
@@ -112,12 +112,13 @@ public final class ByteBufferCollector implements Recyclable {
 
     @Override
     public boolean recycle() {
+        // TODO If the size is too large, it should not be reused?
         return recyclers.recycle(this, handle);
     }
 
     private transient final Recyclers.Handle            handle;
 
-    private static final Recyclers<ByteBufferCollector> recyclers = new Recyclers<ByteBufferCollector>() {
+    private static final Recyclers<ByteBufferCollector> recyclers = new Recyclers<ByteBufferCollector>(16) {
 
                                                                       @Override
                                                                       protected ByteBufferCollector newObject(final Handle handle) {

--- a/jraft-core/src/main/java/com/alipay/sofa/jraft/util/ByteBufferCollector.java
+++ b/jraft-core/src/main/java/com/alipay/sofa/jraft/util/ByteBufferCollector.java
@@ -118,7 +118,8 @@ public final class ByteBufferCollector implements Recyclable {
 
     private transient final Recyclers.Handle            handle;
 
-    private static final Recyclers<ByteBufferCollector> recyclers = new Recyclers<ByteBufferCollector>(16) {
+    private static final Recyclers<ByteBufferCollector> recyclers = new Recyclers<ByteBufferCollector>(
+                                                                      Utils.MAX_COLLECTOR_SIZE_PRE_THREAD) {
 
                                                                       @Override
                                                                       protected ByteBufferCollector newObject(final Handle handle) {

--- a/jraft-core/src/main/java/com/alipay/sofa/jraft/util/ByteBufferCollector.java
+++ b/jraft-core/src/main/java/com/alipay/sofa/jraft/util/ByteBufferCollector.java
@@ -64,14 +64,14 @@ public final class ByteBufferCollector implements Recyclable {
         return allocate(Utils.RAFT_DATA_BUF_SIZE);
     }
 
-    public static ByteBufferCollector allocateRecycleRequired(final int size) {
+    public static ByteBufferCollector allocateByRecyclers(final int size) {
         final ByteBufferCollector collector = recyclers.get();
         collector.reset(size);
         return collector;
     }
 
-    public static ByteBufferCollector allocateRecycleRequired() {
-        return allocateRecycleRequired(Utils.RAFT_DATA_BUF_SIZE);
+    public static ByteBufferCollector allocateByRecyclers() {
+        return allocateByRecyclers(Utils.RAFT_DATA_BUF_SIZE);
     }
 
     private void reset(final int expectSize) {

--- a/jraft-core/src/main/java/com/alipay/sofa/jraft/util/ByteBufferCollector.java
+++ b/jraft-core/src/main/java/com/alipay/sofa/jraft/util/ByteBufferCollector.java
@@ -66,12 +66,23 @@ public final class ByteBufferCollector implements Recyclable {
 
     public static ByteBufferCollector allocateRecycleRequired(final int size) {
         final ByteBufferCollector collector = recyclers.get();
-        collector.expandAtMost(size);
+        collector.reset(size);
         return collector;
     }
 
     public static ByteBufferCollector allocateRecycleRequired() {
         return allocateRecycleRequired(Utils.RAFT_DATA_BUF_SIZE);
+    }
+
+    private void reset(final int expectSize) {
+        if (this.buffer == null) {
+            this.buffer = Utils.allocate(expectSize);
+        } else {
+            this.buffer.flip();
+            if (this.buffer.capacity() < expectSize) {
+                this.buffer = Utils.allocate(expectSize);
+            }
+        }
     }
 
     private ByteBuffer getBuffer(final int expectSize) {

--- a/jraft-core/src/main/java/com/alipay/sofa/jraft/util/Recyclable.java
+++ b/jraft-core/src/main/java/com/alipay/sofa/jraft/util/Recyclable.java
@@ -14,22 +14,16 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.alipay.sofa.jraft.rhea.util;
+package com.alipay.sofa.jraft.util;
 
 /**
- * Recycle tool for {@link Recyclable}.
  *
  * @author jiachun.fjc
  */
-public final class RecycleUtil {
+public interface Recyclable {
 
     /**
-     * Recycle designated instance.
+     * Recycle this instance.
      */
-    public static boolean recycle(final Object obj) {
-        return obj instanceof Recyclable && ((Recyclable) obj).recycle();
-    }
-
-    private RecycleUtil() {
-    }
+    boolean recycle();
 }

--- a/jraft-core/src/main/java/com/alipay/sofa/jraft/util/RecyclableByteBufferList.java
+++ b/jraft-core/src/main/java/com/alipay/sofa/jraft/util/RecyclableByteBufferList.java
@@ -1,0 +1,136 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alipay.sofa.jraft.util;
+
+import java.nio.ByteBuffer;
+import java.util.ArrayList;
+import java.util.Collection;
+
+/**
+ * A simple {@link java.nio.ByteBuffer} list which is recyclable.
+ * This implementation does not allow {@code null} elements to be added.
+ */
+public final class RecyclableByteBufferList extends ArrayList<ByteBuffer> implements Recyclable {
+
+    private static final long serialVersionUID         = -8605125654176467947L;
+
+    private static final int  DEFAULT_INITIAL_CAPACITY = 8;
+
+    private int               byteNumber               = 0;
+
+    /**
+     * Create a new empty {@link RecyclableByteBufferList} instance
+     */
+    public static RecyclableByteBufferList newInstance() {
+        return newInstance(DEFAULT_INITIAL_CAPACITY);
+    }
+
+    /**
+     * Create a new empty {@link RecyclableByteBufferList} instance with the given capacity.
+     */
+    public static RecyclableByteBufferList newInstance(final int minCapacity) {
+        final RecyclableByteBufferList ret = recyclers.get();
+        ret.ensureCapacity(minCapacity);
+        return ret;
+    }
+
+    public int getByteNumber() {
+        return this.byteNumber;
+    }
+
+    @Override
+    public boolean addAll(final Collection<? extends ByteBuffer> c) {
+        throw reject("addAll");
+    }
+
+    @Override
+    public boolean addAll(final int index, final Collection<? extends ByteBuffer> c) {
+        throw reject("addAll");
+    }
+
+    @Override
+    public boolean add(final ByteBuffer element) {
+        if (element == null) {
+            throw new NullPointerException("element");
+        }
+        this.byteNumber += element.remaining();
+        return super.add(element);
+    }
+
+    @Override
+    public void add(final int index, final ByteBuffer element) {
+        if (element == null) {
+            throw new NullPointerException("element");
+        }
+        this.byteNumber += element.remaining();
+        super.add(index, element);
+    }
+
+    @Override
+    public ByteBuffer set(final int index, final ByteBuffer element) {
+        throw reject("set");
+    }
+
+    @Override
+    public ByteBuffer remove(final int index) {
+        throw reject("remove");
+    }
+
+    @Override
+    public boolean remove(final Object o) {
+        throw reject("remove");
+    }
+
+    @Override
+    public boolean recycle() {
+        clear();
+        this.byteNumber = 0;
+        return recyclers.recycle(this, handle);
+    }
+
+    public static int threadLocalCapacity() {
+        return recyclers.threadLocalCapacity();
+    }
+
+    public static int threadLocalSize() {
+        return recyclers.threadLocalSize();
+    }
+
+    private static UnsupportedOperationException reject(final String message) {
+        return new UnsupportedOperationException(message);
+    }
+
+    private RecyclableByteBufferList(final Recyclers.Handle handle) {
+        this(handle, DEFAULT_INITIAL_CAPACITY);
+    }
+
+    private RecyclableByteBufferList(final Recyclers.Handle handle, int initialCapacity) {
+        super(initialCapacity);
+        this.handle = handle;
+    }
+
+    private transient final Recyclers.Handle                 handle;
+
+    private static final Recyclers<RecyclableByteBufferList> recyclers = new Recyclers<RecyclableByteBufferList>(512) {
+
+                                                                           @Override
+                                                                           protected RecyclableByteBufferList newObject(final Handle handle) {
+                                                                               return new RecyclableByteBufferList(
+                                                                                   handle);
+                                                                           }
+                                                                       };
+}

--- a/jraft-core/src/main/java/com/alipay/sofa/jraft/util/RecyclableByteBufferList.java
+++ b/jraft-core/src/main/java/com/alipay/sofa/jraft/util/RecyclableByteBufferList.java
@@ -30,7 +30,7 @@ public final class RecyclableByteBufferList extends ArrayList<ByteBuffer> implem
 
     private static final int  DEFAULT_INITIAL_CAPACITY = 8;
 
-    private int               byteNumber               = 0;
+    private int               capacity                 = 0;
 
     /**
      * Create a new empty {@link RecyclableByteBufferList} instance
@@ -48,8 +48,8 @@ public final class RecyclableByteBufferList extends ArrayList<ByteBuffer> implem
         return ret;
     }
 
-    public int getByteNumber() {
-        return this.byteNumber;
+    public int getCapacity() {
+        return this.capacity;
     }
 
     @Override
@@ -67,7 +67,7 @@ public final class RecyclableByteBufferList extends ArrayList<ByteBuffer> implem
         if (element == null) {
             throw new NullPointerException("element");
         }
-        this.byteNumber += element.remaining();
+        this.capacity += element.remaining();
         return super.add(element);
     }
 
@@ -76,7 +76,7 @@ public final class RecyclableByteBufferList extends ArrayList<ByteBuffer> implem
         if (element == null) {
             throw new NullPointerException("element");
         }
-        this.byteNumber += element.remaining();
+        this.capacity += element.remaining();
         super.add(index, element);
     }
 
@@ -98,7 +98,7 @@ public final class RecyclableByteBufferList extends ArrayList<ByteBuffer> implem
     @Override
     public boolean recycle() {
         clear();
-        this.byteNumber = 0;
+        this.capacity = 0;
         return recyclers.recycle(this, handle);
     }
 

--- a/jraft-core/src/main/java/com/alipay/sofa/jraft/util/RecycleUtil.java
+++ b/jraft-core/src/main/java/com/alipay/sofa/jraft/util/RecycleUtil.java
@@ -14,16 +14,22 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.alipay.sofa.jraft.rhea.util;
+package com.alipay.sofa.jraft.util;
 
 /**
+ * Recycle tool for {@link Recyclable}.
  *
  * @author jiachun.fjc
  */
-public interface Recyclable {
+public final class RecycleUtil {
 
     /**
-     * Recycle this instance.
+     * Recycle designated instance.
      */
-    boolean recycle();
+    public static boolean recycle(final Object obj) {
+        return obj instanceof Recyclable && ((Recyclable) obj).recycle();
+    }
+
+    private RecycleUtil() {
+    }
 }

--- a/jraft-core/src/main/java/com/alipay/sofa/jraft/util/Recyclers.java
+++ b/jraft-core/src/main/java/com/alipay/sofa/jraft/util/Recyclers.java
@@ -110,11 +110,11 @@ public abstract class Recyclers<T> {
 
     protected abstract T newObject(Handle handle);
 
-    final int threadLocalCapacity() {
+    public final int threadLocalCapacity() {
         return threadLocal.get().elements.length;
     }
 
-    final int threadLocalSize() {
+    public final int threadLocalSize() {
         return threadLocal.get().size;
     }
 

--- a/jraft-core/src/main/java/com/alipay/sofa/jraft/util/Recyclers.java
+++ b/jraft-core/src/main/java/com/alipay/sofa/jraft/util/Recyclers.java
@@ -12,7 +12,7 @@
  * or implied. See the License for the specific language governing permissions and limitations under
  * the License.
  */
-package com.alipay.sofa.jraft.rhea.util;
+package com.alipay.sofa.jraft.util;
 
 import java.lang.ref.WeakReference;
 import java.util.Arrays;
@@ -22,8 +22,6 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import com.alipay.sofa.jraft.util.SystemPropertyUtil;
 
 /**
  * Light-weight object pool based on a thread-local stack.
@@ -44,7 +42,7 @@ public abstract class Recyclers<T> {
     private static final int INITIAL_CAPACITY;
 
     static {
-        int maxCapacity = SystemPropertyUtil.getInt("rhea.recyclers.maxCapacity", DEFAULT_INITIAL_MAX_CAPACITY);
+        int maxCapacity = SystemPropertyUtil.getInt("jraft.recyclers.maxCapacity", DEFAULT_INITIAL_MAX_CAPACITY);
         if (maxCapacity < 0) {
             maxCapacity = DEFAULT_INITIAL_MAX_CAPACITY;
         }
@@ -52,16 +50,16 @@ public abstract class Recyclers<T> {
         DEFAULT_MAX_CAPACITY = maxCapacity;
         if (LOG.isDebugEnabled()) {
             if (DEFAULT_MAX_CAPACITY == 0) {
-                LOG.debug("-Drhea.recyclers.maxCapacity.default: disabled");
+                LOG.debug("-Djraft.recyclers.maxCapacity.default: disabled");
             } else {
-                LOG.debug("-Drhea.recyclers.maxCapacity.default: {}", DEFAULT_MAX_CAPACITY);
+                LOG.debug("-Djraft.recyclers.maxCapacity.default: {}", DEFAULT_MAX_CAPACITY);
             }
         }
 
         INITIAL_CAPACITY = Math.min(DEFAULT_MAX_CAPACITY, 256);
     }
 
-    private static final Handle NOOP_HANDLE = new Handle() {};
+    public static final Handle NOOP_HANDLE = new Handle() {};
 
     private final int maxCapacity;
     private final ThreadLocal<Stack<T>> threadLocal = new ThreadLocal<Stack<T>>() {

--- a/jraft-core/src/main/java/com/alipay/sofa/jraft/util/Utils.java
+++ b/jraft-core/src/main/java/com/alipay/sofa/jraft/util/Utils.java
@@ -187,11 +187,11 @@ public class Utils {
                                                               "1024"));
 
     /**
-     * Default max {@link ByteBufferCollector} size pre thread for recycle, it can be set by
-     * -Djraft.max_collector_size_pre_thread, default 256
+     * Default max {@link ByteBufferCollector} size per thread for recycle, it can be set by
+     * -Djraft.max_collector_size_per_thread, default 256
      */
-    public static final int MAX_COLLECTOR_SIZE_PRE_THREAD = Integer.parseInt(System.getProperty(
-                                                              "jraft.max_collector_size_pre_thread", "256"));
+    public static final int MAX_COLLECTOR_SIZE_PER_THREAD = Integer.parseInt(System.getProperty(
+                                                              "jraft.max_collector_size_per_thread", "256"));
 
     /**
      * Expand byte buffer for 1024 bytes.

--- a/jraft-core/src/main/java/com/alipay/sofa/jraft/util/Utils.java
+++ b/jraft-core/src/main/java/com/alipay/sofa/jraft/util/Utils.java
@@ -183,7 +183,15 @@ public class Utils {
     /**
      * Default init and expand buffer size, it can be set by -Djraft.byte_buf.size=n, default 1024.
      */
-    public static final int RAFT_DATA_BUF_SIZE = Integer.parseInt(System.getProperty("jraft.byte_buf.size", "1024"));
+    public static final int RAFT_DATA_BUF_SIZE            = Integer.parseInt(System.getProperty("jraft.byte_buf.size",
+                                                              "1024"));
+
+    /**
+     * Default max {@link ByteBufferCollector} size pre thread for recycle, it can be set by
+     * -Djraft.max_collector_size_pre_thread, default 256
+     */
+    public static final int MAX_COLLECTOR_SIZE_PRE_THREAD = Integer.parseInt(System.getProperty(
+                                                              "jraft.max_collector_size_pre_thread", "256"));
 
     /**
      * Expand byte buffer for 1024 bytes.

--- a/jraft-core/src/main/java/com/google/protobuf/ZeroByteStringHelper.java
+++ b/jraft-core/src/main/java/com/google/protobuf/ZeroByteStringHelper.java
@@ -18,6 +18,7 @@ package com.google.protobuf;
 
 import java.io.IOException;
 import java.nio.ByteBuffer;
+import java.util.List;
 
 /**
  * Byte string and byte buffer converter
@@ -71,5 +72,52 @@ public class ZeroByteStringHelper {
             // ignored
         }
         return byteString.toByteArray();
+    }
+
+    /**
+     * Concatenate the given strings while performing various optimizations to
+     * slow the growth rate of tree depth and tree node count. The result is
+     * either a {@link com.google.protobuf.ByteString.LeafByteString} or a
+     * {@link RopeByteString} depending on which optimizations, if any, were
+     * applied.
+     *
+     * <p>Small pieces of length less than {@link
+     * ByteString#CONCATENATE_BY_COPY_SIZE} may be copied by value here, as in
+     * BAP95.  Large pieces are referenced without copy.
+     *
+     * <p>Most of the operation here is inspired by the now-famous paper <a
+     *  * href="https://web.archive.org/web/20060202015456/http://www.cs.ubc.ca/local/reading/proceedings/spe91-95/spe/vol25/issue12/spe986.pdf">
+     *
+     * @param left  string on the left
+     * @param right string on the right
+     * @return concatenation representing the same sequence as the given strings
+     */
+    public static ByteString concatenate(final ByteString left, final ByteString right) {
+        return RopeByteString.concatenate(left, right);
+    }
+
+    /**
+     * @see #concatenate(ByteString, ByteString)
+     */
+    public static ByteString concatenate(final List<ByteBuffer> byteBuffers) {
+        final int size = byteBuffers.size();
+        if (size == 0) {
+            return null;
+        }
+        if (size == 1) {
+            return wrap(byteBuffers.get(0));
+        }
+
+        ByteString left = null;
+        for (final ByteBuffer buf : byteBuffers) {
+            if (buf.remaining() > 0) {
+                if (left == null) {
+                    left = wrap(buf);
+                } else {
+                    left = concatenate(left, wrap(buf));
+                }
+            }
+        }
+        return left;
     }
 }

--- a/jraft-core/src/test/java/com/alipay/sofa/jraft/rpc/AppendEntriesBenchmark.java
+++ b/jraft-core/src/test/java/com/alipay/sofa/jraft/rpc/AppendEntriesBenchmark.java
@@ -1,0 +1,257 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alipay.sofa.jraft.rpc;
+
+import java.nio.ByteBuffer;
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.concurrent.TimeUnit;
+
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+import org.openjdk.jmh.runner.options.TimeValue;
+
+import com.alipay.sofa.jraft.util.AdaptiveBufAllocator;
+import com.alipay.sofa.jraft.util.ByteBufferCollector;
+import com.alipay.sofa.jraft.util.RecyclableByteBufferList;
+import com.alipay.sofa.jraft.util.RecycleUtil;
+import com.google.protobuf.ZeroByteStringHelper;
+
+import static com.alipay.sofa.jraft.rpc.RpcRequests.AppendEntriesRequest;
+
+/**
+ *
+ * @author jiachun.fjc
+ */
+@State(Scope.Benchmark)
+public class AppendEntriesBenchmark {
+
+    /**
+     * entryCount=256, sizeOfEntry=2048
+     * ---------------------------------------------------------------------------
+     * Benchmark                                  Mode  Cnt  Score   Error   Units
+     * AppendEntriesBenchmark.adaptiveAndPooled  thrpt    3  4.139 ± 2.662  ops/ms
+     * AppendEntriesBenchmark.copy               thrpt    3  0.148 ± 0.027  ops/ms
+     * AppendEntriesBenchmark.pooled             thrpt    3  3.730 ± 0.355  ops/ms
+     * AppendEntriesBenchmark.zeroCopy           thrpt    3  3.069 ± 3.563  ops/ms
+     *
+     *
+     * entryCount=256, sizeOfEntry=1024
+     * ---------------------------------------------------------------------------
+     * Benchmark                                  Mode  Cnt  Score   Error   Units
+     * AppendEntriesBenchmark.adaptiveAndPooled  thrpt    3  8.290 ± 5.438  ops/ms
+     * AppendEntriesBenchmark.copy               thrpt    3  0.326 ± 0.137  ops/ms
+     * AppendEntriesBenchmark.pooled             thrpt    3  7.559 ± 1.245  ops/ms
+     * AppendEntriesBenchmark.zeroCopy           thrpt    3  6.602 ± 0.859  ops/ms
+     *
+     * entryCount=256, sizeOfEntry=512
+     * ---------------------------------------------------------------------------
+     *
+     * Benchmark                                  Mode  Cnt   Score   Error   Units
+     * AppendEntriesBenchmark.adaptiveAndPooled  thrpt    3  14.358 ± 8.622  ops/ms
+     * AppendEntriesBenchmark.copy               thrpt    3   1.625 ± 0.058  ops/ms
+     * AppendEntriesBenchmark.pooled             thrpt    3  15.332 ± 1.531  ops/ms
+     * AppendEntriesBenchmark.zeroCopy           thrpt    3  12.614 ± 5.904  ops/ms
+     *
+     * entryCount=256, sizeOfEntry=256
+     * ---------------------------------------------------------------------------
+     * Benchmark                                  Mode  Cnt   Score    Error   Units
+     * AppendEntriesBenchmark.adaptiveAndPooled  thrpt    3  32.506 ± 21.961  ops/ms
+     * AppendEntriesBenchmark.copy               thrpt    3   6.595 ±  5.772  ops/ms
+     * AppendEntriesBenchmark.pooled             thrpt    3  27.847 ± 14.010  ops/ms
+     * AppendEntriesBenchmark.zeroCopy           thrpt    3  26.427 ±  5.187  ops/ms
+     *
+     * entryCount=256, sizeOfEntry=128
+     * ---------------------------------------------------------------------------
+     * Benchmark                                  Mode  Cnt   Score    Error   Units
+     * AppendEntriesBenchmark.adaptiveAndPooled  thrpt    3  60.014 ± 47.206  ops/ms
+     * AppendEntriesBenchmark.copy               thrpt    3  22.884 ±  3.286  ops/ms
+     * AppendEntriesBenchmark.pooled             thrpt    3  57.373 ±  8.201  ops/ms
+     * AppendEntriesBenchmark.zeroCopy           thrpt    3  43.923 ±  7.133  ops/ms
+     *
+     * entryCount=256, sizeOfEntry=64
+     * ---------------------------------------------------------------------------
+     * Benchmark                                  Mode  Cnt    Score    Error   Units
+     * AppendEntriesBenchmark.adaptiveAndPooled  thrpt    3  114.016 ± 84.874  ops/ms
+     * AppendEntriesBenchmark.copy               thrpt    3   71.699 ± 19.016  ops/ms
+     * AppendEntriesBenchmark.pooled             thrpt    3  107.714 ±  7.944  ops/ms
+     * AppendEntriesBenchmark.zeroCopy           thrpt    3   71.767 ± 14.510  ops/ms
+     *
+     * entryCount=256, sizeOfEntry=16
+     * ---------------------------------------------------------------------------
+     * Benchmark                                  Mode  Cnt    Score     Error   Units
+     * AppendEntriesBenchmark.adaptiveAndPooled  thrpt    3  285.386 ± 114.361  ops/ms
+     * AppendEntriesBenchmark.copy               thrpt    3  243.805 ±  31.725  ops/ms
+     * AppendEntriesBenchmark.pooled             thrpt    3  293.779 ±  76.557  ops/ms
+     * AppendEntriesBenchmark.zeroCopy           thrpt    3  124.669 ±  32.460  ops/ms
+     */
+
+    private static final ThreadLocal<AdaptiveBufAllocator.Handle> handleThreadLocal = ThreadLocal
+                                                                                        .withInitial(AdaptiveBufAllocator.DEFAULT::newHandle);
+
+    private int                                                   entryCount;
+    private int                                                   sizeOfEntry;
+
+    @Setup
+    public void setup() {
+        this.entryCount = 256;
+        this.sizeOfEntry = 2048;
+    }
+
+    public static void main(String[] args) throws RunnerException {
+        final int size = ThreadLocalRandom.current().nextInt(100, 1000);
+        System.out.println(sendEntries1(256, size).length);
+        System.out.println(sendEntries2(256, size).length);
+        System.out.println(sendEntries3(256, size, AdaptiveBufAllocator.DEFAULT.newHandle()).length);
+        System.out.println(sendEntries4(256, size).length);
+
+        Options opt = new OptionsBuilder() //
+            .include(AppendEntriesBenchmark.class.getSimpleName()) //
+            .warmupIterations(1) //
+            .warmupTime(TimeValue.seconds(5)) //
+            .measurementIterations(3) //
+            .measurementTime(TimeValue.seconds(10)) //
+            .threads(8) //
+            .forks(1) //
+            .build();
+
+        new Runner(opt).run();
+    }
+
+    @Benchmark
+    @BenchmarkMode(Mode.Throughput)
+    @OutputTimeUnit(TimeUnit.MILLISECONDS)
+    public void copy() {
+        sendEntries1(this.entryCount, this.sizeOfEntry);
+    }
+
+    @Benchmark
+    @BenchmarkMode(Mode.Throughput)
+    @OutputTimeUnit(TimeUnit.MILLISECONDS)
+    public void pooled() {
+        sendEntries2(this.entryCount, this.sizeOfEntry);
+    }
+
+    @Benchmark
+    @BenchmarkMode(Mode.Throughput)
+    @OutputTimeUnit(TimeUnit.MILLISECONDS)
+    public void adaptiveAndPooled() {
+        sendEntries3(this.entryCount, this.sizeOfEntry, handleThreadLocal.get());
+    }
+
+    @Benchmark
+    @BenchmarkMode(Mode.Throughput)
+    @OutputTimeUnit(TimeUnit.MILLISECONDS)
+    public void zeroCopy() {
+        sendEntries4(this.entryCount, this.sizeOfEntry);
+    }
+
+    private static byte[] sendEntries1(final int entryCount, final int sizeOfEntry) {
+        final AppendEntriesRequest.Builder rb = AppendEntriesRequest.newBuilder();
+        fillCommonFields(rb);
+        final ByteBufferCollector dataBuffer = ByteBufferCollector.allocate();
+        for (int i = 0; i < entryCount; i++) {
+            final byte[] bytes = new byte[sizeOfEntry];
+            ThreadLocalRandom.current().nextBytes(bytes);
+            final ByteBuffer buf = ByteBuffer.wrap(bytes);
+            dataBuffer.put(buf.slice());
+        }
+        final ByteBuffer buf = dataBuffer.getBuffer();
+        buf.flip();
+        rb.setData(ZeroByteStringHelper.wrap(buf));
+        return rb.build().toByteArray();
+    }
+
+    private static byte[] sendEntries2(final int entryCount, final int sizeOfEntry) {
+        final AppendEntriesRequest.Builder rb = AppendEntriesRequest.newBuilder();
+        fillCommonFields(rb);
+        final ByteBufferCollector dataBuffer = ByteBufferCollector.allocateByRecyclers();
+        try {
+            for (int i = 0; i < entryCount; i++) {
+                final byte[] bytes = new byte[sizeOfEntry];
+                ThreadLocalRandom.current().nextBytes(bytes);
+                final ByteBuffer buf = ByteBuffer.wrap(bytes);
+                dataBuffer.put(buf.slice());
+            }
+            final ByteBuffer buf = dataBuffer.getBuffer();
+            buf.flip();
+            rb.setData(ZeroByteStringHelper.wrap(buf));
+            return rb.build().toByteArray();
+        } finally {
+            RecycleUtil.recycle(dataBuffer);
+        }
+    }
+
+    private static byte[] sendEntries3(final int entryCount, final int sizeOfEntry,
+                                       AdaptiveBufAllocator.Handle allocator) {
+        final AppendEntriesRequest.Builder rb = AppendEntriesRequest.newBuilder();
+        fillCommonFields(rb);
+        final ByteBufferCollector dataBuffer = allocator.allocateByRecyclers();
+        try {
+            for (int i = 0; i < entryCount; i++) {
+                final byte[] bytes = new byte[sizeOfEntry];
+                ThreadLocalRandom.current().nextBytes(bytes);
+                final ByteBuffer buf = ByteBuffer.wrap(bytes);
+                dataBuffer.put(buf.slice());
+            }
+            final ByteBuffer buf = dataBuffer.getBuffer();
+            buf.flip();
+            final int remaining = buf.remaining();
+            allocator.record(remaining);
+            rb.setData(ZeroByteStringHelper.wrap(buf));
+            return rb.build().toByteArray();
+        } finally {
+            RecycleUtil.recycle(dataBuffer);
+        }
+    }
+
+    private static byte[] sendEntries4(final int entryCount, final int sizeOfEntry) {
+        final AppendEntriesRequest.Builder rb = AppendEntriesRequest.newBuilder();
+        fillCommonFields(rb);
+        final RecyclableByteBufferList dataBuffer = RecyclableByteBufferList.newInstance();
+        try {
+            for (int i = 0; i < entryCount; i++) {
+                final byte[] bytes = new byte[sizeOfEntry];
+                ThreadLocalRandom.current().nextBytes(bytes);
+                final ByteBuffer buf = ByteBuffer.wrap(bytes);
+                dataBuffer.add(buf.slice());
+            }
+            rb.setData(ZeroByteStringHelper.concatenate(dataBuffer));
+            return rb.build().toByteArray();
+        } finally {
+            RecycleUtil.recycle(dataBuffer);
+        }
+    }
+
+    private static void fillCommonFields(final AppendEntriesRequest.Builder rb) {
+        rb.setTerm(1) //
+            .setGroupId("1") //
+            .setServerId("test") //
+            .setPeerId("127.0.0.1:8080") //
+            .setPrevLogIndex(2) //
+            .setPrevLogTerm(3) //
+            .setCommittedIndex(4);
+    }
+}

--- a/jraft-core/src/test/java/com/alipay/sofa/jraft/util/AdaptiveBufAllocatorTest.java
+++ b/jraft-core/src/test/java/com/alipay/sofa/jraft/util/AdaptiveBufAllocatorTest.java
@@ -1,0 +1,59 @@
+package com.alipay.sofa.jraft.util;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ *
+ * @author jiachun.fjc
+ */
+public class AdaptiveBufAllocatorTest {
+
+    private AdaptiveBufAllocator.Handle handle;
+
+    /*
+     * The allocate size table:
+     *
+     * [16, 32, 48, 64, 80, 96, 112, 128, 144, 160, 176, 192, 208, 224, 240, 256, 272, 288, 304, 320, 336, 352, 368,
+     * 384, 400, 416, 432, 448, 464, 480, 496, 512, 1024, 2048, 4096, 8192, 16384, 32768, 65536, 131072, 262144,
+     * 524288, 1048576, 2097152, 4194304, 8388608, 16777216, 33554432, 67108864, 134217728, 268435456, 536870912,
+     * 1073741824]
+     */
+
+    @Before
+    public void setup() {
+        this.handle = new AdaptiveBufAllocator(64, 512, 524288).newHandle();
+    }
+
+    @Test
+    public void incrementTest() {
+        allocReadExpected(this.handle, 512);
+        allocReadExpected(this.handle, 8192);
+        allocReadExpected(this.handle, 131072);
+        allocReadExpected(this.handle, 524288);
+        allocRead(this.handle, 524288, 8388608);
+    }
+
+    @Test
+    public void decreaseTest() {
+        allocRead(this.handle, 512, 16);
+        allocRead(this.handle, 512, 16);
+        allocRead(this.handle, 496, 16);
+        allocRead(this.handle, 496, 16);
+        allocRead(this.handle, 480, 16);
+        allocRead(this.handle, 480, 16);
+        allocRead(this.handle, 464, 16);
+        allocRead(this.handle, 464, 16);
+    }
+
+    private static void allocReadExpected(final AdaptiveBufAllocator.Handle handle, final int expectedSize) {
+        allocRead(handle, expectedSize, expectedSize);
+    }
+
+    private static void allocRead(final AdaptiveBufAllocator.Handle handle, final int expectedSize, final int lastRead) {
+        assertEquals(expectedSize, handle.allocate().capacity());
+        handle.record(lastRead);
+    }
+}

--- a/jraft-core/src/test/java/com/alipay/sofa/jraft/util/AdaptiveBufAllocatorTest.java
+++ b/jraft-core/src/test/java/com/alipay/sofa/jraft/util/AdaptiveBufAllocatorTest.java
@@ -1,3 +1,19 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.alipay.sofa.jraft.util;
 
 import org.junit.Before;

--- a/jraft-core/src/test/java/com/alipay/sofa/jraft/util/ByteBufferCollectorTest.java
+++ b/jraft-core/src/test/java/com/alipay/sofa/jraft/util/ByteBufferCollectorTest.java
@@ -1,0 +1,69 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alipay.sofa.jraft.util;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
+
+/**
+ *
+ * @author jiachun.fjc
+ */
+public class ByteBufferCollectorTest {
+
+    @Test
+    public void testSmallSizeRecycle() {
+        final ByteBufferCollector object = ByteBufferCollector.allocateByRecyclers(4096);
+        object.recycle();
+        assertEquals(4096, ByteBufferCollector.allocateByRecyclers().capacity());
+    }
+
+    @Test
+    public void testLargeSizeRecycle() {
+        final ByteBufferCollector object = ByteBufferCollector.allocateByRecyclers(4 * 1024 * 1024 + 1);
+        object.recycle();
+        assertEquals(Utils.RAFT_DATA_BUF_SIZE, ByteBufferCollector.allocateByRecyclers().capacity());
+    }
+
+    @Test(expected = IllegalStateException.class)
+    public void testMultipleRecycle() {
+        final ByteBufferCollector object = ByteBufferCollector.allocateByRecyclers();
+        object.recycle();
+        object.recycle();
+    }
+
+    @Test
+    public void testMultipleRecycleAtDifferentThread() throws InterruptedException {
+        final ByteBufferCollector object = ByteBufferCollector.allocateByRecyclers();
+        final Thread thread1 = new Thread(object::recycle);
+        thread1.start();
+        thread1.join();
+        assertSame(object, ByteBufferCollector.allocateByRecyclers());
+    }
+
+    @Test
+    public void testRecycle() {
+        final ByteBufferCollector object = ByteBufferCollector.allocateByRecyclers();
+        object.recycle();
+        final ByteBufferCollector object2 = ByteBufferCollector.allocateByRecyclers();
+        Assert.assertSame(object, object2);
+        object2.recycle();
+    }
+}

--- a/jraft-core/src/test/java/com/alipay/sofa/jraft/util/RecyclableByteBufferListTest.java
+++ b/jraft-core/src/test/java/com/alipay/sofa/jraft/util/RecyclableByteBufferListTest.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alipay.sofa.jraft.util;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import static org.junit.Assert.assertSame;
+
+/**
+ * @author jiachun.fjc
+ */
+public class RecyclableByteBufferListTest {
+
+    @Test(expected = IllegalStateException.class)
+    public void testMultipleRecycle() {
+        final RecyclableByteBufferList object = RecyclableByteBufferList.newInstance();
+        object.recycle();
+        object.recycle();
+    }
+
+    @Test
+    public void testMultipleRecycleAtDifferentThread() throws InterruptedException {
+        final RecyclableByteBufferList object = RecyclableByteBufferList.newInstance();
+        final Thread thread1 = new Thread(object::recycle);
+        thread1.start();
+        thread1.join();
+        assertSame(object, RecyclableByteBufferList.newInstance());
+    }
+
+    @Test
+    public void testRecycle() {
+        final RecyclableByteBufferList object = RecyclableByteBufferList.newInstance();
+        object.recycle();
+        final RecyclableByteBufferList object2 = RecyclableByteBufferList.newInstance();
+        Assert.assertSame(object, object2);
+        object2.recycle();
+    }
+}

--- a/jraft-core/src/test/java/com/alipay/sofa/jraft/util/RecyclersTest.java
+++ b/jraft-core/src/test/java/com/alipay/sofa/jraft/util/RecyclersTest.java
@@ -1,0 +1,120 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alipay.sofa.jraft.util;
+
+import java.util.Random;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+
+/**
+ *
+ * @author jiachun.fjc
+ */
+public class RecyclersTest {
+
+    private static Recyclers<RecyclableObject> newRecyclers(final int max) {
+        return new Recyclers<RecyclableObject>(max) {
+
+            @Override
+            protected RecyclableObject newObject(final Recyclers.Handle handle) {
+                return new RecyclableObject(handle);
+            }
+        };
+    }
+
+    @Test(expected = IllegalStateException.class)
+    public void testMultipleRecycle() {
+        final Recyclers<RecyclableObject> recyclers = newRecyclers(16);
+        final RecyclableObject object = recyclers.get();
+        recyclers.recycle(object, object.handle);
+        recyclers.recycle(object, object.handle);
+    }
+
+    @Test
+    public void testMultipleRecycleAtDifferentThread() throws InterruptedException {
+        final Recyclers<RecyclableObject> recyclers = newRecyclers(512);
+        final RecyclableObject object = recyclers.get();
+        final Thread thread1 = new Thread(() -> recyclers.recycle(object, object.handle));
+        thread1.start();
+        thread1.join();
+        assertSame(object, recyclers.get());
+    }
+
+    @Test
+    public void testRecycle() {
+        final Recyclers<RecyclableObject> recyclers = newRecyclers(16);
+        final RecyclableObject object = recyclers.get();
+        recyclers.recycle(object, object.handle);
+        final RecyclableObject object2 = recyclers.get();
+        Assert.assertSame(object, object2);
+        recyclers.recycle(object2, object2.handle);
+    }
+
+    @Test
+    public void testRecycleDisable() {
+        final Recyclers<RecyclableObject> recyclers = newRecyclers(-1);
+        final RecyclableObject object = recyclers.get();
+        recyclers.recycle(object, object.handle);
+        final RecyclableObject object2 = recyclers.get();
+        assertNotSame(object, object2);
+        recyclers.recycle(object2, object2.handle);
+    }
+
+    @Test
+    public void testMaxCapacity() {
+        testMaxCapacity(300);
+        Random rand = new Random();
+        for (int i = 0; i < 50; i++) {
+            testMaxCapacity(rand.nextInt(1000) + 256); // 256 - 1256
+        }
+    }
+
+    private static void testMaxCapacity(final int maxCapacity) {
+        final Recyclers<RecyclableObject> recyclers = newRecyclers(maxCapacity);
+        final RecyclableObject[] objects = new RecyclableObject[maxCapacity * 3];
+        for (int i = 0; i < objects.length; i++) {
+            objects[i] = recyclers.get();
+        }
+
+        for (int i = 0; i < objects.length; i++) {
+            recyclers.recycle(objects[i], objects[i].handle);
+            objects[i] = null;
+        }
+
+        assertTrue("The threadLocalCapacity (" + recyclers.threadLocalCapacity() + ") must be <= maxCapacity ("
+                   + maxCapacity + ") as we not pool all new handles internally",
+            maxCapacity >= recyclers.threadLocalCapacity());
+    }
+
+    static final class RecyclableObject {
+
+        private final Recyclers.Handle handle;
+
+        private RecyclableObject(Recyclers.Handle handle) {
+            this.handle = handle;
+        }
+
+        public Recyclers.Handle getHandle() {
+            return handle;
+        }
+    }
+}

--- a/jraft-core/src/test/java/com/google/protobuf/ZeroByteStringHelperTest.java
+++ b/jraft-core/src/test/java/com/google/protobuf/ZeroByteStringHelperTest.java
@@ -1,0 +1,64 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.protobuf;
+
+import java.nio.ByteBuffer;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.ThreadLocalRandom;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * @author jiachun.fjc
+ */
+public class ZeroByteStringHelperTest {
+
+    @SuppressWarnings("ConstantConditions")
+    @Test
+    public void concatenateTest() {
+        final ThreadLocalRandom random = ThreadLocalRandom.current();
+        final List<ByteString> byteStrings = new ArrayList<>();
+        final List<ByteBuffer> byteBuffers = new ArrayList<>();
+        final int segSize = 512;
+
+        int start;
+        int end = 0;
+        byte[] bytes;
+
+        for (int j = 0; j < 100; j++) {
+            start = end;
+            end = random.nextInt(start, start + segSize);
+            bytes = new byte[end];
+            for (int i = start; i < end; i++) {
+                bytes[i - start] = (byte) i;
+            }
+            byteBuffers.add(ByteBuffer.wrap(bytes));
+            byteStrings.add(ZeroByteStringHelper.wrap(bytes));
+        }
+        final ByteString rope = ZeroByteStringHelper.concatenate(byteBuffers);
+
+        int i = 0;
+        for (final ByteString bs : byteStrings) {
+            for (Byte b : bs) {
+                Assert.assertEquals(b.byteValue(), rope.byteAt(i++));
+            }
+        }
+        System.out.println(i);
+    }
+}

--- a/jraft-rheakv/rheakv-core/src/main/java/com/alipay/sofa/jraft/rhea/metrics/KVMetricNames.java
+++ b/jraft-rheakv/rheakv-core/src/main/java/com/alipay/sofa/jraft/rhea/metrics/KVMetricNames.java
@@ -24,22 +24,19 @@ package com.alipay.sofa.jraft.rhea.metrics;
 public class KVMetricNames {
 
     // for state machine
-    public static final String STATE_MACHINE_APPLY_QPS         = "rhea-st-apply-qps";
-    public static final String STATE_MACHINE_BATCH_WRITE       = "rhea-st-batch-write";
+    public static final String STATE_MACHINE_APPLY_QPS   = "rhea-st-apply-qps";
+    public static final String STATE_MACHINE_BATCH_WRITE = "rhea-st-batch-write";
 
     // for rpc
-    public static final String RPC_REQUEST_HANDLE_TIMER        = "rhea-rpc-request-timer";
+    public static final String RPC_REQUEST_HANDLE_TIMER  = "rhea-rpc-request-timer";
 
-    public static final String DB_TIMER                        = "rhea-db-timer";
+    public static final String DB_TIMER                  = "rhea-db-timer";
 
-    public static final String REGION_KEYS_READ                = "rhea-region-keys-read";
-    public static final String REGION_KEYS_WRITTEN             = "rhea-region-keys-written";
+    public static final String REGION_KEYS_READ          = "rhea-region-keys-read";
+    public static final String REGION_KEYS_WRITTEN       = "rhea-region-keys-written";
 
-    public static final String REGION_BYTES_READ               = "rhea-region-bytes-read";
-    public static final String REGION_BYTES_WRITTEN            = "rhea-region-bytes-written";
+    public static final String REGION_BYTES_READ         = "rhea-region-bytes-read";
+    public static final String REGION_BYTES_WRITTEN      = "rhea-region-bytes-written";
 
-    public static final String SEND_BATCHING                   = "send_batching";
-
-    public static final String KV_STATES_THREAD_LOCAL_CAPACITY = "kv-states-thread-local-capacity";
-    public static final String KV_STATES_THREAD_LOCAL_SIZE     = "kv-states-thread-local-size";
+    public static final String SEND_BATCHING             = "send_batching";
 }

--- a/jraft-rheakv/rheakv-core/src/main/java/com/alipay/sofa/jraft/rhea/metrics/KVMetricNames.java
+++ b/jraft-rheakv/rheakv-core/src/main/java/com/alipay/sofa/jraft/rhea/metrics/KVMetricNames.java
@@ -24,19 +24,22 @@ package com.alipay.sofa.jraft.rhea.metrics;
 public class KVMetricNames {
 
     // for state machine
-    public static final String STATE_MACHINE_APPLY_QPS   = "rhea-st-apply-qps";
-    public static final String STATE_MACHINE_BATCH_WRITE = "rhea-st-batch-write";
+    public static final String STATE_MACHINE_APPLY_QPS         = "rhea-st-apply-qps";
+    public static final String STATE_MACHINE_BATCH_WRITE       = "rhea-st-batch-write";
 
     // for rpc
-    public static final String RPC_REQUEST_HANDLE_TIMER  = "rhea-rpc-request-timer";
+    public static final String RPC_REQUEST_HANDLE_TIMER        = "rhea-rpc-request-timer";
 
-    public static final String DB_TIMER                  = "rhea-db-timer";
+    public static final String DB_TIMER                        = "rhea-db-timer";
 
-    public static final String REGION_KEYS_READ          = "rhea-region-keys-read";
-    public static final String REGION_KEYS_WRITTEN       = "rhea-region-keys-written";
+    public static final String REGION_KEYS_READ                = "rhea-region-keys-read";
+    public static final String REGION_KEYS_WRITTEN             = "rhea-region-keys-written";
 
-    public static final String REGION_BYTES_READ         = "rhea-region-bytes-read";
-    public static final String REGION_BYTES_WRITTEN      = "rhea-region-bytes-written";
+    public static final String REGION_BYTES_READ               = "rhea-region-bytes-read";
+    public static final String REGION_BYTES_WRITTEN            = "rhea-region-bytes-written";
 
-    public static final String SEND_BATCHING             = "send_batching";
+    public static final String SEND_BATCHING                   = "send_batching";
+
+    public static final String KV_STATES_THREAD_LOCAL_CAPACITY = "kv-states-thread-local-capacity";
+    public static final String KV_STATES_THREAD_LOCAL_SIZE     = "kv-states-thread-local-size";
 }

--- a/jraft-rheakv/rheakv-core/src/main/java/com/alipay/sofa/jraft/rhea/storage/KVStateOutputList.java
+++ b/jraft-rheakv/rheakv-core/src/main/java/com/alipay/sofa/jraft/rhea/storage/KVStateOutputList.java
@@ -45,8 +45,8 @@ public final class KVStateOutputList extends ArrayList<KVState> implements Recyc
     /**
      * Create a new empty {@link KVStateOutputList} instance with the given capacity.
      */
-    public static KVStateOutputList newInstance(int minCapacity) {
-        KVStateOutputList ret = recyclers.get();
+    public static KVStateOutputList newInstance(final int minCapacity) {
+        final KVStateOutputList ret = recyclers.get();
         ret.ensureCapacity(minCapacity);
         return ret;
     }
@@ -69,29 +69,29 @@ public final class KVStateOutputList extends ArrayList<KVState> implements Recyc
     }
 
     @Override
-    public boolean addAll(Collection<? extends KVState> c) {
+    public boolean addAll(final Collection<? extends KVState> c) {
         checkNullElements(c);
         return super.addAll(c);
     }
 
     @Override
-    public boolean addAll(int index, Collection<? extends KVState> c) {
+    public boolean addAll(final int index, final Collection<? extends KVState> c) {
         checkNullElements(c);
         return super.addAll(index, c);
     }
 
-    private static void checkNullElements(Collection<?> c) {
+    private static void checkNullElements(final Collection<?> c) {
         if (c instanceof RandomAccess && c instanceof List) {
             // produce less garbage
-            List<?> list = (List<?>) c;
-            int size = list.size();
+            final List<?> list = (List<?>) c;
+            final int size = list.size();
             for (int i = 0; i < size; i++) {
                 if (list.get(i) == null) {
                     throw new IllegalArgumentException("c contains null values");
                 }
             }
         } else {
-            for (Object element : c) {
+            for (final Object element : c) {
                 if (element == null) {
                     throw new IllegalArgumentException("c contains null values");
                 }
@@ -100,7 +100,7 @@ public final class KVStateOutputList extends ArrayList<KVState> implements Recyc
     }
 
     @Override
-    public boolean add(KVState element) {
+    public boolean add(final KVState element) {
         if (element == null) {
             throw new NullPointerException("element");
         }
@@ -108,7 +108,7 @@ public final class KVStateOutputList extends ArrayList<KVState> implements Recyc
     }
 
     @Override
-    public void add(int index, KVState element) {
+    public void add(final int index, final KVState element) {
         if (element == null) {
             throw new NullPointerException("element");
         }
@@ -116,7 +116,7 @@ public final class KVStateOutputList extends ArrayList<KVState> implements Recyc
     }
 
     @Override
-    public KVState set(int index, KVState element) {
+    public KVState set(final int index, final KVState element) {
         if (element == null) {
             throw new NullPointerException("element");
         }
@@ -137,18 +137,18 @@ public final class KVStateOutputList extends ArrayList<KVState> implements Recyc
         return recyclers.threadLocalSize();
     }
 
-    private KVStateOutputList(Recyclers.Handle handle) {
+    private KVStateOutputList(final Recyclers.Handle handle) {
         this(handle, DEFAULT_INITIAL_CAPACITY);
     }
 
-    private KVStateOutputList(Recyclers.Handle handle, int initialCapacity) {
+    private KVStateOutputList(final Recyclers.Handle handle, final int initialCapacity) {
         super(initialCapacity);
         this.handle = handle;
     }
 
     private transient final Recyclers.Handle          handle;
 
-    private static final Recyclers<KVStateOutputList> recyclers = new Recyclers<KVStateOutputList>() {
+    private static final Recyclers<KVStateOutputList> recyclers = new Recyclers<KVStateOutputList>(512) {
 
                                                                     @Override
                                                                     protected KVStateOutputList newObject(final Handle handle) {

--- a/jraft-rheakv/rheakv-core/src/main/java/com/alipay/sofa/jraft/rhea/storage/KVStateOutputList.java
+++ b/jraft-rheakv/rheakv-core/src/main/java/com/alipay/sofa/jraft/rhea/storage/KVStateOutputList.java
@@ -129,6 +129,14 @@ public final class KVStateOutputList extends ArrayList<KVState> implements Recyc
         return recyclers.recycle(this, handle);
     }
 
+    public static int threadLocalCapacity() {
+        return recyclers.threadLocalCapacity();
+    }
+
+    public static int threadLocalSize() {
+        return recyclers.threadLocalSize();
+    }
+
     private KVStateOutputList(Recyclers.Handle handle) {
         this(handle, DEFAULT_INITIAL_CAPACITY);
     }

--- a/jraft-rheakv/rheakv-core/src/main/java/com/alipay/sofa/jraft/rhea/storage/KVStateOutputList.java
+++ b/jraft-rheakv/rheakv-core/src/main/java/com/alipay/sofa/jraft/rhea/storage/KVStateOutputList.java
@@ -21,8 +21,8 @@ import java.util.Collection;
 import java.util.List;
 import java.util.RandomAccess;
 
-import com.alipay.sofa.jraft.rhea.util.Recyclable;
-import com.alipay.sofa.jraft.rhea.util.Recyclers;
+import com.alipay.sofa.jraft.util.Recyclable;
+import com.alipay.sofa.jraft.util.Recyclers;
 import com.alipay.sofa.jraft.util.Requires;
 
 /**
@@ -143,7 +143,7 @@ public final class KVStateOutputList extends ArrayList<KVState> implements Recyc
     private static final Recyclers<KVStateOutputList> recyclers = new Recyclers<KVStateOutputList>() {
 
                                                                     @Override
-                                                                    protected KVStateOutputList newObject(Handle handle) {
+                                                                    protected KVStateOutputList newObject(final Handle handle) {
                                                                         return new KVStateOutputList(handle);
                                                                     }
                                                                 };

--- a/jraft-rheakv/rheakv-core/src/main/java/com/alipay/sofa/jraft/rhea/storage/KVStoreStateMachine.java
+++ b/jraft-rheakv/rheakv-core/src/main/java/com/alipay/sofa/jraft/rhea/storage/KVStoreStateMachine.java
@@ -46,8 +46,6 @@ import com.alipay.sofa.jraft.util.RecycleUtil;
 import com.codahale.metrics.Histogram;
 import com.codahale.metrics.Meter;
 
-import static com.alipay.sofa.jraft.rhea.metrics.KVMetricNames.KV_STATES_THREAD_LOCAL_CAPACITY;
-import static com.alipay.sofa.jraft.rhea.metrics.KVMetricNames.KV_STATES_THREAD_LOCAL_SIZE;
 import static com.alipay.sofa.jraft.rhea.metrics.KVMetricNames.STATE_MACHINE_APPLY_QPS;
 import static com.alipay.sofa.jraft.rhea.metrics.KVMetricNames.STATE_MACHINE_BATCH_WRITE;
 
@@ -152,16 +150,7 @@ public class KVStoreStateMachine extends StateMachineAdapter {
             return size;
         } finally {
             RecycleUtil.recycle(kvStates);
-            recordKVStateListMetric();
         }
-    }
-
-    private static void recordKVStateListMetric() {
-        final String threadName = Thread.currentThread().getName();
-        KVMetrics.histogram(KV_STATES_THREAD_LOCAL_CAPACITY, threadName) //
-            .update(KVStateOutputList.threadLocalCapacity());
-        KVMetrics.histogram(KV_STATES_THREAD_LOCAL_SIZE, threadName) //
-            .update(KVStateOutputList.threadLocalCapacity());
     }
 
     private void batchApply(final byte opType, final KVStateOutputList kvStates) {

--- a/jraft-rheakv/rheakv-core/src/main/java/com/alipay/sofa/jraft/rhea/storage/KVStoreStateMachine.java
+++ b/jraft-rheakv/rheakv-core/src/main/java/com/alipay/sofa/jraft/rhea/storage/KVStoreStateMachine.java
@@ -38,14 +38,16 @@ import com.alipay.sofa.jraft.rhea.metadata.Region;
 import com.alipay.sofa.jraft.rhea.metrics.KVMetrics;
 import com.alipay.sofa.jraft.rhea.serialization.Serializer;
 import com.alipay.sofa.jraft.rhea.serialization.Serializers;
-import com.alipay.sofa.jraft.util.RecycleUtil;
 import com.alipay.sofa.jraft.rhea.util.StackTraceUtil;
 import com.alipay.sofa.jraft.storage.snapshot.SnapshotReader;
 import com.alipay.sofa.jraft.storage.snapshot.SnapshotWriter;
 import com.alipay.sofa.jraft.util.BytesUtil;
+import com.alipay.sofa.jraft.util.RecycleUtil;
 import com.codahale.metrics.Histogram;
 import com.codahale.metrics.Meter;
 
+import static com.alipay.sofa.jraft.rhea.metrics.KVMetricNames.KV_STATES_THREAD_LOCAL_CAPACITY;
+import static com.alipay.sofa.jraft.rhea.metrics.KVMetricNames.KV_STATES_THREAD_LOCAL_SIZE;
 import static com.alipay.sofa.jraft.rhea.metrics.KVMetricNames.STATE_MACHINE_APPLY_QPS;
 import static com.alipay.sofa.jraft.rhea.metrics.KVMetricNames.STATE_MACHINE_BATCH_WRITE;
 
@@ -150,7 +152,16 @@ public class KVStoreStateMachine extends StateMachineAdapter {
             return size;
         } finally {
             RecycleUtil.recycle(kvStates);
+            recordKVStateListMetric();
         }
+    }
+
+    private static void recordKVStateListMetric() {
+        final String threadName = Thread.currentThread().getName();
+        KVMetrics.histogram(KV_STATES_THREAD_LOCAL_CAPACITY, threadName) //
+            .update(KVStateOutputList.threadLocalCapacity());
+        KVMetrics.histogram(KV_STATES_THREAD_LOCAL_SIZE, threadName) //
+            .update(KVStateOutputList.threadLocalCapacity());
     }
 
     private void batchApply(final byte opType, final KVStateOutputList kvStates) {

--- a/jraft-rheakv/rheakv-core/src/main/java/com/alipay/sofa/jraft/rhea/storage/KVStoreStateMachine.java
+++ b/jraft-rheakv/rheakv-core/src/main/java/com/alipay/sofa/jraft/rhea/storage/KVStoreStateMachine.java
@@ -38,7 +38,7 @@ import com.alipay.sofa.jraft.rhea.metadata.Region;
 import com.alipay.sofa.jraft.rhea.metrics.KVMetrics;
 import com.alipay.sofa.jraft.rhea.serialization.Serializer;
 import com.alipay.sofa.jraft.rhea.serialization.Serializers;
-import com.alipay.sofa.jraft.rhea.util.RecycleUtil;
+import com.alipay.sofa.jraft.util.RecycleUtil;
 import com.alipay.sofa.jraft.rhea.util.StackTraceUtil;
 import com.alipay.sofa.jraft.storage.snapshot.SnapshotReader;
 import com.alipay.sofa.jraft.storage.snapshot.SnapshotWriter;


### PR DESCRIPTION
### Motivation:

Predict the allocation capacity of buf to avoid frequent expansion.

### Modification:

Add AdaptiveBufAllocator

The allocate size table:
[16, 32, 48, 64, 80, 96, 112, 128, 144, 160, 176, 192, 208, 224, 240, 256, 272, 288, 304, 320, 336, 352, 368, 384, 400, 416, 432, 448, 464, 480, 496, 512, 1024, 2048, 4096, 8192, 16384, 32768, 65536, 131072, 262144, 524288, 1048576, 2097152, 4194304, 8388608, 16777216, 33554432, 67108864, 134217728, 268435456, 536870912, 1073741824]


The code comes from https://github.com/netty/netty/blob/4.1/transport/src/main/java/io/netty/channel/AdaptiveRecvByteBufAllocator.java

### Result:

Fixes #158

