### PR TITLE
(DONOT_MERAGE) shutdown logStorage after shutdown fsmCaller

### DIFF
--- a/jraft-core/src/main/java/com/alipay/sofa/jraft/core/FSMCallerImpl.java
+++ b/jraft-core/src/main/java/com/alipay/sofa/jraft/core/FSMCallerImpl.java
@@ -213,7 +213,6 @@ public class FSMCallerImpl implements FSMCaller {
             });
             this.shutdownLatch = latch;
         }
-        doShutdown();
     }
 
     @Override
@@ -432,6 +431,9 @@ public class FSMCallerImpl implements FSMCaller {
         } finally {
             if (shutdown != null) {
                 shutdown.countDown();
+                if (task.type == TaskType.SHUTDOWN) {
+                    doShutdown();
+                }
             }
         }
     }

--- a/jraft-core/src/main/java/com/alipay/sofa/jraft/core/FSMCallerImpl.java
+++ b/jraft-core/src/main/java/com/alipay/sofa/jraft/core/FSMCallerImpl.java
@@ -430,10 +430,10 @@ public class FSMCallerImpl implements FSMCaller {
             return maxCommittedIndex;
         } finally {
             if (shutdown != null) {
-                shutdown.countDown();
                 if (task.type == TaskType.SHUTDOWN) {
                     doShutdown();
                 }
+                shutdown.countDown();
             }
         }
     }


### PR DESCRIPTION
### Motivation:
CI 偶尔出现以下异常，NPE 的原因是 rocksdb 已被关闭(LogStorage 执行了 shutdown)，看起来是 FSMCaller 在 rocksdb 关闭之后仍然执行了 runApplyTask，所以还是应该确保 FSMCaller 完成关闭之后再进行关闭 LogStorage
```
2019-07-20 15:09:42 [JRaft-FSMCaller-disruptor-0] ERROR LogExceptionHandler:65 - Handle FSMCallerImpl disruptor event error, event is com.alipay.sofa.jraft.core.FSMCallerImpl$ApplyTask@223b13e2
java.lang.NullPointerException
	at com.alipay.sofa.jraft.storage.impl.RocksDBLogStorage.getValueFromRocksDB(RocksDBLogStorage.java:402) ~[classes/:?]
	at com.alipay.sofa.jraft.storage.impl.RocksDBLogStorage.getEntry(RocksDBLogStorage.java:382) ~[classes/:?]
	at com.alipay.sofa.jraft.storage.impl.LogManagerImpl.getEntry(LogManagerImpl.java:709) ~[classes/:?]
	at com.alipay.sofa.jraft.core.IteratorImpl.next(IteratorImpl.java:101) ~[classes/:?]
	at com.alipay.sofa.jraft.core.IteratorImpl.<init>(IteratorImpl.java:64) ~[classes/:?]
	at com.alipay.sofa.jraft.core.FSMCallerImpl.doCommitted(FSMCallerImpl.java:477) ~[classes/:?]
	at com.alipay.sofa.jraft.core.FSMCallerImpl.runApplyTask(FSMCallerImpl.java:367) ~[classes/:?]
	at com.alipay.sofa.jraft.core.FSMCallerImpl.access$100(FSMCallerImpl.java:71) ~[classes/:?]
	at com.alipay.sofa.jraft.core.FSMCallerImpl$ApplyTaskHandler.onEvent(FSMCallerImpl.java:146) ~[classes/:?]
	at com.alipay.sofa.jraft.core.FSMCallerImpl$ApplyTaskHandler.onEvent(FSMCallerImpl.java:140) ~[classes/:?]
	at com.lmax.disruptor.BatchEventProcessor.run(BatchEventProcessor.java:137) [disruptor-3.3.7.jar:?]
	at java.lang.Thread.run(Thread.java:748) [?:1.8.0_191]
```

### Modification:


### Result:

