### PR TITLE
(feat) configure the number of processors #180

### DIFF
--- a/jraft-core/src/main/java/com/alipay/sofa/jraft/util/Utils.java
+++ b/jraft-core/src/main/java/com/alipay/sofa/jraft/util/Utils.java
@@ -51,9 +51,12 @@ public class Utils {
     private static final Logger       LOG                                 = LoggerFactory.getLogger(Utils.class);
 
     /**
-     * Current system CPUs count.
+     * The configured number of available processors. The default is {@link Runtime#availableProcessors()}.
+     * This can be overridden by setting the system property "jraft.available_processors".
      */
-    private static final int          CPUS                                = Runtime.getRuntime().availableProcessors();
+    private static final int          CPUS                                = SystemPropertyUtil.getInt(
+                                                                              "jraft.available_processors", Runtime
+                                                                                  .getRuntime().availableProcessors());
 
     /**
      * Default jraft closure executor pool minimum size, CPUs by default.

--- a/jraft-rheakv/rheakv-core/src/main/java/com/alipay/sofa/jraft/rhea/client/DefaultRheaKVStore.java
+++ b/jraft-rheakv/rheakv-core/src/main/java/com/alipay/sofa/jraft/rhea/client/DefaultRheaKVStore.java
@@ -93,6 +93,7 @@ import com.alipay.sofa.jraft.util.BytesUtil;
 import com.alipay.sofa.jraft.util.Endpoint;
 import com.alipay.sofa.jraft.util.LogExceptionHandler;
 import com.alipay.sofa.jraft.util.Requires;
+import com.alipay.sofa.jraft.util.Utils;
 import com.codahale.metrics.Histogram;
 import com.lmax.disruptor.EventFactory;
 import com.lmax.disruptor.EventHandler;
@@ -257,7 +258,7 @@ public class DefaultRheaKVStore implements RheaKVStore {
         this.futureTimeoutMillis = opts.getFutureTimeoutMillis();
         this.onlyLeaderRead = opts.isOnlyLeaderRead();
         if (opts.isUseParallelKVExecutor()) {
-            final int numWorkers = Constants.AVAILABLE_PROCESSORS;
+            final int numWorkers = Utils.cpus();
             final int bufSize = numWorkers << 4;
             final String name = "parallel-kv-executor";
             final ThreadFactory threadFactory = Constants.THREAD_AFFINITY_ENABLED

--- a/jraft-rheakv/rheakv-core/src/main/java/com/alipay/sofa/jraft/rhea/options/RpcOptions.java
+++ b/jraft-rheakv/rheakv-core/src/main/java/com/alipay/sofa/jraft/rhea/options/RpcOptions.java
@@ -16,7 +16,7 @@
  */
 package com.alipay.sofa.jraft.rhea.options;
 
-import com.alipay.sofa.jraft.rhea.util.Constants;
+import com.alipay.sofa.jraft.util.Utils;
 
 /**
  *
@@ -24,8 +24,8 @@ import com.alipay.sofa.jraft.rhea.util.Constants;
  */
 public class RpcOptions {
 
-    private int callbackExecutorCorePoolSize    = Constants.AVAILABLE_PROCESSORS << 2;
-    private int callbackExecutorMaximumPoolSize = Constants.AVAILABLE_PROCESSORS << 3;
+    private int callbackExecutorCorePoolSize    = Utils.cpus() << 2;
+    private int callbackExecutorMaximumPoolSize = Utils.cpus() << 3;
     private int callbackExecutorQueueCapacity   = 512;
     private int rpcTimeoutMillis                = 5000;
 

--- a/jraft-rheakv/rheakv-core/src/main/java/com/alipay/sofa/jraft/rhea/options/StoreEngineOptions.java
+++ b/jraft-rheakv/rheakv-core/src/main/java/com/alipay/sofa/jraft/rhea/options/StoreEngineOptions.java
@@ -21,8 +21,8 @@ import java.util.concurrent.TimeUnit;
 
 import com.alipay.sofa.jraft.option.NodeOptions;
 import com.alipay.sofa.jraft.rhea.storage.StorageType;
-import com.alipay.sofa.jraft.rhea.util.Constants;
 import com.alipay.sofa.jraft.util.Endpoint;
+import com.alipay.sofa.jraft.util.Utils;
 
 /**
  *
@@ -43,12 +43,12 @@ public class StoreEngineOptions {
     private HeartbeatOptions          heartbeatOptions;
     private boolean                   useSharedRpcExecutor;
     // thread poll number of threads
-    private int                       readIndexCoreThreads          = Math.max(Constants.AVAILABLE_PROCESSORS << 2, 16);
+    private int                       readIndexCoreThreads          = Math.max(Utils.cpus() << 2, 16);
     private int                       leaderStateTriggerCoreThreads = 4;
     private int                       snapshotCoreThreads           = 1;
-    private int                       cliRpcCoreThreads             = Constants.AVAILABLE_PROCESSORS << 2;
-    private int                       raftRpcCoreThreads            = Math.max(Constants.AVAILABLE_PROCESSORS << 3, 32);
-    private int                       kvRpcCoreThreads              = Math.max(Constants.AVAILABLE_PROCESSORS << 3, 32);
+    private int                       cliRpcCoreThreads             = Utils.cpus() << 2;
+    private int                       raftRpcCoreThreads            = Math.max(Utils.cpus() << 3, 32);
+    private int                       kvRpcCoreThreads              = Math.max(Utils.cpus() << 3, 32);
     // metrics schedule option (seconds), won't start reporter id metricsReportPeriod <= 0
     private long                      metricsReportPeriod           = TimeUnit.MINUTES.toSeconds(5);
     // the minimum number of keys required to split, less than this value will refuse to split

--- a/jraft-rheakv/rheakv-core/src/main/java/com/alipay/sofa/jraft/rhea/util/Constants.java
+++ b/jraft-rheakv/rheakv-core/src/main/java/com/alipay/sofa/jraft/rhea/util/Constants.java
@@ -44,9 +44,6 @@ public final class Constants {
     // TODO support ipv6
     public static final String  IP_ANY                  = "0.0.0.0";
 
-    /** CPU cores */
-    public static final int     AVAILABLE_PROCESSORS    = Runtime.getRuntime().availableProcessors();
-
     public static final boolean THREAD_AFFINITY_ENABLED = SystemPropertyUtil.getBoolean("rhea.thread.affinity.enabled",
                                                             false);
 

--- a/jraft-rheakv/rheakv-core/src/test/java/com/alipay/sofa/jraft/rhea/chaos/AbstractChaosTest.java
+++ b/jraft-rheakv/rheakv-core/src/test/java/com/alipay/sofa/jraft/rhea/chaos/AbstractChaosTest.java
@@ -42,6 +42,7 @@ import com.alipay.sofa.jraft.rhea.util.Constants;
 import com.alipay.sofa.jraft.util.BytesUtil;
 import com.alipay.sofa.jraft.util.ExecutorServiceHelper;
 import com.alipay.sofa.jraft.util.NamedThreadFactory;
+import com.alipay.sofa.jraft.util.Utils;
 
 /**
  *
@@ -49,7 +50,7 @@ import com.alipay.sofa.jraft.util.NamedThreadFactory;
  */
 public abstract class AbstractChaosTest {
 
-    private static final int    LOOP_1             = Constants.AVAILABLE_PROCESSORS;
+    private static final int    LOOP_1             = Utils.cpus();
     private static final int    LOOP_2             = 20;
     private static final int    INITIAL_PEER_COUNT = 5;
     private static final int    RETRIES            = 10;

--- a/jraft-rheakv/rheakv-pd/src/main/java/com/alipay/sofa/jraft/rhea/PlacementDriverServer.java
+++ b/jraft-rheakv/rheakv-pd/src/main/java/com/alipay/sofa/jraft/rhea/PlacementDriverServer.java
@@ -38,13 +38,13 @@ import com.alipay.sofa.jraft.rhea.cmd.pd.SetStoreInfoRequest;
 import com.alipay.sofa.jraft.rhea.cmd.pd.StoreHeartbeatRequest;
 import com.alipay.sofa.jraft.rhea.options.PlacementDriverServerOptions;
 import com.alipay.sofa.jraft.rhea.options.RheaKVStoreOptions;
-import com.alipay.sofa.jraft.rhea.util.Constants;
 import com.alipay.sofa.jraft.rhea.util.concurrent.CallerRunsPolicyWithReport;
 import com.alipay.sofa.jraft.rhea.util.concurrent.NamedThreadFactory;
 import com.alipay.sofa.jraft.util.Endpoint;
 import com.alipay.sofa.jraft.util.ExecutorServiceHelper;
 import com.alipay.sofa.jraft.util.Requires;
 import com.alipay.sofa.jraft.util.ThreadPoolUtil;
+import com.alipay.sofa.jraft.util.Utils;
 
 /**
  * PlacementDriverServer is a role responsible for overall global control.
@@ -218,7 +218,7 @@ public class PlacementDriverServer implements Lifecycle<PlacementDriverServerOpt
     }
 
     private ThreadPoolExecutor createDefaultPdExecutor() {
-        final int corePoolSize = Math.max(Constants.AVAILABLE_PROCESSORS << 2, 32);
+        final int corePoolSize = Math.max(Utils.cpus() << 2, 32);
         final String name = "rheakv-pd-executor";
         return ThreadPoolUtil.newBuilder() //
             .poolName(name) //


### PR DESCRIPTION
### Motivation:

In cases when an application is running in a container or is otherwise
constrained to the number of processors that it is using, the JVM
invocation Runtime#availableProcessors will not return the constrained value but rather the number of processors available to the virtual machine. SOFAJRaft uses this number in sizing various resources.
Additionally, some applications will constrain the number of threads
that they are using independenly of the number of processors available
on the system.
Thus, applications should have a way to globally configure the number of processors.

### Modification:

### Result:

Fixes #180 

