### PR TITLE
(feat) revert default log storage to be RocksDBLogStorage

### DIFF
--- a/jraft-core/src/main/java/com/alipay/sofa/jraft/core/DefaultJRaftServiceFactory.java
+++ b/jraft-core/src/main/java/com/alipay/sofa/jraft/core/DefaultJRaftServiceFactory.java
@@ -26,7 +26,7 @@ import com.alipay.sofa.jraft.storage.LogStorage;
 import com.alipay.sofa.jraft.storage.RaftMetaStorage;
 import com.alipay.sofa.jraft.storage.SnapshotStorage;
 import com.alipay.sofa.jraft.storage.impl.LocalRaftMetaStorage;
-import com.alipay.sofa.jraft.storage.log.RocksDBSegmentLogStorage;
+import com.alipay.sofa.jraft.storage.impl.RocksDBLogStorage;
 import com.alipay.sofa.jraft.storage.snapshot.local.LocalSnapshotStorage;
 import com.alipay.sofa.jraft.util.Requires;
 import com.alipay.sofa.jraft.util.SPI;
@@ -47,7 +47,7 @@ public class DefaultJRaftServiceFactory implements JRaftServiceFactory {
     @Override
     public LogStorage createLogStorage(final String uri, final RaftOptions raftOptions) {
         Requires.requireTrue(StringUtils.isNotBlank(uri), "Blank log storage uri.");
-        return new RocksDBSegmentLogStorage(uri, raftOptions);
+        return new RocksDBLogStorage(uri, raftOptions);
     }
 
     @Override

--- a/jraft-core/src/test/java/com/alipay/sofa/jraft/core/TestJRaftServiceFactory.java
+++ b/jraft-core/src/test/java/com/alipay/sofa/jraft/core/TestJRaftServiceFactory.java
@@ -18,14 +18,13 @@ package com.alipay.sofa.jraft.core;
 
 import com.alipay.sofa.jraft.option.RaftOptions;
 import com.alipay.sofa.jraft.storage.LogStorage;
-import com.alipay.sofa.jraft.storage.log.RocksDBSegmentLogStorage;
+import com.alipay.sofa.jraft.storage.impl.RocksDBLogStorage;
 
 public class TestJRaftServiceFactory extends DefaultJRaftServiceFactory {
 
     @Override
-    public LogStorage createLogStorage(String uri, RaftOptions raftOptions) {
-        //Force the data to be stored in segments.
-        return new RocksDBSegmentLogStorage(uri, raftOptions, 0);
+    public LogStorage createLogStorage(final String uri, final RaftOptions raftOptions) {
+        return new RocksDBLogStorage(uri, raftOptions);
     }
 
 }


### PR DESCRIPTION
### Motivation:

Revert default log storage to be `RocksDBLogStorage`. The `RocksDBSegmentLogStorage` is in expirement.

