### PR TITLE
Enable rocksdb force_consistency_checks

### DIFF
--- a/jraft-rheakv/rheakv-core/src/main/java/com/alipay/sofa/jraft/rhea/options/RocksDBOptions.java
+++ b/jraft-rheakv/rheakv-core/src/main/java/com/alipay/sofa/jraft/rhea/options/RocksDBOptions.java
@@ -35,6 +35,8 @@ public class RocksDBOptions {
     // https://github.com/facebook/rocksdb/wiki/Checkpoints
     private boolean fastSnapshot                      = false;
     private boolean openStatisticsCollector           = true;
+    // https://github.com/facebook/rocksdb/pull/5744
+    private boolean forceConsistencyChecks            = true;
     private long    statisticsCallbackIntervalSeconds = 0;
     private String  dbPath;
 
@@ -86,6 +88,14 @@ public class RocksDBOptions {
         this.openStatisticsCollector = openStatisticsCollector;
     }
 
+    public boolean isForceConsistencyChecks() {
+        return forceConsistencyChecks;
+    }
+
+    public void setForceConsistencyChecks(boolean forceConsistencyChecks) {
+        this.forceConsistencyChecks = forceConsistencyChecks;
+    }
+
     public long getStatisticsCallbackIntervalSeconds() {
         return statisticsCallbackIntervalSeconds;
     }
@@ -105,7 +115,8 @@ public class RocksDBOptions {
     @Override
     public String toString() {
         return "RocksDBOptions{" + "sync=" + sync + ", fastSnapshot=" + fastSnapshot + ", openStatisticsCollector="
-               + openStatisticsCollector + ", statisticsCallbackIntervalSeconds=" + statisticsCallbackIntervalSeconds
-               + ", dbPath='" + dbPath + '\'' + '}';
+               + openStatisticsCollector + ", forceConsistencyChecks=" + forceConsistencyChecks
+               + ", statisticsCallbackIntervalSeconds=" + statisticsCallbackIntervalSeconds + ", dbPath='" + dbPath
+               + '\'' + '}';
     }
 }

--- a/jraft-rheakv/rheakv-core/src/main/java/com/alipay/sofa/jraft/rhea/options/configured/RocksDBOptionsConfigured.java
+++ b/jraft-rheakv/rheakv-core/src/main/java/com/alipay/sofa/jraft/rhea/options/configured/RocksDBOptionsConfigured.java
@@ -46,6 +46,11 @@ public final class RocksDBOptionsConfigured implements Configured<RocksDBOptions
         return this;
     }
 
+    public RocksDBOptionsConfigured withForceConsistencyChecks(final boolean forceConsistencyChecks) {
+        this.opts.setForceConsistencyChecks(forceConsistencyChecks);
+        return this;
+    }
+
     public RocksDBOptionsConfigured withStatisticsCallbackIntervalSeconds(final long statisticsCallbackIntervalSeconds) {
         this.opts.setStatisticsCallbackIntervalSeconds(statisticsCallbackIntervalSeconds);
         return this;

--- a/jraft-rheakv/rheakv-core/src/main/java/com/alipay/sofa/jraft/rhea/storage/RocksRawKVStore.java
+++ b/jraft-rheakv/rheakv-core/src/main/java/com/alipay/sofa/jraft/rhea/storage/RocksRawKVStore.java
@@ -144,6 +144,9 @@ public class RocksRawKVStore extends BatchRawKVStore<RocksDBOptions> {
                 }
             }
             final ColumnFamilyOptions cfOptions = createColumnFamilyOptions();
+            if (opts.isForceConsistencyChecks()) {
+                cfOptions.setForceConsistencyChecks(opts.isForceConsistencyChecks());
+            }
             this.cfOptionsList.add(cfOptions);
             // default column family
             this.cfDescriptors.add(new ColumnFamilyDescriptor(RocksDB.DEFAULT_COLUMN_FAMILY, cfOptions));


### PR DESCRIPTION
### Motivation:

Enable `force_consistency_checks` for all CFs. If rocksdb detects LSM corruption, it will either abort (before [facebook/rocksdb@`a281822`)](https://github.com/facebook/rocksdb/commit/a28182233109f09e23e6336b5ed860ddf2c8eece) or return background error in subsequent writes (after that patch). This is to prevent LSM corruption to propagate further and corrupt data in RocksRawKVStore.

### Modification:

RocksDBOptions add forceConsistencyChecks option for rocksdb `force_consistency_checks`.

### Result:

Fixes #283 
