### PR TITLE
(fix) If `sync` is true, `disableWAL` must be set false.

### DIFF
--- a/jraft-rheakv/rheakv-core/src/main/java/com/alipay/sofa/jraft/rhea/options/RocksDBOptions.java
+++ b/jraft-rheakv/rheakv-core/src/main/java/com/alipay/sofa/jraft/rhea/options/RocksDBOptions.java
@@ -29,6 +29,8 @@ public class RocksDBOptions {
     private boolean sync                              = false;
     // For the same reason(See the comment of ‘sync’ field), we also
     // don't need WAL, which can improve performance.
+    //
+    // If `sync` is true, `disableWAL` must be set false
     private boolean disableWAL                        = true;
     private boolean fastSnapshot                      = false;
     private boolean openStatisticsCollector           = true;

--- a/jraft-rheakv/rheakv-core/src/main/java/com/alipay/sofa/jraft/rhea/storage/RocksRawKVStore.java
+++ b/jraft-rheakv/rheakv-core/src/main/java/com/alipay/sofa/jraft/rhea/storage/RocksRawKVStore.java
@@ -153,7 +153,8 @@ public class RocksRawKVStore extends BatchRawKVStore<RocksDBOptions> {
             this.cfDescriptors.add(new ColumnFamilyDescriptor(BytesUtil.writeUtf8("RHEA_FENCING"), cfOptions));
             this.writeOptions = new WriteOptions();
             this.writeOptions.setSync(opts.isSync());
-            this.writeOptions.setDisableWAL(opts.isDisableWAL());
+            // If `sync` is true, `disableWAL` must be set false.
+            this.writeOptions.setDisableWAL(!opts.isSync() && opts.isDisableWAL());
             // Delete existing data, relying on raft's snapshot and log playback
             // to reply to the data is the correct behavior.
             destroyRocksDB(opts);


### PR DESCRIPTION
### Motivation:

If `sync` is true, we must enable WAL

### Modification:

If the user sets the wrong option, it will be corrected automatically
```
this.writeOptions.setDisableWAL(!opts.isSync() && opts.isDisableWAL());
```

### Result:

