### PR TITLE
(feat) batch delete api

### DIFF
--- a/jraft-rheakv/rheakv-core/src/main/java/com/alipay/sofa/jraft/rhea/DefaultRegionKVService.java
+++ b/jraft-rheakv/rheakv-core/src/main/java/com/alipay/sofa/jraft/rhea/DefaultRegionKVService.java
@@ -25,6 +25,8 @@ import org.slf4j.LoggerFactory;
 import com.alipay.sofa.jraft.Status;
 import com.alipay.sofa.jraft.rhea.cmd.store.BaseRequest;
 import com.alipay.sofa.jraft.rhea.cmd.store.BaseResponse;
+import com.alipay.sofa.jraft.rhea.cmd.store.BatchDeleteRequest;
+import com.alipay.sofa.jraft.rhea.cmd.store.BatchDeleteResponse;
 import com.alipay.sofa.jraft.rhea.cmd.store.BatchPutRequest;
 import com.alipay.sofa.jraft.rhea.cmd.store.BatchPutResponse;
 import com.alipay.sofa.jraft.rhea.cmd.store.CompareAndPutRequest;
@@ -283,6 +285,34 @@ public class DefaultRegionKVService implements RegionKVService {
             final byte[] startKey = KVParameterRequires.requireNonNull(request.getStartKey(), "deleteRange.startKey");
             final byte[] endKey = KVParameterRequires.requireNonNull(request.getEndKey(), "deleteRange.endKey");
             this.rawKVStore.deleteRange(startKey, endKey, new BaseKVStoreClosure() {
+
+                @Override
+                public void run(final Status status) {
+                    if (status.isOk()) {
+                        response.setValue((Boolean) getData());
+                    } else {
+                        setFailure(request, response, status, getError());
+                    }
+                    closure.sendResponse(response);
+                }
+            });
+        } catch (final Throwable t) {
+            LOG.error("Failed to handle: {}, {}.", request, StackTraceUtil.stackTrace(t));
+            response.setError(Errors.forException(t));
+            closure.sendResponse(response);
+        }
+    }
+
+    @Override
+    public void handleBatchDeleteRequest(final BatchDeleteRequest request,
+                                         final RequestProcessClosure<BaseRequest, BaseResponse<?>> closure) {
+        final BatchDeleteResponse response = new BatchDeleteResponse();
+        response.setRegionId(getRegionId());
+        response.setRegionEpoch(getRegionEpoch());
+        try {
+            KVParameterRequires.requireSameEpoch(request, getRegionEpoch());
+            final List<byte[]> keys = KVParameterRequires.requireNonEmpty(request.getKeys(), "delete.keys");
+            this.rawKVStore.delete(keys, new BaseKVStoreClosure() {
 
                 @Override
                 public void run(final Status status) {

--- a/jraft-rheakv/rheakv-core/src/main/java/com/alipay/sofa/jraft/rhea/KVCommandProcessor.java
+++ b/jraft-rheakv/rheakv-core/src/main/java/com/alipay/sofa/jraft/rhea/KVCommandProcessor.java
@@ -23,6 +23,7 @@ import com.alipay.remoting.BizContext;
 import com.alipay.remoting.rpc.protocol.AsyncUserProcessor;
 import com.alipay.sofa.jraft.rhea.cmd.store.BaseRequest;
 import com.alipay.sofa.jraft.rhea.cmd.store.BaseResponse;
+import com.alipay.sofa.jraft.rhea.cmd.store.BatchDeleteRequest;
 import com.alipay.sofa.jraft.rhea.cmd.store.BatchPutRequest;
 import com.alipay.sofa.jraft.rhea.cmd.store.CompareAndPutRequest;
 import com.alipay.sofa.jraft.rhea.cmd.store.DeleteRangeRequest;
@@ -95,6 +96,9 @@ public class KVCommandProcessor<T extends BaseRequest> extends AsyncUserProcesso
                 break;
             case BaseRequest.DELETE_RANGE:
                 regionKVService.handleDeleteRangeRequest((DeleteRangeRequest) request, closure);
+                break;
+            case BaseRequest.BATCH_DELETE:
+                regionKVService.handleBatchDeleteRequest((BatchDeleteRequest) request, closure);
                 break;
             case BaseRequest.MERGE:
                 regionKVService.handleMergeRequest((MergeRequest) request, closure);

--- a/jraft-rheakv/rheakv-core/src/main/java/com/alipay/sofa/jraft/rhea/RegionKVService.java
+++ b/jraft-rheakv/rheakv-core/src/main/java/com/alipay/sofa/jraft/rhea/RegionKVService.java
@@ -18,6 +18,7 @@ package com.alipay.sofa.jraft.rhea;
 
 import com.alipay.sofa.jraft.rhea.cmd.store.BaseRequest;
 import com.alipay.sofa.jraft.rhea.cmd.store.BaseResponse;
+import com.alipay.sofa.jraft.rhea.cmd.store.BatchDeleteRequest;
 import com.alipay.sofa.jraft.rhea.cmd.store.BatchPutRequest;
 import com.alipay.sofa.jraft.rhea.cmd.store.CompareAndPutRequest;
 import com.alipay.sofa.jraft.rhea.cmd.store.DeleteRangeRequest;
@@ -91,6 +92,12 @@ public interface RegionKVService {
      * {@link BaseRequest#DELETE_RANGE}
      */
     void handleDeleteRangeRequest(final DeleteRangeRequest request,
+                                  final RequestProcessClosure<BaseRequest, BaseResponse<?>> closure);
+
+    /**
+     * {@link BaseRequest#BATCH_DELETE}
+     */
+    void handleBatchDeleteRequest(final BatchDeleteRequest request,
                                   final RequestProcessClosure<BaseRequest, BaseResponse<?>> closure);
 
     /**

--- a/jraft-rheakv/rheakv-core/src/main/java/com/alipay/sofa/jraft/rhea/StoreEngineHelper.java
+++ b/jraft-rheakv/rheakv-core/src/main/java/com/alipay/sofa/jraft/rhea/StoreEngineHelper.java
@@ -26,6 +26,7 @@ import java.util.concurrent.SynchronousQueue;
 import java.util.concurrent.ThreadPoolExecutor;
 
 import com.alipay.remoting.rpc.RpcServer;
+import com.alipay.sofa.jraft.rhea.cmd.store.BatchDeleteRequest;
 import com.alipay.sofa.jraft.rhea.cmd.store.BatchPutRequest;
 import com.alipay.sofa.jraft.rhea.cmd.store.CompareAndPutRequest;
 import com.alipay.sofa.jraft.rhea.cmd.store.DeleteRangeRequest;
@@ -107,6 +108,7 @@ public final class StoreEngineHelper {
         rpcServer.registerUserProcessor(new KVCommandProcessor<>(BatchPutRequest.class, engine));
         rpcServer.registerUserProcessor(new KVCommandProcessor<>(DeleteRequest.class, engine));
         rpcServer.registerUserProcessor(new KVCommandProcessor<>(DeleteRangeRequest.class, engine));
+        rpcServer.registerUserProcessor(new KVCommandProcessor<>(BatchDeleteRequest.class, engine));
         rpcServer.registerUserProcessor(new KVCommandProcessor<>(NodeExecuteRequest.class, engine));
         rpcServer.registerUserProcessor(new KVCommandProcessor<>(RangeSplitRequest.class, engine));
     }

--- a/jraft-rheakv/rheakv-core/src/main/java/com/alipay/sofa/jraft/rhea/client/DefaultRheaKVStore.java
+++ b/jraft-rheakv/rheakv-core/src/main/java/com/alipay/sofa/jraft/rhea/client/DefaultRheaKVStore.java
@@ -46,6 +46,7 @@ import com.alipay.sofa.jraft.rhea.client.failover.impl.MapFailoverFuture;
 import com.alipay.sofa.jraft.rhea.client.pd.FakePlacementDriverClient;
 import com.alipay.sofa.jraft.rhea.client.pd.PlacementDriverClient;
 import com.alipay.sofa.jraft.rhea.client.pd.RemotePlacementDriverClient;
+import com.alipay.sofa.jraft.rhea.cmd.store.BatchDeleteRequest;
 import com.alipay.sofa.jraft.rhea.cmd.store.BatchPutRequest;
 import com.alipay.sofa.jraft.rhea.cmd.store.CompareAndPutRequest;
 import com.alipay.sofa.jraft.rhea.cmd.store.DeleteRangeRequest;
@@ -1187,6 +1188,64 @@ public class DefaultRheaKVStore implements RheaKVStore {
     @Override
     public boolean bDeleteRange(final String startKey, final String endKey) {
         return FutureHelper.get(deleteRange(startKey, endKey), this.futureTimeoutMillis);
+    }
+
+    @Override
+    public CompletableFuture<Boolean> delete(final List<byte[]> keys) {
+        checkState();
+        Requires.requireNonNull(keys, "keys");
+        Requires.requireTrue(!keys.isEmpty(), "keys empty");
+        final FutureGroup<Boolean> futureGroup = internalDelete(keys, this.failoverRetries, null);
+        return FutureHelper.joinBooleans(futureGroup);
+    }
+
+    @Override
+    public Boolean bDelete(final List<byte[]> keys) {
+        return FutureHelper.get(delete(keys), this.futureTimeoutMillis);
+    }
+
+    private FutureGroup<Boolean> internalDelete(final List<byte[]> keys, final int retriesLeft,
+                                             final Throwable lastCause) {
+        final Map<Region, List<byte[]>> regionMap = this.pdClient
+                .findRegionsByKeys(keys, ApiExceptionHelper.isInvalidEpoch(lastCause));
+        final List<CompletableFuture<Boolean>> futures = Lists.newArrayListWithCapacity(regionMap.size());
+        final Errors lastError = lastCause == null ? null : Errors.forException(lastCause);
+        for (final Map.Entry<Region, List<byte[]>> entry : regionMap.entrySet()) {
+            final Region region = entry.getKey();
+            final List<byte[]> subKeys = entry.getValue();
+            final RetryCallable<Boolean> retryCallable = retryCause -> internalDelete(subKeys, retriesLeft - 1,
+                    retryCause);
+            final BoolFailoverFuture future = new BoolFailoverFuture(retriesLeft, retryCallable);
+            internalRegionDelete(region, subKeys, future, retriesLeft, lastError);
+            futures.add(future);
+        }
+        return new FutureGroup<>(futures);
+    }
+
+    private void internalRegionDelete(final Region region, final List<byte[]> subKeys,
+                                   final CompletableFuture<Boolean> future, final int retriesLeft,
+                                   final Errors lastCause) {
+        final RegionEngine regionEngine = getRegionEngine(region.getId(), true);
+        final RetryRunner retryRunner = retryCause -> internalRegionDelete(region, subKeys, future,
+                retriesLeft - 1, retryCause);
+        final FailoverClosure<Boolean> closure = new FailoverClosureImpl<>(future, false, retriesLeft,
+                retryRunner);
+        if (regionEngine != null) {
+            if (ensureOnValidEpoch(region, regionEngine, closure)) {
+                final RawKVStore rawKVStore = getRawKVStore(regionEngine);
+                if (this.kvDispatcher == null) {
+                    rawKVStore.delete(subKeys, closure);
+                } else {
+                    this.kvDispatcher.execute(() -> rawKVStore.delete(subKeys, closure));
+                }
+            }
+        } else {
+            final BatchDeleteRequest request = new BatchDeleteRequest();
+            request.setKeys(subKeys);
+            request.setRegionId(region.getId());
+            request.setRegionEpoch(region.getRegionEpoch());
+            this.rheaKVRpcService.callAsyncWithRpc(request, closure, lastCause);
+        }
     }
 
     private void internalRegionDeleteRange(final Region region, final byte[] subStartKey, final byte[] subEndKey,

--- a/jraft-rheakv/rheakv-core/src/main/java/com/alipay/sofa/jraft/rhea/client/DefaultRheaKVStore.java
+++ b/jraft-rheakv/rheakv-core/src/main/java/com/alipay/sofa/jraft/rhea/client/DefaultRheaKVStore.java
@@ -1205,7 +1205,7 @@ public class DefaultRheaKVStore implements RheaKVStore {
     }
 
     private FutureGroup<Boolean> internalDelete(final List<byte[]> keys, final int retriesLeft,
-                                             final Throwable lastCause) {
+                                                final Throwable lastCause) {
         final Map<Region, List<byte[]>> regionMap = this.pdClient
                 .findRegionsByKeys(keys, ApiExceptionHelper.isInvalidEpoch(lastCause));
         final List<CompletableFuture<Boolean>> futures = Lists.newArrayListWithCapacity(regionMap.size());
@@ -1223,8 +1223,8 @@ public class DefaultRheaKVStore implements RheaKVStore {
     }
 
     private void internalRegionDelete(final Region region, final List<byte[]> subKeys,
-                                   final CompletableFuture<Boolean> future, final int retriesLeft,
-                                   final Errors lastCause) {
+                                      final CompletableFuture<Boolean> future, final int retriesLeft,
+                                      final Errors lastCause) {
         final RegionEngine regionEngine = getRegionEngine(region.getId(), true);
         final RetryRunner retryRunner = retryCause -> internalRegionDelete(region, subKeys, future,
                 retriesLeft - 1, retryCause);

--- a/jraft-rheakv/rheakv-core/src/main/java/com/alipay/sofa/jraft/rhea/client/RheaKVStore.java
+++ b/jraft-rheakv/rheakv-core/src/main/java/com/alipay/sofa/jraft/rhea/client/RheaKVStore.java
@@ -546,6 +546,16 @@ public interface RheaKVStore extends Lifecycle<RheaKVStoreOptions> {
     boolean bDeleteRange(final String startKey, final String endKey);
 
     /**
+     * The batch method of {@link #delete(byte[])}
+     */
+    CompletableFuture<Boolean> delete(final List<byte[]> keys);
+
+    /**
+     * @see #delete(List)
+     */
+    Boolean bDelete(final List<byte[]> keys);
+
+    /**
      * @see #getDistributedLock(byte[], long, TimeUnit, ScheduledExecutorService)
      */
     DistributedLock<byte[]> getDistributedLock(final byte[] target, final long lease, final TimeUnit unit);

--- a/jraft-rheakv/rheakv-core/src/main/java/com/alipay/sofa/jraft/rhea/cmd/store/BaseRequest.java
+++ b/jraft-rheakv/rheakv-core/src/main/java/com/alipay/sofa/jraft/rhea/cmd/store/BaseRequest.java
@@ -46,6 +46,7 @@ public abstract class BaseRequest implements Serializable {
     public static final byte  NODE_EXECUTE     = 0x0f;
     public static final byte  RANGE_SPLIT      = 0x10;
     public static final byte  COMPARE_PUT      = 0x11;
+    public static final byte  BATCH_DELETE     = 0x12;
 
     private long              regionId;
     private RegionEpoch       regionEpoch;

--- a/jraft-rheakv/rheakv-core/src/main/java/com/alipay/sofa/jraft/rhea/cmd/store/BatchDeleteRequest.java
+++ b/jraft-rheakv/rheakv-core/src/main/java/com/alipay/sofa/jraft/rhea/cmd/store/BatchDeleteRequest.java
@@ -43,6 +43,6 @@ public class BatchDeleteRequest extends BaseRequest {
 
     @Override
     public String toString() {
-        return "BatchPutRequest{" + "keys=" + keys + "} " + super.toString();
+        return "BatchDeleteRequest{" + "keys=" + keys + "} " + super.toString();
     }
 }

--- a/jraft-rheakv/rheakv-core/src/main/java/com/alipay/sofa/jraft/rhea/cmd/store/BatchDeleteRequest.java
+++ b/jraft-rheakv/rheakv-core/src/main/java/com/alipay/sofa/jraft/rhea/cmd/store/BatchDeleteRequest.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alipay.sofa.jraft.rhea.cmd.store;
+
+import java.util.List;
+
+/**
+ *
+ * @author nicholas.jxf
+ */
+public class BatchDeleteRequest extends BaseRequest {
+
+    private static final long serialVersionUID = -472951628397420368L;
+
+    private List<byte[]>      keys;
+
+    public List<byte[]> getKeys() {
+        return keys;
+    }
+
+    public void setKeys(List<byte[]> keys) {
+        this.keys = keys;
+    }
+
+    @Override
+    public byte magic() {
+        return BATCH_DELETE;
+    }
+
+    @Override
+    public String toString() {
+        return "BatchPutRequest{" + "keys=" + keys + "} " + super.toString();
+    }
+}

--- a/jraft-rheakv/rheakv-core/src/main/java/com/alipay/sofa/jraft/rhea/cmd/store/BatchDeleteResponse.java
+++ b/jraft-rheakv/rheakv-core/src/main/java/com/alipay/sofa/jraft/rhea/cmd/store/BatchDeleteResponse.java
@@ -1,0 +1,26 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alipay.sofa.jraft.rhea.cmd.store;
+
+/**
+ *
+ * @author nicholas.jxf
+ */
+public class BatchDeleteResponse extends BaseResponse<Boolean> {
+
+    private static final long serialVersionUID = 8507492618405370694L;
+}

--- a/jraft-rheakv/rheakv-core/src/main/java/com/alipay/sofa/jraft/rhea/storage/BatchRawKVStore.java
+++ b/jraft-rheakv/rheakv-core/src/main/java/com/alipay/sofa/jraft/rhea/storage/BatchRawKVStore.java
@@ -65,6 +65,13 @@ public abstract class BatchRawKVStore<T> extends BaseRawKVStore<T> {
         }
     }
 
+    public void batchDeleteList(final KVStateOutputList kvStates) {
+        for (int i = 0, l = kvStates.size(); i < l; i++) {
+            final KVState kvState = kvStates.get(i);
+            delete(kvState.getOp().getKeys(), kvState.getDone());
+        }
+    }
+
     public void batchGetSequence(final KVStateOutputList kvStates) {
         for (int i = 0, l = kvStates.size(); i < l; i++) {
             final KVState kvState = kvStates.get(i);

--- a/jraft-rheakv/rheakv-core/src/main/java/com/alipay/sofa/jraft/rhea/storage/KVOperation.java
+++ b/jraft-rheakv/rheakv-core/src/main/java/com/alipay/sofa/jraft/rhea/storage/KVOperation.java
@@ -72,13 +72,15 @@ public class KVOperation implements Serializable {
     public static final byte    RANGE_SPLIT      = 0x10;
     /** Compare and put operation */
     public static final byte    COMPARE_PUT      = 0x11;
+    /** Delete list operation */
+    public static final byte    DELETE_LIST      = 0x12;
 
-    public static final byte    EOF              = 0x12;
+    public static final byte    EOF              = 0x13;
 
     private static final byte[] VALID_OPS;
 
     static {
-        VALID_OPS = new byte[17];
+        VALID_OPS = new byte[18];
         VALID_OPS[0] = PUT;
         VALID_OPS[1] = PUT_IF_ABSENT;
         VALID_OPS[2] = DELETE;
@@ -96,6 +98,7 @@ public class KVOperation implements Serializable {
         VALID_OPS[14] = RESET_SEQUENCE;
         VALID_OPS[15] = RANGE_SPLIT;
         VALID_OPS[16] = COMPARE_PUT;
+        VALID_OPS[17] = DELETE_LIST;
     }
 
     private byte[]              key;                                    // also startKey for DELETE_RANGE
@@ -145,6 +148,12 @@ public class KVOperation implements Serializable {
         Requires.requireNonNull(startKey, "startKey");
         Requires.requireNonNull(endKey, "endKey");
         return new KVOperation(startKey, endKey, null, DELETE_RANGE);
+    }
+
+    public static KVOperation createDeleteList(final List<byte[]> keys) {
+        Requires.requireNonNull(keys, "keys");
+        Requires.requireTrue(!keys.isEmpty(), "keys is empty");
+        return new KVOperation(BytesUtil.EMPTY_BYTES, BytesUtil.EMPTY_BYTES, keys, DELETE_LIST);
     }
 
     public static KVOperation createGetSequence(final byte[] seqKey, final int step) {
@@ -262,6 +271,11 @@ public class KVOperation implements Serializable {
     @SuppressWarnings("unchecked")
     public List<KVEntry> getEntries() {
         return (List<KVEntry>) this.attach;
+    }
+
+    @SuppressWarnings("unchecked")
+    public List<byte[]> getKeys() {
+        return (List<byte[]>) this.attach;
     }
 
     public NodeExecutor getNodeExecutor() {

--- a/jraft-rheakv/rheakv-core/src/main/java/com/alipay/sofa/jraft/rhea/storage/KVStoreStateMachine.java
+++ b/jraft-rheakv/rheakv-core/src/main/java/com/alipay/sofa/jraft/rhea/storage/KVStoreStateMachine.java
@@ -171,6 +171,9 @@ public class KVStoreStateMachine extends StateMachineAdapter {
             case KVOperation.DELETE_RANGE:
                 this.rawKVStore.batchDeleteRange(kvStates);
                 break;
+            case KVOperation.DELETE_LIST:
+                this.rawKVStore.batchDeleteList(kvStates);
+                break;
             case KVOperation.GET_SEQUENCE:
                 this.rawKVStore.batchGetSequence(kvStates);
                 break;

--- a/jraft-rheakv/rheakv-core/src/main/java/com/alipay/sofa/jraft/rhea/storage/MemoryRawKVStore.java
+++ b/jraft-rheakv/rheakv-core/src/main/java/com/alipay/sofa/jraft/rhea/storage/MemoryRawKVStore.java
@@ -590,6 +590,22 @@ public class MemoryRawKVStore extends BatchRawKVStore<MemoryDBOptions> {
     }
 
     @Override
+    public void delete(final List<byte[]> keys, final KVStoreClosure closure) {
+        final Timer.Context timeCtx = getTimeContext("DELETE_LIST");
+        try {
+            for (final byte[] key : keys) {
+                this.defaultDB.remove(key);
+            }
+            setSuccess(closure, Boolean.TRUE);
+        } catch (final Exception e) {
+            LOG.error("Failed to [DELETE_LIST], [size = {}], {}.", keys.size(), StackTraceUtil.stackTrace(e));
+            setCriticalError(closure, "Fail to [DELETE_LIST]", e);
+        } finally {
+            timeCtx.stop();
+        }
+    }
+
+    @Override
     public long getApproximateKeysInRange(final byte[] startKey, final byte[] endKey) {
         final Timer.Context timeCtx = getTimeContext("APPROXIMATE_KEYS");
         try {

--- a/jraft-rheakv/rheakv-core/src/main/java/com/alipay/sofa/jraft/rhea/storage/MetricsKVClosureAdapter.java
+++ b/jraft-rheakv/rheakv-core/src/main/java/com/alipay/sofa/jraft/rhea/storage/MetricsKVClosureAdapter.java
@@ -141,6 +141,10 @@ public class MetricsKVClosureAdapter implements KVStoreClosure {
                 // TODO if this is needed?
                 break;
             }
+            case KVOperation.DELETE_LIST: {
+                KVMetrics.counter(REGION_KEYS_WRITTEN, id).inc(keysCount);
+                break;
+            }
             case KVOperation.GET_SEQUENCE:
             case KVOperation.KEY_LOCK: {
                 KVMetrics.counter(REGION_KEYS_READ, id).inc();

--- a/jraft-rheakv/rheakv-core/src/main/java/com/alipay/sofa/jraft/rhea/storage/MetricsRawKVStore.java
+++ b/jraft-rheakv/rheakv-core/src/main/java/com/alipay/sofa/jraft/rhea/storage/MetricsRawKVStore.java
@@ -25,6 +25,7 @@ import com.codahale.metrics.Timer;
 import static com.alipay.sofa.jraft.rhea.metrics.KVMetricNames.RPC_REQUEST_HANDLE_TIMER;
 import static com.alipay.sofa.jraft.rhea.storage.KVOperation.COMPARE_PUT;
 import static com.alipay.sofa.jraft.rhea.storage.KVOperation.DELETE;
+import static com.alipay.sofa.jraft.rhea.storage.KVOperation.DELETE_LIST;
 import static com.alipay.sofa.jraft.rhea.storage.KVOperation.DELETE_RANGE;
 import static com.alipay.sofa.jraft.rhea.storage.KVOperation.GET;
 import static com.alipay.sofa.jraft.rhea.storage.KVOperation.GET_PUT;
@@ -196,6 +197,12 @@ public class MetricsRawKVStore implements RawKVStore {
     public void deleteRange(final byte[] startKey, final byte[] endKey, final KVStoreClosure closure) {
         final KVStoreClosure c = metricsAdapter(closure, DELETE_RANGE, 0, 0);
         this.rawKVStore.deleteRange(startKey, endKey, c);
+    }
+
+    @Override
+    public void delete(final List<byte[]> keys, final KVStoreClosure closure) {
+        final KVStoreClosure c = metricsAdapter(closure, DELETE_LIST, keys.size(), 0);
+        this.rawKVStore.delete(keys, c);
     }
 
     @Override

--- a/jraft-rheakv/rheakv-core/src/main/java/com/alipay/sofa/jraft/rhea/storage/RaftRawKVStore.java
+++ b/jraft-rheakv/rheakv-core/src/main/java/com/alipay/sofa/jraft/rhea/storage/RaftRawKVStore.java
@@ -277,6 +277,11 @@ public class RaftRawKVStore implements RawKVStore {
     }
 
     @Override
+    public void delete(final List<byte[]> keys, final KVStoreClosure closure) {
+        applyOperation(KVOperation.createDeleteList(keys), closure);
+    }
+
+    @Override
     public void execute(final NodeExecutor nodeExecutor, final boolean isLeader, final KVStoreClosure closure) {
         applyOperation(KVOperation.createNodeExecutor(nodeExecutor), closure);
     }

--- a/jraft-rheakv/rheakv-core/src/main/java/com/alipay/sofa/jraft/rhea/storage/RawKVStore.java
+++ b/jraft-rheakv/rheakv-core/src/main/java/com/alipay/sofa/jraft/rhea/storage/RawKVStore.java
@@ -193,6 +193,11 @@ public interface RawKVStore {
     void deleteRange(final byte[] startKey, final byte[] endKey, final KVStoreClosure closure);
 
     /**
+     * Delete data by the {@code keys} in batch.
+     */
+    void delete(final List<byte[]> keys, final KVStoreClosure closure);
+
+    /**
      * The {@code nodeExecutor} will be triggered when each node's
      * state machine is applied.
      */

--- a/jraft-rheakv/rheakv-core/src/main/java/com/alipay/sofa/jraft/rhea/storage/RocksRawKVStore.java
+++ b/jraft-rheakv/rheakv-core/src/main/java/com/alipay/sofa/jraft/rhea/storage/RocksRawKVStore.java
@@ -570,7 +570,7 @@ public class RocksRawKVStore extends BatchRawKVStore<RocksDBOptions> {
                         if (Arrays.equals(expects.get(key), prevValMap.get(key))) {
                             batch.put(key, updates.get(key));
                             setData(kvState.getDone(), Boolean.TRUE);
-                        } else{
+                        } else {
                             setData(kvState.getDone(), Boolean.FALSE);
                         }
                     }

--- a/jraft-rheakv/rheakv-core/src/main/java/com/alipay/sofa/jraft/rhea/storage/RocksRawKVStore.java
+++ b/jraft-rheakv/rheakv-core/src/main/java/com/alipay/sofa/jraft/rhea/storage/RocksRawKVStore.java
@@ -567,14 +567,14 @@ public class RocksRawKVStore extends BatchRawKVStore<RocksDBOptions> {
                     final Map<byte[], byte[]> prevValMap = this.db.multiGet(Lists.newArrayList(expects.keySet()));
                     for (final KVState kvState : segment) {
                         final byte[] key = kvState.getOp().getKey();
-                        if(Arrays.equals(expects.get(key), prevValMap.get(key))) {
+                        if (Arrays.equals(expects.get(key), prevValMap.get(key))) {
                             batch.put(key, updates.get(key));
                             setData(kvState.getDone(), Boolean.TRUE);
                         } else{
                             setData(kvState.getDone(), Boolean.FALSE);
                         }
                     }
-                    if(batch.count() > 0) {
+                    if (batch.count() > 0) {
                         this.db.write(this.writeOptions, batch);
                     }
                     for (final KVState kvState : segment) {
@@ -713,12 +713,12 @@ public class RocksRawKVStore extends BatchRawKVStore<RocksDBOptions> {
                     for (final KVState kvState : segment) {
                         final byte[] key = kvState.getOp().getKey();
                         final byte[] prevVal = prevValMap.get(key);
-                        if(prevVal == null) {
+                        if (prevVal == null) {
                             batch.put(key, values.get(key));
                         }
                         setData(kvState.getDone(), prevVal);
                     }
-                    if(batch.count() > 0) {
+                    if (batch.count() > 0) {
                         this.db.write(this.writeOptions, batch);
                     }
                     for (final KVState kvState : segment) {
@@ -1066,6 +1066,26 @@ public class RocksRawKVStore extends BatchRawKVStore<RocksDBOptions> {
             LOG.error("Fail to [DELETE_RANGE], ['[{}, {})'], {}.", BytesUtil.toHex(startKey), BytesUtil.toHex(endKey),
                 StackTraceUtil.stackTrace(e));
             setCriticalError(closure, "Fail to [DELETE_RANGE]", e);
+        } finally {
+            readLock.unlock();
+            timeCtx.stop();
+        }
+    }
+
+    @Override
+    public void delete(final List<byte[]> keys, final KVStoreClosure closure) {
+        final Timer.Context timeCtx = getTimeContext("DELETE_LIST");
+        final Lock readLock = this.readWriteLock.readLock();
+        readLock.lock();
+        try (final WriteBatch batch = new WriteBatch()) {
+            for (final byte[] key : keys) {
+                batch.delete(key);
+            }
+            this.db.write(this.writeOptions, batch);
+            setSuccess(closure, Boolean.TRUE);
+        } catch (final Exception e) {
+            LOG.error("Failed to [DELETE_LIST], [size = {}], {}.", keys.size(), StackTraceUtil.stackTrace(e));
+            setCriticalError(closure, "Fail to [DELETE_LIST]", e);
         } finally {
             readLock.unlock();
             timeCtx.stop();

--- a/jraft-rheakv/rheakv-core/src/test/java/com/alipay/sofa/jraft/rhea/storage/memorydb/MemoryKVStoreTest.java
+++ b/jraft-rheakv/rheakv-core/src/test/java/com/alipay/sofa/jraft/rhea/storage/memorydb/MemoryKVStoreTest.java
@@ -564,6 +564,32 @@ public class MemoryKVStoreTest extends BaseKVStoreTest {
         assertNotNull(value);
     }
 
+    /**
+     * Test method: {@link MemoryRawKVStore#delete(List, KVStoreClosure)}
+     */
+    @Test
+    public void deleteListTest() {
+        final List<KVEntry> entries = Lists.newArrayList();
+        final List<byte[]> keys = Lists.newArrayList();
+        for (int i = 0; i < 10; i++) {
+            final byte[] key = makeKey("batch_del_test" + i);
+            entries.add(new KVEntry(key, makeValue("batch_del_test_value")));
+            keys.add(key);
+        }
+        this.kvStore.put(entries, null);
+        this.kvStore.delete(keys, null);
+        TestClosure closure = new TestClosure();
+        this.kvStore.scan(makeKey("batch_del_test"), makeKey("batch_del_test" + 99), closure);
+        List<KVEntry> entries2 = (List<KVEntry>) closure.getData();
+        assertEquals(0, entries2.size());
+        for (int i = 0; i < keys.size(); i++) {
+            closure = new TestClosure();
+            this.kvStore.get(keys.get(i), closure);
+            byte[] value = (byte[]) closure.getData();
+            assertNull(value);
+        }
+    }
+
     private byte[] get(final byte[] key) {
         return new SyncKVStore<byte[]>() {
             @Override

--- a/jraft-rheakv/rheakv-core/src/test/java/com/alipay/sofa/jraft/rhea/storage/rocksdb/RocksKVStoreTest.java
+++ b/jraft-rheakv/rheakv-core/src/test/java/com/alipay/sofa/jraft/rhea/storage/rocksdb/RocksKVStoreTest.java
@@ -370,7 +370,7 @@ public class RocksKVStoreTest extends BaseKVStoreTest {
     public void batchCompareAndPutTest() {
         final KVStateOutputList kvStates = KVStateOutputList.newInstance();
         final int batchWriteSize = RocksRawKVStore.MAX_BATCH_WRITE_SIZE + 1;
-        for(int i = 1; i <= batchWriteSize; i++) {
+        for (int i = 1; i <= batchWriteSize; i++) {
             final byte[] key = makeKey("put_test" + i);
             final byte[] value = makeValue("put_test_value" + i);
             kvStates.add(KVState.of(KVOperation.createPut(key, value), null));
@@ -378,7 +378,7 @@ public class RocksKVStoreTest extends BaseKVStoreTest {
         this.kvStore.batchPut(kvStates);
         kvStates.clear();
 
-        for(int i = 1; i <= batchWriteSize; i++) {
+        for (int i = 1; i <= batchWriteSize; i++) {
             final byte[] key = makeKey("put_test" + i);
             final byte[] value = makeValue("put_test_value" + i);
             final byte[] update = makeValue("put_test_update" + i);
@@ -394,7 +394,7 @@ public class RocksKVStoreTest extends BaseKVStoreTest {
         kvStates.forEach(kvState -> assertEquals(kvState.getDone().getData(), Boolean.FALSE));
         kvStates.clear();
 
-        for(int i = 1; i <= batchWriteSize; i++) {
+        for (int i = 1; i <= batchWriteSize; i++) {
             final byte[] key = makeKey("put_test" + i);
             final byte[] value = makeValue("put_test_value" + i);
             final byte[] update = makeValue("put_test_update" + i);
@@ -479,7 +479,7 @@ public class RocksKVStoreTest extends BaseKVStoreTest {
     public void batchPutIfAbsentTest() {
         final KVStateOutputList kvStates = KVStateOutputList.newInstance();
         final int batchWriteSize = RocksRawKVStore.MAX_BATCH_WRITE_SIZE + 1;
-        for(int i = 1; i <= batchWriteSize; i++) {
+        for (int i = 1; i <= batchWriteSize; i++) {
             final byte[] key = makeKey("put_test" + i);
             final byte[] value = makeValue("put_test_value" + i);
             KVStoreClosure kvStoreClosure = new BaseKVStoreClosure() {
@@ -494,7 +494,7 @@ public class RocksKVStoreTest extends BaseKVStoreTest {
         kvStates.forEach(kvState -> assertNull(kvState.getDone().getData()));
         kvStates.clear();
 
-        for(int i = 1; i <= batchWriteSize; i++) {
+        for (int i = 1; i <= batchWriteSize; i++) {
             final byte[] key = makeKey("put_test" + i);
             final byte[] value = makeValue("put_test_value" + i);
             KVStoreClosure kvStoreClosure = new BaseKVStoreClosure() {
@@ -584,6 +584,33 @@ public class RocksKVStoreTest extends BaseKVStoreTest {
         this.kvStore.get(makeKey("del_range_test8"), closure);
         value = (byte[]) closure.getData();
         assertNotNull(value);
+    }
+
+    /**
+     * Test method: {@link RocksRawKVStore#delete(List, KVStoreClosure)}
+     */
+    @SuppressWarnings("unchecked")
+    @Test
+    public void deleteListTest() {
+        final List<KVEntry> entries = Lists.newArrayList();
+        final List<byte[]> keys = Lists.newArrayList();
+        for (int i = 0; i < 10; i++) {
+            final byte[] key = makeKey("batch_del_test" + i);
+            entries.add(new KVEntry(key, makeValue("batch_del_test_value")));
+            keys.add(key);
+        }
+        this.kvStore.put(entries, null);
+        this.kvStore.delete(keys, null);
+        TestClosure closure = new TestClosure();
+        this.kvStore.scan(makeKey("batch_del_test"), makeKey("batch_del_test" + 99), closure);
+        List<KVEntry> entries2 = (List<KVEntry>) closure.getData();
+        assertEquals(0, entries2.size());
+        for (int i = 0; i < keys.size(); i++) {
+            closure = new TestClosure();
+            this.kvStore.get(keys.get(i), closure);
+            byte[] value = (byte[]) closure.getData();
+            assertNull(value);
+        }
     }
 
     @Test


### PR DESCRIPTION
### Motivation:

Provide delete(List<byte[]> keys) method similar to put(List<KVEntry> entries) etc.

### Modification:

RheaKVStore provide delete(List<byte[]> keys) method similar to put(List<KVEntry> entries) etc.
````
CompletableFuture<Boolean> delete(final List<byte[]> keys);

Boolean bDelete(final List<byte[]> keys);
````

### Result:

Fixes #194 