### PR TITLE
[ISSUE#273]The log class name in the AbstractBoltClientService Class can be modified to AbstractBoltClientService. 

### DIFF
--- a/jraft-core/src/main/java/com/alipay/sofa/jraft/rpc/impl/AbstractBoltClientService.java
+++ b/jraft-core/src/main/java/com/alipay/sofa/jraft/rpc/impl/AbstractBoltClientService.java
@@ -56,7 +56,7 @@ import com.google.protobuf.Message;
  */
 public abstract class AbstractBoltClientService implements ClientService {
 
-    protected static final Logger   LOG = LoggerFactory.getLogger(BoltRaftClientService.class);
+    protected static final Logger   LOG = LoggerFactory.getLogger(AbstractBoltClientService.class);
 
     static {
         ProtobufMsgFactory.load();


### PR DESCRIPTION
Modification:
(1)Modify to change the log class name in the AbstractBoltClientService Class to AbstractBoltClientService. 

Result:
Fixes #273

If there is no issue then describe the changes introduced by this PR.