### PR TITLE
Update get leader log

### DIFF
--- a/jraft-core/src/main/java/com/alipay/sofa/jraft/core/CliServiceImpl.java
+++ b/jraft-core/src/main/java/com/alipay/sofa/jraft/core/CliServiceImpl.java
@@ -330,7 +330,7 @@ public class CliServiceImpl implements CliService {
         final Status st = new Status(-1, "Fail to get leader of group %s", groupId);
         for (final PeerId peer : conf) {
             if (!this.cliClientService.connect(peer.getEndpoint())) {
-                LOG.error("Fail to connect peer {} to get leader for group {}.", groupId);
+                LOG.error("Fail to connect peer {} to get leader for group {}.", peer, groupId);
                 continue;
             }
 


### PR DESCRIPTION
### Motivation:
Update log of getLeader() method when fail to connect peer to get leader for group.
