### PR TITLE
(fix) method return type

### DIFF
--- a/jraft-rheakv/rheakv-core/src/main/java/com/alipay/sofa/jraft/rhea/client/DefaultRheaKVStore.java
+++ b/jraft-rheakv/rheakv-core/src/main/java/com/alipay/sofa/jraft/rhea/client/DefaultRheaKVStore.java
@@ -1008,7 +1008,7 @@ public class DefaultRheaKVStore implements RheaKVStore {
     }
 
     @Override
-    public boolean bPut(final List<KVEntry> entries) {
+    public Boolean bPut(final List<KVEntry> entries) {
         return FutureHelper.get(put(entries), this.futureTimeoutMillis);
     }
 
@@ -1180,12 +1180,12 @@ public class DefaultRheaKVStore implements RheaKVStore {
     }
 
     @Override
-    public boolean bDeleteRange(final byte[] startKey, final byte[] endKey) {
+    public Boolean bDeleteRange(final byte[] startKey, final byte[] endKey) {
         return FutureHelper.get(deleteRange(startKey, endKey), this.futureTimeoutMillis);
     }
 
     @Override
-    public boolean bDeleteRange(final String startKey, final String endKey) {
+    public Boolean bDeleteRange(final String startKey, final String endKey) {
         return FutureHelper.get(deleteRange(startKey, endKey), this.futureTimeoutMillis);
     }
 

--- a/jraft-rheakv/rheakv-core/src/main/java/com/alipay/sofa/jraft/rhea/client/RheaKVStore.java
+++ b/jraft-rheakv/rheakv-core/src/main/java/com/alipay/sofa/jraft/rhea/client/RheaKVStore.java
@@ -466,7 +466,7 @@ public interface RheaKVStore extends Lifecycle<RheaKVStoreOptions> {
     /**
      * @see #put(List)
      */
-    boolean bPut(final List<KVEntry> entries);
+    Boolean bPut(final List<KVEntry> entries);
 
     /**
      * If the specified key is not already associated with a value
@@ -538,12 +538,12 @@ public interface RheaKVStore extends Lifecycle<RheaKVStoreOptions> {
     /**
      * @see #deleteRange(byte[], byte[])
      */
-    boolean bDeleteRange(final byte[] startKey, final byte[] endKey);
+    Boolean bDeleteRange(final byte[] startKey, final byte[] endKey);
 
     /**
      * @see #deleteRange(byte[], byte[])
      */
-    boolean bDeleteRange(final String startKey, final String endKey);
+    Boolean bDeleteRange(final String startKey, final String endKey);
 
     /**
      * @see #getDistributedLock(byte[], long, TimeUnit, ScheduledExecutorService)


### PR DESCRIPTION
### Motivation:

Methods of RheaKVStore like bPut,bDeleteRange return type should not be primitive type.

### Modification:

Methods of RheaKVStore like bPut,bDeleteRange return type should use wrapper class.

### Result:

Fixes #205
