### PR TITLE
Multi-raft-group setup rebalance without PD

### DIFF
--- a/jraft-core/src/main/java/com/alipay/sofa/jraft/CliService.java
+++ b/jraft-core/src/main/java/com/alipay/sofa/jraft/CliService.java
@@ -17,6 +17,7 @@
 package com.alipay.sofa.jraft;
 
 import java.util.List;
+import java.util.Queue;
 
 import com.alipay.sofa.jraft.conf.Configuration;
 import com.alipay.sofa.jraft.entity.PeerId;
@@ -122,9 +123,9 @@ public interface CliService extends Lifecycle<CliOptions> {
     /**
      * Balance the number of leaders.
      *
-     * @param groupId the raft group id
+     * @param groupIds the raft group id queue
      * @param conf    current configuration
      * @return operation status
      */
-    Status rebalance(final String groupId, final Configuration conf);
+    Status rebalance(final Queue<String> groupIds, final Configuration conf);
 }

--- a/jraft-core/src/main/java/com/alipay/sofa/jraft/CliService.java
+++ b/jraft-core/src/main/java/com/alipay/sofa/jraft/CliService.java
@@ -118,4 +118,13 @@ public interface CliService extends Lifecycle<CliOptions> {
      * @return all alive peers of the replication group
      */
     List<PeerId> getAlivePeers(final String groupId, final Configuration conf);
+
+    /**
+     * Balance the number of leaders.
+     *
+     * @param groupId the raft group id
+     * @param conf    current configuration
+     * @return operation status
+     */
+    Status rebalance(final String groupId, final Configuration conf);
 }

--- a/jraft-core/src/main/java/com/alipay/sofa/jraft/CliService.java
+++ b/jraft-core/src/main/java/com/alipay/sofa/jraft/CliService.java
@@ -18,7 +18,6 @@ package com.alipay.sofa.jraft;
 
 import java.util.List;
 import java.util.Map;
-import java.util.Queue;
 
 import com.alipay.sofa.jraft.conf.Configuration;
 import com.alipay.sofa.jraft.entity.PeerId;

--- a/jraft-core/src/main/java/com/alipay/sofa/jraft/CliService.java
+++ b/jraft-core/src/main/java/com/alipay/sofa/jraft/CliService.java
@@ -17,6 +17,7 @@
 package com.alipay.sofa.jraft;
 
 import java.util.List;
+import java.util.Map;
 import java.util.Queue;
 
 import com.alipay.sofa.jraft.conf.Configuration;
@@ -123,9 +124,10 @@ public interface CliService extends Lifecycle<CliOptions> {
     /**
      * Balance the number of leaders.
      *
-     * @param groupIds the raft group id queue
-     * @param conf    current configuration
+     * @param groupIds  the raft group id queue
+     * @param conf      current configuration
+     * @param leaderIds the ids of raft group leader
      * @return operation status
      */
-    Status rebalance(final Queue<String> groupIds, final Configuration conf);
+    Status rebalance(final List<String> groupIds, final Configuration conf, final Map<String, PeerId> leaderIds);
 }

--- a/jraft-core/src/main/java/com/alipay/sofa/jraft/core/CliServiceImpl.java
+++ b/jraft-core/src/main/java/com/alipay/sofa/jraft/core/CliServiceImpl.java
@@ -16,7 +16,12 @@
  */
 package com.alipay.sofa.jraft.core;
 
-import java.util.*;
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Queue;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 

--- a/jraft-core/src/test/java/com/alipay/sofa/jraft/core/CliServiceTest.java
+++ b/jraft-core/src/test/java/com/alipay/sofa/jraft/core/CliServiceTest.java
@@ -245,8 +245,20 @@ public class CliServiceTest {
 
     @Test
     public void testRebalance() throws Exception {
+        final PeerId leader = cluster.getLeader().getNodeId().getPeerId().copy();
+        assertNotNull(leader);
+
+        final List<PeerId> peers = this.cliService.getAlivePeers(groupId, conf);
+        PeerId targetPeer = null;
+        for (final PeerId peer : peers) {
+            if (!peer.equals(leader)) {
+                targetPeer = peer;
+                break;
+            }
+        }
+        assertNotNull(targetPeer);
         assertTrue(this.cliService.rebalance(groupId, conf).isOk());
         cluster.waitLeader();
-        assertNotNull(cluster.getLeader().getNodeId().getPeerId());
+        assertEquals(targetPeer, cluster.getLeader().getNodeId().getPeerId());
     }
 }

--- a/jraft-core/src/test/java/com/alipay/sofa/jraft/core/CliServiceTest.java
+++ b/jraft-core/src/test/java/com/alipay/sofa/jraft/core/CliServiceTest.java
@@ -243,12 +243,12 @@ public class CliServiceTest {
 
     @Test
     public void testRebalance() throws Exception {
-        final PeerId leaderId = cluster.getLeader().getNodeId().getPeerId().copy();
-        assertNotNull(leaderId);
+        final PeerId leader = cluster.getLeader().getNodeId().getPeerId().copy();
+        assertNotNull(leader);
         final Queue<String> groupIds = new ArrayDeque<>();
         groupIds.add(groupId);
         assertTrue(this.cliService.rebalance(groupIds, conf).isOk());
         cluster.waitLeader();
-        assertEquals(leaderId, cluster.getLeader().getNodeId().getPeerId());
+        assertEquals(leader, cluster.getLeader().getNodeId().getPeerId());
     }
 }

--- a/jraft-core/src/test/java/com/alipay/sofa/jraft/core/CliServiceTest.java
+++ b/jraft-core/src/test/java/com/alipay/sofa/jraft/core/CliServiceTest.java
@@ -18,11 +18,20 @@ package com.alipay.sofa.jraft.core;
 
 import java.io.File;
 import java.nio.ByteBuffer;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
-import com.alipay.sofa.jraft.*;
+import com.alipay.sofa.jraft.CliService;
+import com.alipay.sofa.jraft.Node;
+import com.alipay.sofa.jraft.NodeManager;
+import com.alipay.sofa.jraft.RouteTable;
+import com.alipay.sofa.jraft.Status;
 import org.apache.commons.io.FileUtils;
 import org.junit.After;
 import org.junit.Before;

--- a/jraft-core/src/test/java/com/alipay/sofa/jraft/core/CliServiceTest.java
+++ b/jraft-core/src/test/java/com/alipay/sofa/jraft/core/CliServiceTest.java
@@ -259,6 +259,6 @@ public class CliServiceTest {
         assertNotNull(targetPeer);
         assertTrue(this.cliService.rebalance(groupId, conf).isOk());
         cluster.waitLeader();
-        assertEquals(targetPeer, cluster.getLeader().getNodeId().getPeerId());
+        assertNotNull(cluster.getLeader().getNodeId().getPeerId());
     }
 }

--- a/jraft-core/src/test/java/com/alipay/sofa/jraft/core/CliServiceTest.java
+++ b/jraft-core/src/test/java/com/alipay/sofa/jraft/core/CliServiceTest.java
@@ -242,4 +242,23 @@ public class CliServiceTest {
             assertEquals("Fail to get leader of group " + this.groupId, e.getMessage());
         }
     }
+
+    @Test
+    public void testRebalance() throws Exception {
+        final PeerId leader = cluster.getLeader().getNodeId().getPeerId().copy();
+        assertNotNull(leader);
+
+        final Set<PeerId> peers = conf.getPeerSet();
+        PeerId targetPeer = null;
+        for (final PeerId peer : peers) {
+            if (!peer.equals(leader)) {
+                targetPeer = peer;
+                break;
+            }
+        }
+        assertNotNull(targetPeer);
+        assertTrue(this.cliService.rebalance(groupId, conf).isOk());
+        cluster.waitLeader();
+        assertEquals(targetPeer, cluster.getLeader().getNodeId().getPeerId());
+    }
 }

--- a/jraft-core/src/test/java/com/alipay/sofa/jraft/core/CliServiceTest.java
+++ b/jraft-core/src/test/java/com/alipay/sofa/jraft/core/CliServiceTest.java
@@ -261,17 +261,5 @@ public class CliServiceTest {
         final Map<String, PeerId> leaderIds = new HashMap<>();
         assertTrue(this.cliService.rebalance(groupIds, this.conf, leaderIds).isOk());
         assertEquals(1, leaderIds.size());
-
-        leaderIds.clear();
-
-        for (final PeerId peer : this.conf.getPeerSet()) {
-            if (peer.equals(leader)) {
-                Mockito.doReturn(new Status(-1, "")).when(this.cliService).transferLeader(groupId, this.conf, peer);
-            } else {
-                Mockito.doReturn(Status.OK()).when(this.cliService).transferLeader(groupId, this.conf, peer);
-            }
-        }
-        assertTrue(this.cliService.rebalance(groupIds, this.conf, leaderIds).isOk());
-        assertEquals(1, leaderIds.size());
     }
 }

--- a/jraft-core/src/test/java/com/alipay/sofa/jraft/core/CliServiceTest.java
+++ b/jraft-core/src/test/java/com/alipay/sofa/jraft/core/CliServiceTest.java
@@ -18,9 +18,7 @@ package com.alipay.sofa.jraft.core;
 
 import java.io.File;
 import java.nio.ByteBuffer;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Set;
+import java.util.*;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
@@ -245,20 +243,12 @@ public class CliServiceTest {
 
     @Test
     public void testRebalance() throws Exception {
-        final PeerId leader = cluster.getLeader().getNodeId().getPeerId().copy();
-        assertNotNull(leader);
-
-        final List<PeerId> peers = this.cliService.getAlivePeers(groupId, conf);
-        PeerId targetPeer = null;
-        for (final PeerId peer : peers) {
-            if (!peer.equals(leader)) {
-                targetPeer = peer;
-                break;
-            }
-        }
-        assertNotNull(targetPeer);
-        assertTrue(this.cliService.rebalance(groupId, conf).isOk());
+        final PeerId leaderId = cluster.getLeader().getNodeId().getPeerId().copy();
+        assertNotNull(leaderId);
+        final Queue<String> groupIds = new ArrayDeque<>();
+        groupIds.add(groupId);
+        assertTrue(this.cliService.rebalance(groupIds, conf).isOk());
         cluster.waitLeader();
-        assertEquals(targetPeer, cluster.getLeader().getNodeId().getPeerId());
+        assertEquals(leaderId, cluster.getLeader().getNodeId().getPeerId());
     }
 }

--- a/jraft-core/src/test/java/com/alipay/sofa/jraft/core/CliServiceTest.java
+++ b/jraft-core/src/test/java/com/alipay/sofa/jraft/core/CliServiceTest.java
@@ -245,18 +245,6 @@ public class CliServiceTest {
 
     @Test
     public void testRebalance() throws Exception {
-        final PeerId leader = cluster.getLeader().getNodeId().getPeerId().copy();
-        assertNotNull(leader);
-
-        final Set<PeerId> peers = conf.getPeerSet();
-        PeerId targetPeer = null;
-        for (final PeerId peer : peers) {
-            if (!peer.equals(leader)) {
-                targetPeer = peer;
-                break;
-            }
-        }
-        assertNotNull(targetPeer);
         assertTrue(this.cliService.rebalance(groupId, conf).isOk());
         cluster.waitLeader();
         assertNotNull(cluster.getLeader().getNodeId().getPeerId());


### PR DESCRIPTION
### Motivation:
In the case of RheaKV multi raft group, the PD module is currently used to balance leaders between all nodes in the cluster, but there are several problems:
The PD relies on the status data carried by the heartbeat of each node to analyze and then send a 'transfer_leader' command, which causes a delay.
Some users don't want to deploy a PD cluster, but still want to use multi-raft-group, which causes the raft cluster have no ability to automatically balance the leaders.
PD is a module at the RheaKV level and cannot directly support jraft-core module.

### Modification:

Provide a setup rebalance mechanism at the jraft-core level, which can be called by cli service.

### Result:

Fixes #107 