### PR TITLE
Disruptor Metrics

### DIFF
--- a/jraft-core/src/main/java/com/alipay/sofa/jraft/core/FSMCallerImpl.java
+++ b/jraft-core/src/main/java/com/alipay/sofa/jraft/core/FSMCallerImpl.java
@@ -191,10 +191,9 @@ public class FSMCallerImpl implements FSMCaller {
             .build();
         this.disruptor.handleEventsWith(new ApplyTaskHandler());
         this.disruptor.setDefaultExceptionHandler(new LogExceptionHandler<Object>(getClass().getSimpleName()));
-        this.disruptor.start();
-        this.taskQueue = this.disruptor.getRingBuffer();
+        this.taskQueue = this.disruptor.start();
         if (this.nodeMetrics.getMetricRegistry() != null) {
-            this.nodeMetrics.getMetricRegistry().register("JRaft-FSMCaller-Disruptor",
+            this.nodeMetrics.getMetricRegistry().register("jraft-fsmcaller-disruptor",
                 new DisruptorMetricSet<>(this.taskQueue));
         }
         this.error = new RaftException(EnumOutter.ErrorType.ERROR_TYPE_NONE);

--- a/jraft-core/src/main/java/com/alipay/sofa/jraft/core/FSMCallerImpl.java
+++ b/jraft-core/src/main/java/com/alipay/sofa/jraft/core/FSMCallerImpl.java
@@ -193,8 +193,8 @@ public class FSMCallerImpl implements FSMCaller {
         this.disruptor.setDefaultExceptionHandler(new LogExceptionHandler<Object>(getClass().getSimpleName()));
         this.taskQueue = this.disruptor.start();
         if (this.nodeMetrics.getMetricRegistry() != null) {
-            this.nodeMetrics.getMetricRegistry().register("jraft-fsmcaller-disruptor",
-                new DisruptorMetricSet<>(this.taskQueue));
+            this.nodeMetrics.getMetricRegistry().register("jraft-fsm-caller-disruptor",
+                new DisruptorMetricSet(this.taskQueue));
         }
         this.error = new RaftException(EnumOutter.ErrorType.ERROR_TYPE_NONE);
         LOG.info("Starts FSMCaller successfully.");

--- a/jraft-core/src/main/java/com/alipay/sofa/jraft/core/NodeImpl.java
+++ b/jraft-core/src/main/java/com/alipay/sofa/jraft/core/NodeImpl.java
@@ -730,8 +730,8 @@ public class NodeImpl implements Node, RaftServerService {
         this.applyDisruptor.setDefaultExceptionHandler(new LogExceptionHandler<Object>(getClass().getSimpleName()));
         this.applyQueue = this.applyDisruptor.start();
         if (this.metrics.getMetricRegistry() != null) {
-            this.metrics.getMetricRegistry().register("jraft-nodeimpl-disruptor",
-                new DisruptorMetricSet<>(this.applyQueue));
+            this.metrics.getMetricRegistry().register("jraft-node-impl-disruptor",
+                new DisruptorMetricSet(this.applyQueue));
         }
 
         this.fsmCaller = new FSMCallerImpl();

--- a/jraft-core/src/main/java/com/alipay/sofa/jraft/core/NodeImpl.java
+++ b/jraft-core/src/main/java/com/alipay/sofa/jraft/core/NodeImpl.java
@@ -728,10 +728,9 @@ public class NodeImpl implements Node, RaftServerService {
             .build();
         this.applyDisruptor.handleEventsWith(new LogEntryAndClosureHandler());
         this.applyDisruptor.setDefaultExceptionHandler(new LogExceptionHandler<Object>(getClass().getSimpleName()));
-        this.applyDisruptor.start();
-        this.applyQueue = this.applyDisruptor.getRingBuffer();
+        this.applyQueue = this.applyDisruptor.start();
         if (this.metrics.getMetricRegistry() != null) {
-            this.metrics.getMetricRegistry().register("JRaft-NodeImpl-Disruptor",
+            this.metrics.getMetricRegistry().register("jraft-nodeimpl-disruptor",
                 new DisruptorMetricSet<>(this.applyQueue));
         }
 

--- a/jraft-core/src/main/java/com/alipay/sofa/jraft/core/NodeImpl.java
+++ b/jraft-core/src/main/java/com/alipay/sofa/jraft/core/NodeImpl.java
@@ -97,6 +97,7 @@ import com.alipay.sofa.jraft.storage.SnapshotExecutor;
 import com.alipay.sofa.jraft.storage.impl.LogManagerImpl;
 import com.alipay.sofa.jraft.storage.snapshot.SnapshotExecutorImpl;
 import com.alipay.sofa.jraft.util.DisruptorBuilder;
+import com.alipay.sofa.jraft.util.DisruptorMetricSet;
 import com.alipay.sofa.jraft.util.LogExceptionHandler;
 import com.alipay.sofa.jraft.util.NamedThreadFactory;
 import com.alipay.sofa.jraft.util.OnlyForTest;
@@ -729,6 +730,10 @@ public class NodeImpl implements Node, RaftServerService {
         this.applyDisruptor.setDefaultExceptionHandler(new LogExceptionHandler<Object>(getClass().getSimpleName()));
         this.applyDisruptor.start();
         this.applyQueue = this.applyDisruptor.getRingBuffer();
+        if (this.metrics.getMetricRegistry() != null) {
+            this.metrics.getMetricRegistry().register("JRaft-NodeImpl-Disruptor",
+                new DisruptorMetricSet<>(this.applyQueue));
+        }
 
         this.fsmCaller = new FSMCallerImpl();
         if (!initLogStorage()) {

--- a/jraft-core/src/main/java/com/alipay/sofa/jraft/core/ReadOnlyServiceImpl.java
+++ b/jraft-core/src/main/java/com/alipay/sofa/jraft/core/ReadOnlyServiceImpl.java
@@ -237,7 +237,7 @@ public class ReadOnlyServiceImpl implements ReadOnlyService, LastAppliedLogIndex
             .setDefaultExceptionHandler(new LogExceptionHandler<Object>(this.getClass().getSimpleName()));
         this.readIndexQueue = this.readIndexDisruptor.start();
         if(this.nodeMetrics.getMetricRegistry() != null) {
-            this.nodeMetrics.getMetricRegistry().register("jraft-readonlyservice-disruptor", new DisruptorMetricSet<>(this.readIndexQueue));
+            this.nodeMetrics.getMetricRegistry().register("jraft-read-only-service-disruptor", new DisruptorMetricSet(this.readIndexQueue));
         }
         // listen on lastAppliedLogIndex change events.
         this.fsmCaller.addLastAppliedLogIndexListener(this);

--- a/jraft-core/src/main/java/com/alipay/sofa/jraft/core/ReadOnlyServiceImpl.java
+++ b/jraft-core/src/main/java/com/alipay/sofa/jraft/core/ReadOnlyServiceImpl.java
@@ -234,11 +234,10 @@ public class ReadOnlyServiceImpl implements ReadOnlyService, LastAppliedLogIndex
                 .build();
         this.readIndexDisruptor.handleEventsWith(new ReadIndexEventHandler());
         this.readIndexDisruptor
-        .setDefaultExceptionHandler(new LogExceptionHandler<Object>(this.getClass().getSimpleName()));
-        this.readIndexDisruptor.start();
-        this.readIndexQueue = this.readIndexDisruptor.getRingBuffer();
+            .setDefaultExceptionHandler(new LogExceptionHandler<Object>(this.getClass().getSimpleName()));
+        this.readIndexQueue = this.readIndexDisruptor.start();
         if(this.nodeMetrics.getMetricRegistry() != null) {
-            this.nodeMetrics.getMetricRegistry().register("JRaft-ReadOnlyService-Disruptor", new DisruptorMetricSet<>(this.readIndexQueue));
+            this.nodeMetrics.getMetricRegistry().register("jraft-readonlyservice-disruptor", new DisruptorMetricSet<>(this.readIndexQueue));
         }
         // listen on lastAppliedLogIndex change events.
         this.fsmCaller.addLastAppliedLogIndexListener(this);

--- a/jraft-core/src/main/java/com/alipay/sofa/jraft/core/ReadOnlyServiceImpl.java
+++ b/jraft-core/src/main/java/com/alipay/sofa/jraft/core/ReadOnlyServiceImpl.java
@@ -46,6 +46,7 @@ import com.alipay.sofa.jraft.rpc.RpcRequests.ReadIndexResponse;
 import com.alipay.sofa.jraft.rpc.RpcResponseClosureAdapter;
 import com.alipay.sofa.jraft.util.Bytes;
 import com.alipay.sofa.jraft.util.DisruptorBuilder;
+import com.alipay.sofa.jraft.util.DisruptorMetricSet;
 import com.alipay.sofa.jraft.util.LogExceptionHandler;
 import com.alipay.sofa.jraft.util.NamedThreadFactory;
 import com.alipay.sofa.jraft.util.OnlyForTest;
@@ -236,7 +237,9 @@ public class ReadOnlyServiceImpl implements ReadOnlyService, LastAppliedLogIndex
         .setDefaultExceptionHandler(new LogExceptionHandler<Object>(this.getClass().getSimpleName()));
         this.readIndexDisruptor.start();
         this.readIndexQueue = this.readIndexDisruptor.getRingBuffer();
-
+        if(this.nodeMetrics.getMetricRegistry() != null) {
+            this.nodeMetrics.getMetricRegistry().register("JRaft-ReadOnlyService-Disruptor", new DisruptorMetricSet<>(this.readIndexQueue));
+        }
         // listen on lastAppliedLogIndex change events.
         this.fsmCaller.addLastAppliedLogIndexListener(this);
 

--- a/jraft-core/src/main/java/com/alipay/sofa/jraft/storage/impl/LogManagerImpl.java
+++ b/jraft-core/src/main/java/com/alipay/sofa/jraft/storage/impl/LogManagerImpl.java
@@ -205,7 +205,7 @@ public class LogManagerImpl implements LogManager {
                     (event, ex) -> reportError(-1, "LogManager handle event error")));
             this.diskQueue = this.disruptor.start();
             if(this.nodeMetrics.getMetricRegistry() != null) {
-                this.nodeMetrics.getMetricRegistry().register("jraft-logManager-disruptor", new DisruptorMetricSet<>(this.diskQueue));
+                this.nodeMetrics.getMetricRegistry().register("jraft-log-manager-disruptor", new DisruptorMetricSet(this.diskQueue));
             }
         } finally {
             this.writeLock.unlock();

--- a/jraft-core/src/main/java/com/alipay/sofa/jraft/storage/impl/LogManagerImpl.java
+++ b/jraft-core/src/main/java/com/alipay/sofa/jraft/storage/impl/LogManagerImpl.java
@@ -203,10 +203,9 @@ public class LogManagerImpl implements LogManager {
             this.disruptor.handleEventsWith(new StableClosureEventHandler());
             this.disruptor.setDefaultExceptionHandler(new LogExceptionHandler<Object>(this.getClass().getSimpleName(),
                     (event, ex) -> reportError(-1, "LogManager handle event error")));
-            this.disruptor.start();
-            this.diskQueue = this.disruptor.getRingBuffer();
+            this.diskQueue = this.disruptor.start();
             if(this.nodeMetrics.getMetricRegistry() != null) {
-                this.nodeMetrics.getMetricRegistry().register("JRaft-LogManager-Disruptor", new DisruptorMetricSet<>(this.diskQueue));
+                this.nodeMetrics.getMetricRegistry().register("jraft-logManager-disruptor", new DisruptorMetricSet<>(this.diskQueue));
             }
         } finally {
             this.writeLock.unlock();

--- a/jraft-core/src/main/java/com/alipay/sofa/jraft/util/DisruptorMetricSet.java
+++ b/jraft-core/src/main/java/com/alipay/sofa/jraft/util/DisruptorMetricSet.java
@@ -26,13 +26,12 @@ import java.util.Map;
 
 /**
  * Disruptor metric set including buffer-size, remaining-capacity etc.
- * @param <T>
  */
-public final class DisruptorMetricSet<T> implements MetricSet {
+public final class DisruptorMetricSet implements MetricSet {
 
-    private final RingBuffer<T> ringBuffer;
+    private final RingBuffer ringBuffer;
 
-    public DisruptorMetricSet(RingBuffer<T> ringBuffer) {
+    public DisruptorMetricSet(RingBuffer<?> ringBuffer) {
         super();
         this.ringBuffer = ringBuffer;
     }

--- a/jraft-core/src/main/java/com/alipay/sofa/jraft/util/DisruptorMetricSet.java
+++ b/jraft-core/src/main/java/com/alipay/sofa/jraft/util/DisruptorMetricSet.java
@@ -1,0 +1,43 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alipay.sofa.jraft.util;
+
+import com.codahale.metrics.Gauge;
+import com.codahale.metrics.Metric;
+import com.codahale.metrics.MetricSet;
+import com.lmax.disruptor.RingBuffer;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public final class DisruptorMetricSet<T> implements MetricSet {
+
+    private final RingBuffer<T> ringBuffer;
+
+    public DisruptorMetricSet(RingBuffer<T> ringBuffer) {
+        super();
+        this.ringBuffer = ringBuffer;
+    }
+
+    @Override
+    public Map<String, Metric> getMetrics() {
+        final Map<String, Metric> gauges = new HashMap<>();
+        gauges.put("buffer-size", (Gauge<Integer>) this.ringBuffer::getBufferSize);
+        gauges.put("remaining-capacity", (Gauge<Long>) this.ringBuffer::remainingCapacity);
+        return gauges;
+    }
+}

--- a/jraft-core/src/main/java/com/alipay/sofa/jraft/util/DisruptorMetricSet.java
+++ b/jraft-core/src/main/java/com/alipay/sofa/jraft/util/DisruptorMetricSet.java
@@ -24,6 +24,10 @@ import com.lmax.disruptor.RingBuffer;
 import java.util.HashMap;
 import java.util.Map;
 
+/**
+ * Disruptor metric set including buffer-size, remaining-capacity etc.
+ * @param <T>
+ */
 public final class DisruptorMetricSet<T> implements MetricSet {
 
     private final RingBuffer<T> ringBuffer;
@@ -33,6 +37,10 @@ public final class DisruptorMetricSet<T> implements MetricSet {
         this.ringBuffer = ringBuffer;
     }
 
+    /**
+     * Return disruptor metrics
+     * @return disruptor metrics map
+     */
     @Override
     public Map<String, Metric> getMetrics() {
         final Map<String, Metric> gauges = new HashMap<>();

--- a/jraft-core/src/main/java/com/alipay/sofa/jraft/util/DisruptorMetricSet.java
+++ b/jraft-core/src/main/java/com/alipay/sofa/jraft/util/DisruptorMetricSet.java
@@ -29,7 +29,7 @@ import java.util.Map;
  */
 public final class DisruptorMetricSet implements MetricSet {
 
-    private final RingBuffer ringBuffer;
+    private final RingBuffer<?> ringBuffer;
 
     public DisruptorMetricSet(RingBuffer<?> ringBuffer) {
         super();

--- a/jraft-core/src/main/java/com/alipay/sofa/jraft/util/ThreadPoolMetricSet.java
+++ b/jraft-core/src/main/java/com/alipay/sofa/jraft/util/ThreadPoolMetricSet.java
@@ -24,6 +24,9 @@ import com.codahale.metrics.Gauge;
 import com.codahale.metrics.Metric;
 import com.codahale.metrics.MetricSet;
 
+/**
+ * Thread pool metric set including pool-size, queued, active, completed etc.
+ */
 public final class ThreadPoolMetricSet implements MetricSet {
 
     private final ThreadPoolExecutor executor;
@@ -33,6 +36,10 @@ public final class ThreadPoolMetricSet implements MetricSet {
         this.executor = rpcExecutor;
     }
 
+    /**
+     * Return thread pool metrics
+     * @return thread pool metrics map
+     */
     @Override
     public Map<String, Metric> getMetrics() {
         final Map<String, Metric> gauges = new HashMap<>();

--- a/jraft-rheakv/rheakv-core/src/main/java/com/alipay/sofa/jraft/rhea/client/DefaultRheaKVStore.java
+++ b/jraft-rheakv/rheakv-core/src/main/java/com/alipay/sofa/jraft/rhea/client/DefaultRheaKVStore.java
@@ -1692,8 +1692,7 @@ public class DefaultRheaKVStore implements RheaKVStore {
             this.disruptor = new Disruptor<>(factory, bufSize, new NamedThreadFactory(name, true));
             this.disruptor.handleEventsWith(handler);
             this.disruptor.setDefaultExceptionHandler(new LogExceptionHandler<Object>(name));
-            this.disruptor.start();
-            this.ringBuffer = disruptor.getRingBuffer();
+            this.ringBuffer = this.disruptor.start();
         }
 
         public abstract boolean apply(final E message, final CompletableFuture<F> future);


### PR DESCRIPTION
### Motivation:

Metrics adds the number of queue tasks for each disruptor to help observe the queue, by the way similar to ThreadPoolMetricSet.

### Modification:

Metrics adds the number of queue tasks for each disruptor built by DisruptorBuilder,for example buffer-size,remaining-capcity etc.

### Result:

Fixes #145 
