### PR TITLE
(feat) add follower state listener

### DIFF
--- a/jraft-rheakv/rheakv-core/src/main/java/com/alipay/sofa/jraft/rhea/FollowerStateListener.java
+++ b/jraft-rheakv/rheakv-core/src/main/java/com/alipay/sofa/jraft/rhea/FollowerStateListener.java
@@ -19,25 +19,29 @@ package com.alipay.sofa.jraft.rhea;
 import com.alipay.sofa.jraft.entity.PeerId;
 
 /**
- * Leader state listener.
+ * Follower state listener.
  *
- * @author dennis
+ * @author jiachun.fjc
  */
-public interface LeaderStateListener extends StateListener {
+public interface FollowerStateListener extends StateListener {
 
     /**
      * Called when current node becomes leader.
      *
-     * @param newTerm the new term
+     * @param term the new term
      */
-    void onLeaderStart(final long newTerm);
+    default void onLeaderStart(final long term) {
+        // NO-OP
+    }
 
     /**
      * Called when current node loses leadership.
      *
-     * @param oldTerm the old term
+     * @param term the old term
      */
-    void onLeaderStop(final long oldTerm);
+    default void onLeaderStop(final long term) {
+        // NO-OP
+    }
 
     /**
      * This method is called when a follower or candidate starts following a leader and its leaderId
@@ -52,9 +56,7 @@ public interface LeaderStateListener extends StateListener {
      * @param newLeaderId the new leader id whom the follower starts to follow
      * @param newTerm     the new term
      */
-    default void onStartFollowing(final PeerId newLeaderId, final long newTerm) {
-        // NO-OP
-    }
+    void onStartFollowing(final PeerId newLeaderId, final long newTerm);
 
     /**
      * This method is called when a follower stops following a leader and its leaderId becomes null,
@@ -71,7 +73,5 @@ public interface LeaderStateListener extends StateListener {
      * @param oldLeaderId the old leader id whom the follower followed before
      * @param oldTerm     the old term
      */
-    default void onStopFollowing(final PeerId oldLeaderId, final long oldTerm) {
-        // NO-OP
-    }
+    void onStopFollowing(final PeerId oldLeaderId, final long oldTerm);
 }

--- a/jraft-rheakv/rheakv-core/src/main/java/com/alipay/sofa/jraft/rhea/StateListener.java
+++ b/jraft-rheakv/rheakv-core/src/main/java/com/alipay/sofa/jraft/rhea/StateListener.java
@@ -19,11 +19,11 @@ package com.alipay.sofa.jraft.rhea;
 import com.alipay.sofa.jraft.entity.PeerId;
 
 /**
- * Leader state listener.
+ * The raft state listener.
  *
- * @author dennis
+ * @author jiachun.fjc
  */
-public interface LeaderStateListener extends StateListener {
+public interface StateListener {
 
     /**
      * Called when current node becomes leader.
@@ -52,9 +52,7 @@ public interface LeaderStateListener extends StateListener {
      * @param newLeaderId the new leader id whom the follower starts to follow
      * @param newTerm     the new term
      */
-    default void onStartFollowing(final PeerId newLeaderId, final long newTerm) {
-        // NO-OP
-    }
+    void onStartFollowing(final PeerId newLeaderId, final long newTerm);
 
     /**
      * This method is called when a follower stops following a leader and its leaderId becomes null,
@@ -71,7 +69,5 @@ public interface LeaderStateListener extends StateListener {
      * @param oldLeaderId the old leader id whom the follower followed before
      * @param oldTerm     the old term
      */
-    default void onStopFollowing(final PeerId oldLeaderId, final long oldTerm) {
-        // NO-OP
-    }
+    void onStopFollowing(final PeerId oldLeaderId, final long oldTerm);
 }

--- a/jraft-rheakv/rheakv-core/src/main/java/com/alipay/sofa/jraft/rhea/StoreEngine.java
+++ b/jraft-rheakv/rheakv-core/src/main/java/com/alipay/sofa/jraft/rhea/StoreEngine.java
@@ -103,7 +103,7 @@ public class StoreEngine implements Lifecycle<StoreEngineOptions> {
 
     // Shared executor services
     private ExecutorService                            readIndexExecutor;
-    private ExecutorService                            leaderStateTrigger;
+    private ExecutorService                            raftStateTrigger;
     private ExecutorService                            snapshotExecutor;
     private ExecutorService                            cliRpcExecutor;
     private ExecutorService                            raftRpcExecutor;
@@ -170,9 +170,8 @@ public class StoreEngine implements Lifecycle<StoreEngineOptions> {
         if (this.readIndexExecutor == null) {
             this.readIndexExecutor = StoreEngineHelper.createReadIndexExecutor(opts.getReadIndexCoreThreads());
         }
-        if (this.leaderStateTrigger == null) {
-            this.leaderStateTrigger = StoreEngineHelper.createLeaderStateTrigger(opts
-                .getLeaderStateTriggerCoreThreads());
+        if (this.raftStateTrigger == null) {
+            this.raftStateTrigger = StoreEngineHelper.createRaftStateTrigger(opts.getLeaderStateTriggerCoreThreads());
         }
         if (this.snapshotExecutor == null) {
             this.snapshotExecutor = StoreEngineHelper.createSnapshotExecutor(opts.getSnapshotCoreThreads());
@@ -254,7 +253,7 @@ public class StoreEngine implements Lifecycle<StoreEngineOptions> {
             this.threadPoolMetricsReporter.stop();
         }
         ExecutorServiceHelper.shutdownAndAwaitTermination(this.readIndexExecutor);
-        ExecutorServiceHelper.shutdownAndAwaitTermination(this.leaderStateTrigger);
+        ExecutorServiceHelper.shutdownAndAwaitTermination(this.raftStateTrigger);
         ExecutorServiceHelper.shutdownAndAwaitTermination(this.snapshotExecutor);
         ExecutorServiceHelper.shutdownAndAwaitTermination(this.cliRpcExecutor);
         ExecutorServiceHelper.shutdownAndAwaitTermination(this.raftRpcExecutor);
@@ -337,12 +336,12 @@ public class StoreEngine implements Lifecycle<StoreEngineOptions> {
         this.readIndexExecutor = readIndexExecutor;
     }
 
-    public ExecutorService getLeaderStateTrigger() {
-        return leaderStateTrigger;
+    public ExecutorService getRaftStateTrigger() {
+        return raftStateTrigger;
     }
 
-    public void setLeaderStateTrigger(ExecutorService leaderStateTrigger) {
-        this.leaderStateTrigger = leaderStateTrigger;
+    public void setRaftStateTrigger(ExecutorService raftStateTrigger) {
+        this.raftStateTrigger = raftStateTrigger;
     }
 
     public ExecutorService getSnapshotExecutor() {

--- a/jraft-rheakv/rheakv-core/src/main/java/com/alipay/sofa/jraft/rhea/StoreEngineHelper.java
+++ b/jraft-rheakv/rheakv-core/src/main/java/com/alipay/sofa/jraft/rhea/StoreEngineHelper.java
@@ -59,9 +59,9 @@ public final class StoreEngineHelper {
         return newPool(coreThreads, maxThreads, "rheakv-read-index-callback", handler);
     }
 
-    public static ExecutorService createLeaderStateTrigger(final int coreThreads) {
+    public static ExecutorService createRaftStateTrigger(final int coreThreads) {
         final BlockingQueue<Runnable> workQueue = new ArrayBlockingQueue<>(32);
-        return newPool(coreThreads, coreThreads, "rheakv-leader-state-trigger", workQueue);
+        return newPool(coreThreads, coreThreads, "rheakv-raft-state-trigger", workQueue);
     }
 
     public static ExecutorService createSnapshotExecutor(final int coreThreads) {

--- a/jraft-rheakv/rheakv-core/src/main/java/com/alipay/sofa/jraft/rhea/client/DefaultRheaKVStore.java
+++ b/jraft-rheakv/rheakv-core/src/main/java/com/alipay/sofa/jraft/rhea/client/DefaultRheaKVStore.java
@@ -29,9 +29,11 @@ import org.slf4j.LoggerFactory;
 import com.alipay.sofa.jraft.RouteTable;
 import com.alipay.sofa.jraft.Status;
 import com.alipay.sofa.jraft.entity.PeerId;
+import com.alipay.sofa.jraft.rhea.FollowerStateListener;
 import com.alipay.sofa.jraft.rhea.JRaftHelper;
 import com.alipay.sofa.jraft.rhea.LeaderStateListener;
 import com.alipay.sofa.jraft.rhea.RegionEngine;
+import com.alipay.sofa.jraft.rhea.StateListener;
 import com.alipay.sofa.jraft.rhea.StoreEngine;
 import com.alipay.sofa.jraft.rhea.client.failover.FailoverClosure;
 import com.alipay.sofa.jraft.rhea.client.failover.ListRetryCallable;
@@ -1286,6 +1288,16 @@ public class DefaultRheaKVStore implements RheaKVStore {
 
     @Override
     public void addLeaderStateListener(final long regionId, final LeaderStateListener listener) {
+        addStateListener(regionId, listener);
+    }
+
+    @Override
+    public void addFollowerStateListener(final long regionId, final FollowerStateListener listener) {
+        addStateListener(regionId, listener);
+    }
+
+    @Override
+    public void addStateListener(final long regionId, final StateListener listener) {
         checkState();
         if (this.storeEngine == null) {
             throw new IllegalStateException("current node do not have store engine");
@@ -1294,7 +1306,7 @@ public class DefaultRheaKVStore implements RheaKVStore {
         if (regionEngine == null) {
             throw new IllegalStateException("current node do not have this region engine[" + regionId + "]");
         }
-        regionEngine.getFsm().addLeaderStateListener(listener);
+        regionEngine.getFsm().addStateListener(listener);
     }
 
     public long getClusterId() {

--- a/jraft-rheakv/rheakv-core/src/main/java/com/alipay/sofa/jraft/rhea/client/RheaKVStore.java
+++ b/jraft-rheakv/rheakv-core/src/main/java/com/alipay/sofa/jraft/rhea/client/RheaKVStore.java
@@ -23,7 +23,9 @@ import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 
 import com.alipay.sofa.jraft.Lifecycle;
+import com.alipay.sofa.jraft.rhea.FollowerStateListener;
 import com.alipay.sofa.jraft.rhea.LeaderStateListener;
+import com.alipay.sofa.jraft.rhea.StateListener;
 import com.alipay.sofa.jraft.rhea.client.pd.PlacementDriverClient;
 import com.alipay.sofa.jraft.rhea.options.RheaKVStoreOptions;
 import com.alipay.sofa.jraft.rhea.storage.KVEntry;
@@ -579,4 +581,22 @@ public interface RheaKVStore extends Lifecycle<RheaKVStoreOptions> {
      * then regionId = -1 as the input parameter.
      */
     void addLeaderStateListener(final long regionId, final LeaderStateListener listener);
+
+    /**
+     * Add a listener for the state change of the follower with
+     * this region.
+     * <p>
+     * In a special case, if that is a single region environment,
+     * then regionId = -1 as the input parameter.
+     */
+    void addFollowerStateListener(final long regionId, final FollowerStateListener listener);
+
+    /**
+     * Add a listener for the state change (leader, follower) with
+     * this region.
+     * <p>
+     * In a special case, if that is a single region environment,
+     * then regionId = -1 as the input parameter.
+     */
+    void addStateListener(final long regionId, final StateListener listener);
 }

--- a/jraft-rheakv/rheakv-core/src/test/java/com/alipay/sofa/jraft/rhea/storage/KVStateMachineTest.java
+++ b/jraft-rheakv/rheakv-core/src/test/java/com/alipay/sofa/jraft/rhea/storage/KVStateMachineTest.java
@@ -257,7 +257,7 @@ public class KVStateMachineTest {
         }
 
         @Override
-        public ExecutorService getLeaderStateTrigger() {
+        public ExecutorService getRaftStateTrigger() {
             return this.leaderStateTrigger;
         }
     }


### PR DESCRIPTION
### Motivation:

Now we can listen to the leader state (`LeaderStateListener`), sometimes we also need to listen to the state of the follower. Then user can reset the node's information as it starts to follower or stops following some leader.

### Modification:

1. Add `FollowerStateListener` and `StateListener`
2. Both `LeaderStateListener` and `FollowerStateListener` inherit `StateListener`.
3. Add new API to RheaKVStore
    - `void addFollowerStateListener(final long regionId, final FollowerStateListener listener)`
    - `void addStateListener(final long regionId, final StateListener listener)`
### Result:

