### PR TITLE
feat/avoid copy of checksum

### DIFF
--- a/jraft-core/src/main/java/com/alipay/sofa/jraft/entity/LogEntry.java
+++ b/jraft-core/src/main/java/com/alipay/sofa/jraft/entity/LogEntry.java
@@ -73,11 +73,7 @@ public class LogEntry implements Checksum {
             }
         }
         if (this.data != null && this.data.hasRemaining()) {
-            final byte[] bs = new byte[this.data.remaining()];
-            this.data.mark();
-            this.data.get(bs);
-            this.data.reset();
-            c = checksum(c, CrcUtil.crc64(bs));
+            c = checksum(c, CrcUtil.crc64(this.data));
         }
         return c;
     }

--- a/jraft-core/src/test/java/com/alipay/sofa/jraft/util/CrcUtilTest.java
+++ b/jraft-core/src/test/java/com/alipay/sofa/jraft/util/CrcUtilTest.java
@@ -16,6 +16,8 @@
  */
 package com.alipay.sofa.jraft.util;
 
+import java.nio.ByteBuffer;
+
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
@@ -29,5 +31,13 @@ public class CrcUtilTest {
         assertEquals(c, CrcUtil.crc64(bs));
         assertEquals(c, CrcUtil.crc64(bs));
         assertEquals(c, CrcUtil.crc64(bs, 0, bs.length));
+
+        ByteBuffer buf = ByteBuffer.wrap(bs);
+        assertEquals(c, CrcUtil.crc64(buf));
+
+        buf = ByteBuffer.allocateDirect(bs.length);
+        buf.put(bs);
+        buf.flip();
+        assertEquals(c, CrcUtil.crc64(buf));
     }
 }


### PR DESCRIPTION
### Motivation:

Avoid memory copy on LogEntry checksum

### Modification:


### Result:

Fixes #291 


