### PR TITLE
(fix) Declare rpcClient to be volatile, fix #319

### DIFF
--- a/jraft-core/src/main/java/com/alipay/sofa/jraft/core/NodeImpl.java
+++ b/jraft-core/src/main/java/com/alipay/sofa/jraft/core/NodeImpl.java
@@ -1362,6 +1362,7 @@ public class NodeImpl implements Node, RaftServerService {
             }
 
         } catch (final Exception e) {
+            LOG.error("Fail to apply task.", e);
             Utils.runClosureInThread(task.getDone(), new Status(RaftError.EPERM, "Node is down."));
         }
     }


### PR DESCRIPTION
### Motivation:

Fixed #319 

### Modification:

Declare `rpcClient` to be volatile.

### Result:

Fixes #319 


