### PR TITLE
fix timer's thread leak

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,5 +19,5 @@ install:
   - sh ./tools/check_format.sh
 
 script:
-  - travis_retry mvn --projects $TESTFOLDER test
+  - travis_wait 30 mvn --projects $TESTFOLDER test
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,5 +19,5 @@ install:
   - sh ./tools/check_format.sh
 
 script:
-  - travis_wait 30 mvn --projects $TESTFOLDER test
+  - travis_retry travis_wait 30 mvn --projects $TESTFOLDER test
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,5 +19,5 @@ install:
   - sh ./tools/check_format.sh
 
 script:
-  - travis_retry travis_wait 30 mvn --projects $TESTFOLDER test
+  - travis_retry mvn --projects $TESTFOLDER test
 

--- a/jraft-core/src/main/java/com/alipay/sofa/jraft/core/DefaultJRaftServiceFactory.java
+++ b/jraft-core/src/main/java/com/alipay/sofa/jraft/core/DefaultJRaftServiceFactory.java
@@ -26,7 +26,7 @@ import com.alipay.sofa.jraft.storage.LogStorage;
 import com.alipay.sofa.jraft.storage.RaftMetaStorage;
 import com.alipay.sofa.jraft.storage.SnapshotStorage;
 import com.alipay.sofa.jraft.storage.impl.LocalRaftMetaStorage;
-import com.alipay.sofa.jraft.storage.log.RocksDBSegmentLogStorage;
+import com.alipay.sofa.jraft.storage.impl.RocksDBLogStorage;
 import com.alipay.sofa.jraft.storage.snapshot.local.LocalSnapshotStorage;
 import com.alipay.sofa.jraft.util.Requires;
 import com.alipay.sofa.jraft.util.SPI;
@@ -47,7 +47,7 @@ public class DefaultJRaftServiceFactory implements JRaftServiceFactory {
     @Override
     public LogStorage createLogStorage(final String uri, final RaftOptions raftOptions) {
         Requires.requireTrue(StringUtils.isNotBlank(uri), "Blank log storage uri.");
-        return new RocksDBSegmentLogStorage(uri, raftOptions);
+        return new RocksDBLogStorage(uri, raftOptions);
     }
 
     @Override

--- a/jraft-core/src/main/java/com/alipay/sofa/jraft/core/NodeImpl.java
+++ b/jraft-core/src/main/java/com/alipay/sofa/jraft/core/NodeImpl.java
@@ -2403,7 +2403,7 @@ public class NodeImpl implements Node, RaftServerService {
 
             // Destroy all timers out of lock
             if (timers != null) {
-                destroyAllTimes(timers);
+                destroyAllTimers(timers);
             }
         }
     }
@@ -2430,7 +2430,7 @@ public class NodeImpl implements Node, RaftServerService {
         return timers;
     }
 
-    private void destroyAllTimes(final List<RepeatedTimer> timers) {
+    private void destroyAllTimers(final List<RepeatedTimer> timers) {
         for (final RepeatedTimer timer : timers) {
             timer.destroy();
         }

--- a/jraft-core/src/main/java/com/alipay/sofa/jraft/core/ReadOnlyServiceImpl.java
+++ b/jraft-core/src/main/java/com/alipay/sofa/jraft/core/ReadOnlyServiceImpl.java
@@ -168,14 +168,15 @@ public class ReadOnlyServiceImpl implements ReadOnlyService, LastAppliedLogIndex
             ReadOnlyServiceImpl.this.lock.lock();
             try {
                 if (readIndexStatus.isApplied(ReadOnlyServiceImpl.this.fsmCaller.getLastAppliedIndex())) {
-                    // Already applied,notify readIndex request.
+                    // Already applied, notify readIndex request.
                     ReadOnlyServiceImpl.this.lock.unlock();
                     doUnlock = false;
                     notifySuccess(readIndexStatus);
                 } else {
                     // Not applied, add it to pending-notify cache.
                     ReadOnlyServiceImpl.this.pendingNotifyStatus
-                    .computeIfAbsent(readIndexStatus.getIndex(), k -> new ArrayList<>(10)).add(readIndexStatus);
+                        .computeIfAbsent(readIndexStatus.getIndex(), k -> new ArrayList<>(10)) //
+                        .add(readIndexStatus);
                 }
             } finally {
                 if (doUnlock) {
@@ -224,27 +225,32 @@ public class ReadOnlyServiceImpl implements ReadOnlyService, LastAppliedLogIndex
         this.raftOptions = opts.getRaftOptions();
 
         this.scheduledExecutorService = Executors
-                .newSingleThreadScheduledExecutor(new NamedThreadFactory("ReadOnlyService-PendingNotify-Scanner", true));
+            .newSingleThreadScheduledExecutor(new NamedThreadFactory("ReadOnlyService-PendingNotify-Scanner", true));
         this.readIndexDisruptor = DisruptorBuilder.<ReadIndexEvent> newInstance() //
-                .setEventFactory(new ReadIndexEventFactory()) //
-                .setRingBufferSize(this.raftOptions.getDisruptorBufferSize()) //
-                .setThreadFactory(new NamedThreadFactory("JRaft-ReadOnlyService-Disruptor-", true)) //
-                .setWaitStrategy(new BlockingWaitStrategy()) //
-                .setProducerType(ProducerType.MULTI) //
-                .build();
+            .setEventFactory(new ReadIndexEventFactory()) //
+            .setRingBufferSize(this.raftOptions.getDisruptorBufferSize()) //
+            .setThreadFactory(new NamedThreadFactory("JRaft-ReadOnlyService-Disruptor-", true)) //
+            .setWaitStrategy(new BlockingWaitStrategy()) //
+            .setProducerType(ProducerType.MULTI) //
+            .build();
         this.readIndexDisruptor.handleEventsWith(new ReadIndexEventHandler());
         this.readIndexDisruptor
             .setDefaultExceptionHandler(new LogExceptionHandler<Object>(this.getClass().getSimpleName()));
         this.readIndexQueue = this.readIndexDisruptor.start();
         if(this.nodeMetrics.getMetricRegistry() != null) {
-            this.nodeMetrics.getMetricRegistry().register("jraft-read-only-service-disruptor", new DisruptorMetricSet(this.readIndexQueue));
+            this.nodeMetrics.getMetricRegistry() //
+                .register("jraft-read-only-service-disruptor", new DisruptorMetricSet(this.readIndexQueue));
         }
         // listen on lastAppliedLogIndex change events.
         this.fsmCaller.addLastAppliedLogIndexListener(this);
 
         // start scanner
-        this.scheduledExecutorService.scheduleAtFixedRate(() -> onApplied(this.fsmCaller.getLastAppliedIndex()),
-            this.raftOptions.getMaxElectionDelayMs(), this.raftOptions.getMaxElectionDelayMs(), TimeUnit.MILLISECONDS);
+        this.scheduledExecutorService.scheduleAtFixedRate(
+            () -> onApplied(this.fsmCaller.getLastAppliedIndex()),
+            this.raftOptions.getMaxElectionDelayMs(),
+            this.raftOptions.getMaxElectionDelayMs(),
+            TimeUnit.MILLISECONDS
+        );
         return true;
     }
 

--- a/jraft-core/src/main/java/com/alipay/sofa/jraft/core/Replicator.java
+++ b/jraft-core/src/main/java/com/alipay/sofa/jraft/core/Replicator.java
@@ -782,7 +782,7 @@ public class Replicator implements ThreadId.OnError {
         }
         final Replicator r = new Replicator(opts, raftOptions);
         if (!r.rpcService.connect(opts.getPeerId().getEndpoint())) {
-            LOG.error("Fail to init sending channel to {}", opts.getPeerId());
+            LOG.error("Fail to init sending channel to {}.", opts.getPeerId());
             // Return and it will be retried later.
             return null;
         }

--- a/jraft-core/src/main/java/com/alipay/sofa/jraft/storage/snapshot/remote/RemoteFileCopier.java
+++ b/jraft-core/src/main/java/com/alipay/sofa/jraft/storage/snapshot/remote/RemoteFileCopier.java
@@ -73,7 +73,7 @@ public class RemoteFileCopier {
 
         final int prefixSize = Snapshot.REMOTE_SNAPSHOT_URI_SCHEME.length();
         if (uri == null || !uri.startsWith(Snapshot.REMOTE_SNAPSHOT_URI_SCHEME)) {
-            LOG.error("Invalid uri {}", uri);
+            LOG.error("Invalid uri {}.", uri);
             return false;
         }
         uri = uri.substring(prefixSize);
@@ -86,7 +86,7 @@ public class RemoteFileCopier {
             final String[] ipAndPortStrs = ipAndPort.split(":");
             this.endpoint = new Endpoint(ipAndPortStrs[0], Integer.parseInt(ipAndPortStrs[1]));
         } catch (final Exception e) {
-            LOG.error("Fail to parse readerId or endpoint", e);
+            LOG.error("Fail to parse readerId or endpoint.", e);
             return false;
         }
         if (!this.rpcService.connect(this.endpoint)) {
@@ -126,7 +126,7 @@ public class RemoteFileCopier {
         // delete exists file.
         if (file.exists()) {
             if (!file.delete()) {
-                LOG.error("Fail to delete destPath: {}", destPath);
+                LOG.error("Fail to delete destPath: {}.", destPath);
                 return null;
             }
         }

--- a/jraft-core/src/main/java/com/alipay/sofa/jraft/storage/snapshot/remote/RemoteFileCopier.java
+++ b/jraft-core/src/main/java/com/alipay/sofa/jraft/storage/snapshot/remote/RemoteFileCopier.java
@@ -89,8 +89,8 @@ public class RemoteFileCopier {
             LOG.error("Fail to parse readerId or endpoint", e);
             return false;
         }
-        if (!this.rpcService.connect(endpoint)) {
-            LOG.error("Fail to init channel to {}", this.endpoint);
+        if (!this.rpcService.connect(this.endpoint)) {
+            LOG.error("Fail to init channel to {}.", this.endpoint);
             return false;
         }
 

--- a/jraft-core/src/main/java/com/alipay/sofa/jraft/util/RepeatedTimer.java
+++ b/jraft-core/src/main/java/com/alipay/sofa/jraft/util/RepeatedTimer.java
@@ -216,6 +216,8 @@ public abstract class RepeatedTimer implements Describer {
             if (!this.running) {
                 invokeDestroyed = true;
             }
+            // Timer#stop is idempotent
+            this.timer.stop();
             if (this.stopped) {
                 return;
             }
@@ -227,7 +229,6 @@ public abstract class RepeatedTimer implements Describer {
                 }
                 this.timeout = null;
             }
-            this.timer.stop();
         } finally {
             this.lock.unlock();
             if (invokeDestroyed) {

--- a/jraft-core/src/main/java/com/alipay/sofa/jraft/util/RepeatedTimer.java
+++ b/jraft-core/src/main/java/com/alipay/sofa/jraft/util/RepeatedTimer.java
@@ -90,7 +90,7 @@ public abstract class RepeatedTimer implements Describer {
         try {
             onTrigger();
         } catch (Throwable t) {
-            LOG.error("run timer failed", t);
+            LOG.error("Run timer failed.", t);
         }
         boolean invokeDestroyed = false;
         this.lock.lock();
@@ -164,7 +164,7 @@ public abstract class RepeatedTimer implements Describer {
             try {
                 RepeatedTimer.this.run();
             } catch (final Throwable t) {
-                LOG.error("Run timer task failed taskName={}.", RepeatedTimer.this.name, t);
+                LOG.error("Run timer task failed, taskName={}.", RepeatedTimer.this.name, t);
             }
         };
         this.timeout = this.timer.newTimeout(timerTask, adjustTimeout(this.timeoutMs), TimeUnit.MILLISECONDS);

--- a/jraft-core/src/main/java/com/alipay/sofa/jraft/util/RepeatedTimer.java
+++ b/jraft-core/src/main/java/com/alipay/sofa/jraft/util/RepeatedTimer.java
@@ -89,7 +89,7 @@ public abstract class RepeatedTimer implements Describer {
         }
         try {
             onTrigger();
-        } catch (Throwable t) {
+        } catch (final Throwable t) {
             LOG.error("Run timer failed.", t);
         }
         boolean invokeDestroyed = false;

--- a/jraft-core/src/test/java/com/alipay/sofa/jraft/core/CliServiceTest.java
+++ b/jraft-core/src/test/java/com/alipay/sofa/jraft/core/CliServiceTest.java
@@ -163,7 +163,9 @@ public class CliServiceTest {
             assertTrue(cluster.start(peer.getEndpoint()));
         }
 
-        final PeerId oldLeader = cluster.getLeader().getNodeId().getPeerId();
+        final Node oldLeaderNode = cluster.getLeader();
+        assertNotNull(oldLeaderNode);
+        final PeerId oldLeader = oldLeaderNode.getNodeId().getPeerId();
         assertNotNull(oldLeader);
         assertTrue(this.cliService.changePeers(groupId, conf, new Configuration(newPeers)).isOk());
         cluster.waitLeader();

--- a/jraft-core/src/test/java/com/alipay/sofa/jraft/core/CliServiceTest.java
+++ b/jraft-core/src/test/java/com/alipay/sofa/jraft/core/CliServiceTest.java
@@ -162,7 +162,7 @@ public class CliServiceTest {
         for (final PeerId peer : newPeers) {
             assertTrue(cluster.start(peer.getEndpoint()));
         }
-
+        cluster.waitLeader();
         final Node oldLeaderNode = cluster.getLeader();
         assertNotNull(oldLeaderNode);
         final PeerId oldLeader = oldLeaderNode.getNodeId().getPeerId();

--- a/jraft-core/src/test/java/com/alipay/sofa/jraft/core/FSMCallerTest.java
+++ b/jraft-core/src/test/java/com/alipay/sofa/jraft/core/FSMCallerTest.java
@@ -77,9 +77,10 @@ public class FSMCallerTest {
     }
 
     @After
-    public void teardown() {
+    public void teardown() throws Exception {
         if (this.fsmCaller != null) {
             this.fsmCaller.shutdown();
+            this.fsmCaller.join();
         }
     }
 

--- a/jraft-core/src/test/java/com/alipay/sofa/jraft/core/NodeTest.java
+++ b/jraft-core/src/test/java/com/alipay/sofa/jraft/core/NodeTest.java
@@ -94,8 +94,8 @@ public class NodeTest {
     @After
     public void teardown() throws Exception {
         if (NodeImpl.GLOBAL_NUM_NODES.get() > 0) {
-            Thread.sleep(1000);
-            assertEquals(NodeImpl.GLOBAL_NUM_NODES.get(), 0);
+            Thread.sleep(5000);
+            assertEquals(0, NodeImpl.GLOBAL_NUM_NODES.get());
         }
         FileUtils.deleteDirectory(new File(this.dataPath));
         NodeManager.getInstance().clear();

--- a/jraft-core/src/test/java/com/alipay/sofa/jraft/core/NodeTest.java
+++ b/jraft-core/src/test/java/com/alipay/sofa/jraft/core/NodeTest.java
@@ -16,16 +16,6 @@
  */
 package com.alipay.sofa.jraft.core;
 
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNotSame;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
-
 import java.io.File;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
@@ -74,6 +64,16 @@ import com.alipay.sofa.jraft.test.TestUtils;
 import com.alipay.sofa.jraft.util.Endpoint;
 import com.alipay.sofa.jraft.util.Utils;
 import com.codahale.metrics.ConsoleReporter;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 public class NodeTest {
 
@@ -1195,6 +1195,7 @@ public class NodeTest {
         Thread.sleep(2000);
 
         // restart leader
+        cluster.waitLeader();
         assertEquals(0, cluster.getLeaderFsm().getLoadSnapshotTimes());
         assertTrue(cluster.start(leaderAddr));
         cluster.ensureSame();

--- a/jraft-core/src/test/java/com/alipay/sofa/jraft/core/NodeTest.java
+++ b/jraft-core/src/test/java/com/alipay/sofa/jraft/core/NodeTest.java
@@ -164,6 +164,7 @@ public class NodeTest {
         assertEquals(10, c.get());
 
         node.shutdown();
+        node.join();
     }
 
     @Test

--- a/jraft-core/src/test/java/com/alipay/sofa/jraft/core/TestJRaftServiceFactory.java
+++ b/jraft-core/src/test/java/com/alipay/sofa/jraft/core/TestJRaftServiceFactory.java
@@ -18,14 +18,13 @@ package com.alipay.sofa.jraft.core;
 
 import com.alipay.sofa.jraft.option.RaftOptions;
 import com.alipay.sofa.jraft.storage.LogStorage;
-import com.alipay.sofa.jraft.storage.log.RocksDBSegmentLogStorage;
+import com.alipay.sofa.jraft.storage.impl.RocksDBLogStorage;
 
 public class TestJRaftServiceFactory extends DefaultJRaftServiceFactory {
 
     @Override
-    public LogStorage createLogStorage(String uri, RaftOptions raftOptions) {
-        //Force the data to be stored in segments.
-        return new RocksDBSegmentLogStorage(uri, raftOptions, 0);
+    public LogStorage createLogStorage(final String uri, final RaftOptions raftOptions) {
+        return new RocksDBLogStorage(uri, raftOptions);
     }
 
 }


### PR DESCRIPTION
### Motivation:

The `destroy` method should stop the `timer` even if it has not been started yet. Otherwise there will be a resource leak

### Modification:


### Result:

