### PR TITLE
fix/serialization compatibility

### DIFF
--- a/jraft-rheakv/rheakv-core/src/main/java/com/alipay/sofa/jraft/rhea/DefaultRegionKVService.java
+++ b/jraft-rheakv/rheakv-core/src/main/java/com/alipay/sofa/jraft/rhea/DefaultRegionKVService.java
@@ -566,7 +566,6 @@ public class DefaultRegionKVService implements RegionKVService {
     private static void setFailure(final BaseRequest request, final BaseResponse<?> response, final Status status,
                                    final Errors error) {
         response.setError(error == null ? Errors.STORAGE_ERROR : error);
-        response.setErrorMsg(status.toString());
         LOG.error("Failed to handle: {}, status: {}, error: {}.", request, status, error);
     }
 }

--- a/jraft-rheakv/rheakv-core/src/main/java/com/alipay/sofa/jraft/rhea/client/DefaultRheaKVRpcService.java
+++ b/jraft-rheakv/rheakv-core/src/main/java/com/alipay/sofa/jraft/rhea/client/DefaultRheaKVRpcService.java
@@ -144,7 +144,7 @@ public class DefaultRheaKVRpcService implements RheaKVRpcService {
                     closure.run(Status.OK());
                 } else {
                     closure.setError(response.getError());
-                    closure.run(new Status(-1, "RPC failed: %s", response));
+                    closure.run(new Status(-1, "RPC failed with address: %s, response: %s", address, response));
                 }
             }
 

--- a/jraft-rheakv/rheakv-core/src/main/java/com/alipay/sofa/jraft/rhea/client/pd/DefaultPlacementDriverRpcService.java
+++ b/jraft-rheakv/rheakv-core/src/main/java/com/alipay/sofa/jraft/rhea/client/pd/DefaultPlacementDriverRpcService.java
@@ -105,7 +105,7 @@ public class DefaultPlacementDriverRpcService implements PlacementDriverRpcServi
                     closure.run(Status.OK());
                 } else {
                     closure.setError(response.getError());
-                    closure.run(new Status(-1, "RPC failed: %s", response));
+                    closure.run(new Status(-1, "RPC failed with address: %s, response: %s", address, response));
                 }
             }
 

--- a/jraft-rheakv/rheakv-core/src/main/java/com/alipay/sofa/jraft/rhea/client/pd/HeartbeatSender.java
+++ b/jraft-rheakv/rheakv-core/src/main/java/com/alipay/sofa/jraft/rhea/client/pd/HeartbeatSender.java
@@ -219,7 +219,7 @@ public class HeartbeatSender implements Lifecycle<HeartbeatOptions> {
                     closure.run(Status.OK());
                 } else {
                     closure.setError(response.getError());
-                    closure.run(new Status(-1, "RPC failed: %s", response));
+                    closure.run(new Status(-1, "RPC failed with address: %s, response: %s", address, response));
                 }
             }
 

--- a/jraft-rheakv/rheakv-core/src/main/java/com/alipay/sofa/jraft/rhea/cmd/store/BaseResponse.java
+++ b/jraft-rheakv/rheakv-core/src/main/java/com/alipay/sofa/jraft/rhea/cmd/store/BaseResponse.java
@@ -31,7 +31,6 @@ public class BaseResponse<T> implements Serializable {
     private static final long serialVersionUID = 8411573936817037697L;
 
     private Errors            error            = Errors.NONE;
-    private String            errorMsg;
     private long              regionId;
     private RegionEpoch       regionEpoch;
     private T                 value;
@@ -46,14 +45,6 @@ public class BaseResponse<T> implements Serializable {
 
     public void setError(Errors error) {
         this.error = error;
-    }
-
-    public String getErrorMsg() {
-        return errorMsg;
-    }
-
-    public void setErrorMsg(String errorMsg) {
-        this.errorMsg = errorMsg;
     }
 
     public long getRegionId() {
@@ -82,7 +73,7 @@ public class BaseResponse<T> implements Serializable {
 
     @Override
     public String toString() {
-        return "BaseResponse{" + "error=" + error + ", errorMsg='" + errorMsg + '\'' + ", regionId=" + regionId
-               + ", regionEpoch=" + regionEpoch + ", value=" + value + '}';
+        return "BaseResponse{" + "error=" + error + ", regionId=" + regionId + ", regionEpoch=" + regionEpoch
+               + ", value=" + value + '}';
     }
 }

--- a/jraft-rheakv/rheakv-core/src/main/java/com/alipay/sofa/jraft/rhea/serialization/impl/protostuff/ProtoStuffSerializer.java
+++ b/jraft-rheakv/rheakv-core/src/main/java/com/alipay/sofa/jraft/rhea/serialization/impl/protostuff/ProtoStuffSerializer.java
@@ -52,7 +52,7 @@ public class ProtoStuffSerializer extends Serializer {
         // applies to java beans/data objects.
         //
         final String always_use_sun_reflection_factory = SystemPropertyUtil.get(
-            "rhea.serializer.protostuff.always_use_sun_reflection_factory", "true");
+            "rhea.serializer.protostuff.always_use_sun_reflection_factory", "false");
         SystemPropertyUtil.setProperty("protostuff.runtime.always_use_sun_reflection_factory",
             always_use_sun_reflection_factory);
 


### PR DESCRIPTION
### Motivation:

Solve this problem: the serialization incompatibility error caused by the object being added field.

### Modification:

1. Remove the field `errorMsg` from `BaseResponse`.
2. When calling schema.newMessage(), instead of using ReflectionFactory.newConstructorFromSerialization (do not initializes internal state), the default constructor is used to fill the field values.

### Result:

