### PR TITLE
(feat) add thread pool metric report

### DIFF
--- a/jraft-core/src/main/java/com/alipay/sofa/jraft/ThreadPoolMetricsSignalHandler.java
+++ b/jraft-core/src/main/java/com/alipay/sofa/jraft/ThreadPoolMetricsSignalHandler.java
@@ -1,0 +1,60 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alipay.sofa.jraft;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.PrintStream;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.alipay.sofa.jraft.util.FileOutputSignalHandler;
+import com.alipay.sofa.jraft.util.MetricReporter;
+import com.alipay.sofa.jraft.util.MetricThreadPoolExecutor;
+import com.alipay.sofa.jraft.util.SystemPropertyUtil;
+
+/**
+ *
+ * @author jiachun.fjc
+ */
+public class ThreadPoolMetricsSignalHandler extends FileOutputSignalHandler {
+
+    private static Logger       LOG       = LoggerFactory.getLogger(ThreadPoolMetricsSignalHandler.class);
+
+    private static final String DIR       = SystemPropertyUtil.get("jraft.signal.thread.pool.metrics.dir", "");
+    private static final String BASE_NAME = "thread_pool_metrics.log";
+
+    @Override
+    public void handle(final String signalName) {
+        try {
+            final File file = getOutputFile(DIR, BASE_NAME);
+
+            LOG.info("Printing thread pools metrics with signal: {} to file: {}.", signalName, file);
+
+            try (final PrintStream out = new PrintStream(new FileOutputStream(file, true))) {
+                final MetricReporter reporter = MetricReporter.forRegistry(MetricThreadPoolExecutor.metricRegistry()) //
+                    .outputTo(out) //
+                    .build();
+                reporter.report();
+            }
+        } catch (final IOException e) {
+            LOG.error("Fail to print thread pools metrics.", e);
+        }
+    }
+}

--- a/jraft-core/src/main/java/com/alipay/sofa/jraft/closure/ClosureQueueImpl.java
+++ b/jraft-core/src/main/java/com/alipay/sofa/jraft/closure/ClosureQueueImpl.java
@@ -76,11 +76,13 @@ public class ClosureQueueImpl implements ClosureQueue {
         }
 
         final Status status = new Status(RaftError.EPERM, "Leader stepped down");
-        for (final Closure done : savedQueue) {
-            if (done != null) {
-                Utils.runClosureInThread(done, status);
+        Utils.runInThread(() -> {
+            for (final Closure done : savedQueue) {
+                if (done != null) {
+                    done.run(status);
+                }
             }
-        }
+        });
     }
 
     @Override

--- a/jraft-core/src/main/java/com/alipay/sofa/jraft/core/BallotBox.java
+++ b/jraft-core/src/main/java/com/alipay/sofa/jraft/core/BallotBox.java
@@ -216,7 +216,8 @@ public class BallotBox implements Lifecycle<BallotBoxOptions>, Describer {
 
     /**
      * Called by follower, otherwise the behavior is undefined.
-     *  Set committed index received from leader
+     * Set committed index received from leader
+     *
      * @param lastCommittedIndex last committed index
      * @return returns true if set success
      */

--- a/jraft-core/src/main/java/com/alipay/sofa/jraft/core/FSMCallerImpl.java
+++ b/jraft-core/src/main/java/com/alipay/sofa/jraft/core/FSMCallerImpl.java
@@ -354,6 +354,10 @@ public class FSMCallerImpl implements FSMCaller {
         if (this.shutdownLatch != null) {
             this.shutdownLatch.await();
             this.disruptor.shutdown();
+            if (this.afterShutdown != null) {
+                this.afterShutdown.run(Status.OK());
+                this.afterShutdown = null;
+            }
             this.shutdownLatch = null;
         }
     }
@@ -446,10 +450,6 @@ public class FSMCallerImpl implements FSMCaller {
         }
         if (this.fsm != null) {
             this.fsm.onShutdown();
-        }
-        if (this.afterShutdown != null) {
-            this.afterShutdown.run(Status.OK());
-            this.afterShutdown = null;
         }
     }
 

--- a/jraft-core/src/main/java/com/alipay/sofa/jraft/core/NodeImpl.java
+++ b/jraft-core/src/main/java/com/alipay/sofa/jraft/core/NodeImpl.java
@@ -1156,8 +1156,8 @@ public class NodeImpl implements Node, RaftServerService {
                 NodeImpl.this.ballotBox.commitAt(this.firstLogIndex, this.firstLogIndex + this.nEntries - 1,
                     NodeImpl.this.serverId);
             } else {
-                LOG.error("Node {} append [{}, {}] failed.", getNodeId(), this.firstLogIndex, this.firstLogIndex
-                                                                                              + this.nEntries - 1);
+                LOG.error("Node {} append [{}, {}] failed, status={}.", getNodeId(), this.firstLogIndex,
+                    this.firstLogIndex + this.nEntries - 1, status);
             }
         }
     }

--- a/jraft-core/src/main/java/com/alipay/sofa/jraft/core/NodeImpl.java
+++ b/jraft-core/src/main/java/com/alipay/sofa/jraft/core/NodeImpl.java
@@ -1051,9 +1051,9 @@ public class NodeImpl implements Node, RaftServerService {
 
         // Start learner's replicators
         for (final PeerId peer : this.conf.listLearners()) {
-            LOG.debug("Node {} add a leaarner replicator, term={}, peer={}.", getNodeId(), this.currTerm, peer);
+            LOG.debug("Node {} add a learner replicator, term={}, peer={}.", getNodeId(), this.currTerm, peer);
             if (!this.replicatorGroup.addReplicator(peer, ReplicatorType.Learner)) {
-                LOG.error("Fail to add a leaarner replicator, peer={}.", peer);
+                LOG.error("Fail to add a learner replicator, peer={}.", peer);
             }
         }
 

--- a/jraft-core/src/main/java/com/alipay/sofa/jraft/storage/impl/LogManagerImpl.java
+++ b/jraft-core/src/main/java/com/alipay/sofa/jraft/storage/impl/LogManagerImpl.java
@@ -634,7 +634,7 @@ public class LogManagerImpl implements LogManager {
                 }
             } else {
                 if (!reset(meta.getLastIncludedIndex() + 1)) {
-                    LOG.warn("Reset log manager failed, nextLogIndex={}", meta.getLastIncludedIndex() + 1);
+                    LOG.warn("Reset log manager failed, nextLogIndex={}.", meta.getLastIncludedIndex() + 1);
                 }
             }
         } finally {

--- a/jraft-core/src/main/java/com/alipay/sofa/jraft/storage/impl/LogManagerImpl.java
+++ b/jraft-core/src/main/java/com/alipay/sofa/jraft/storage/impl/LogManagerImpl.java
@@ -771,11 +771,11 @@ public class LogManagerImpl implements LogManager {
     }
 
     private long getTermFromLogStorage(final long index) {
-        LogEntry entry = this.logStorage.getEntry(index);
+        final LogEntry entry = this.logStorage.getEntry(index);
         if (entry != null) {
             if (this.raftOptions.isEnableLogEntryChecksum() && entry.isCorrupted()) {
                 // Report error to node and throw exception.
-                String msg = String.format(
+                final String msg = String.format(
                     "The log entry is corrupted, index=%d, term=%d, expectedChecksum=%d, realChecksum=%d", entry
                         .getId().getIndex(), entry.getId().getTerm(), entry.getChecksum(), entry.checksum());
                 reportError(RaftError.EIO.getNumber(), msg);

--- a/jraft-core/src/main/java/com/alipay/sofa/jraft/storage/impl/RocksDBLogStorage.java
+++ b/jraft-core/src/main/java/com/alipay/sofa/jraft/storage/impl/RocksDBLogStorage.java
@@ -35,7 +35,6 @@ import org.rocksdb.ReadOptions;
 import org.rocksdb.RocksDB;
 import org.rocksdb.RocksDBException;
 import org.rocksdb.RocksIterator;
-import org.rocksdb.Statistics;
 import org.rocksdb.StringAppendOperator;
 import org.rocksdb.WriteBatch;
 import org.rocksdb.WriteOptions;
@@ -55,6 +54,7 @@ import com.alipay.sofa.jraft.option.RaftOptions;
 import com.alipay.sofa.jraft.storage.LogStorage;
 import com.alipay.sofa.jraft.util.Bits;
 import com.alipay.sofa.jraft.util.BytesUtil;
+import com.alipay.sofa.jraft.util.DebugStatistics;
 import com.alipay.sofa.jraft.util.Describer;
 import com.alipay.sofa.jraft.util.Requires;
 import com.alipay.sofa.jraft.util.StorageOptionsFactory;
@@ -97,7 +97,7 @@ public class RocksDBLogStorage implements LogStorage, Describer {
     private ColumnFamilyHandle              defaultHandle;
     private ColumnFamilyHandle              confHandle;
     private ReadOptions                     totalOrderReadOptions;
-    private Statistics                      statistics;
+    private DebugStatistics                 statistics;
     private final ReadWriteLock             readWriteLock = new ReentrantReadWriteLock();
     private final Lock                      readLock      = this.readWriteLock.readLock();
     private final Lock                      writeLock     = this.readWriteLock.writeLock();
@@ -145,7 +145,7 @@ public class RocksDBLogStorage implements LogStorage, Describer {
             Requires.requireNonNull(this.logEntryEncoder, "Null log entry encoder");
             this.dbOptions = createDBOptions();
             if (this.openStatistics) {
-                this.statistics = new Statistics();
+                this.statistics = new DebugStatistics();
                 this.dbOptions.setStatistics(this.statistics);
             }
 
@@ -662,7 +662,7 @@ public class RocksDBLogStorage implements LogStorage, Describer {
             }
             out.println("");
             if (this.statistics != null) {
-                out.println(this.statistics.toString());
+                out.println(this.statistics.getString());
             }
         } catch (final RocksDBException e) {
             out.println(e);

--- a/jraft-core/src/main/java/com/alipay/sofa/jraft/storage/snapshot/SnapshotExecutorImpl.java
+++ b/jraft-core/src/main/java/com/alipay/sofa/jraft/storage/snapshot/SnapshotExecutorImpl.java
@@ -270,7 +270,7 @@ public class SnapshotExecutorImpl implements SnapshotExecutor {
             Utils.closeQuietly(reader);
         }
         if (!done.status.isOk()) {
-            LOG.error("Fail to load snapshot from {},FirstSnapshotLoadDone status is {}.", opts.getUri(), done.status);
+            LOG.error("Fail to load snapshot from {}, FirstSnapshotLoadDone status is {}.", opts.getUri(), done.status);
             return false;
         }
         return true;

--- a/jraft-core/src/main/java/com/alipay/sofa/jraft/util/DebugStatistics.java
+++ b/jraft-core/src/main/java/com/alipay/sofa/jraft/util/DebugStatistics.java
@@ -1,0 +1,36 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alipay.sofa.jraft.util;
+
+import org.rocksdb.Statistics;
+
+/**
+ *
+ * @author jiachun.fjc
+ */
+public class DebugStatistics extends Statistics {
+
+    public String getString() {
+        return super.toString();
+    }
+
+    @Override
+    public String toString() {
+        // no crash when debug
+        return getClass().getName() + "@" + Integer.toHexString(hashCode());
+    }
+}

--- a/jraft-core/src/main/resources/META-INF/services/com.alipay.sofa.jraft.util.JRaftSignalHandler
+++ b/jraft-core/src/main/resources/META-INF/services/com.alipay.sofa.jraft.util.JRaftSignalHandler
@@ -1,2 +1,3 @@
 com.alipay.sofa.jraft.NodeDescribeSignalHandler
 com.alipay.sofa.jraft.NodeMetricsSignalHandler
+com.alipay.sofa.jraft.ThreadPoolMetricsSignalHandler

--- a/jraft-core/src/test/java/com/alipay/sofa/jraft/core/NodeTest.java
+++ b/jraft-core/src/test/java/com/alipay/sofa/jraft/core/NodeTest.java
@@ -104,6 +104,11 @@ public class NodeTest {
 
     @After
     public void teardown() throws Exception {
+        if (!TestCluster.CLUSTERS.isEmpty()) {
+            for (final TestCluster c : TestCluster.CLUSTERS.removeAll()) {
+                c.stopAll();
+            }
+        }
         if (NodeImpl.GLOBAL_NUM_NODES.get() > 0) {
             Thread.sleep(5000);
             assertEquals(0, NodeImpl.GLOBAL_NUM_NODES.get());

--- a/jraft-core/src/test/java/com/alipay/sofa/jraft/core/NodeTest.java
+++ b/jraft-core/src/test/java/com/alipay/sofa/jraft/core/NodeTest.java
@@ -36,7 +36,9 @@ import org.apache.commons.io.FileUtils;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.TestName;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -89,8 +91,12 @@ public class NodeTest {
     private final AtomicInteger startedCounter = new AtomicInteger(0);
     private final AtomicInteger stoppedCounter = new AtomicInteger(0);
 
+    @Rule
+    public TestName             testName       = new TestName();
+
     @Before
     public void setup() throws Exception {
+        System.out.println(">>>>>>>>>>>>>>> Start test method: " + this.testName.getMethodName());
         this.dataPath = TestUtils.mkTempDir();
         FileUtils.forceMkdir(new File(this.dataPath));
         assertEquals(NodeImpl.GLOBAL_NUM_NODES.get(), 0);
@@ -106,6 +112,7 @@ public class NodeTest {
         NodeManager.getInstance().clear();
         this.startedCounter.set(0);
         this.stoppedCounter.set(0);
+        System.out.println(">>>>>>>>>>>>>>> End test method: " + this.testName.getMethodName());
     }
 
     @Test

--- a/jraft-core/src/test/java/com/alipay/sofa/jraft/core/NodeTest.java
+++ b/jraft-core/src/test/java/com/alipay/sofa/jraft/core/NodeTest.java
@@ -16,16 +16,6 @@
  */
 package com.alipay.sofa.jraft.core;
 
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNotSame;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
-
 import java.io.File;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
@@ -79,6 +69,16 @@ import com.alipay.sofa.jraft.test.TestUtils;
 import com.alipay.sofa.jraft.util.Endpoint;
 import com.alipay.sofa.jraft.util.Utils;
 import com.codahale.metrics.ConsoleReporter;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 public class NodeTest {
 
@@ -1738,8 +1738,8 @@ public class NodeTest {
 
         latch = new CountDownLatch(1);
         node.shutdown(new ExpectClosure(latch));
-        waitLatch(latch);
         node.join();
+        waitLatch(latch);
     }
 
     @Test
@@ -1771,8 +1771,8 @@ public class NodeTest {
 
         final CountDownLatch latch = new CountDownLatch(1);
         node.shutdown(new ExpectClosure(latch));
-        waitLatch(latch);
         node.join();
+        waitLatch(latch);
     }
 
     @Test

--- a/jraft-core/src/test/java/com/alipay/sofa/jraft/core/NodeTest.java
+++ b/jraft-core/src/test/java/com/alipay/sofa/jraft/core/NodeTest.java
@@ -909,15 +909,18 @@ public class NodeTest {
             new Thread() {
                 @Override
                 public void run() {
-                    for (int i = 0; i < 100; i++) {
-                        try {
-                            sendTestTaskAndWait(leader);
-                        } catch (final InterruptedException e) {
-                            Thread.currentThread().interrupt();
+                    try {
+                        for (int i = 0; i < 100; i++) {
+                            try {
+                                sendTestTaskAndWait(leader);
+                            } catch (final InterruptedException e) {
+                                Thread.currentThread().interrupt();
+                            }
+                            readIndexRandom(cluster);
                         }
-                        readIndexRandom(cluster);
+                    } finally {
+                        latch.countDown();
                     }
-                    latch.countDown();
                 }
 
                 private void readIndexRandom(final TestCluster cluster) {

--- a/jraft-core/src/test/java/com/alipay/sofa/jraft/core/TestCluster.java
+++ b/jraft-core/src/test/java/com/alipay/sofa/jraft/core/TestCluster.java
@@ -199,8 +199,8 @@ public class TestCluster {
         final CountDownLatch latch = new CountDownLatch(1);
         if (node != null) {
             node.shutdown(new ExpectClosure(latch));
-            latch.await();
             node.join();
+            latch.await();
         }
         final RaftGroupService raftGroupService = this.serverMap.remove(listenAddr.toString());
         raftGroupService.shutdown();

--- a/jraft-core/src/test/java/com/alipay/sofa/jraft/core/TestCluster.java
+++ b/jraft-core/src/test/java/com/alipay/sofa/jraft/core/TestCluster.java
@@ -20,6 +20,7 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
+import java.util.IdentityHashMap;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
@@ -51,6 +52,33 @@ import com.alipay.sofa.jraft.util.Endpoint;
  * 2018-Apr-20 1:41:17 PM
  */
 public class TestCluster {
+
+    static class Clusters {
+
+        public final IdentityHashMap<TestCluster, Object> needCloses = new IdentityHashMap<>();
+        private final Object                              EXIST      = new Object();
+
+        public synchronized void add(final TestCluster cluster) {
+            this.needCloses.put(cluster, EXIST);
+        }
+
+        public synchronized boolean remove(final TestCluster cluster) {
+            return this.needCloses.remove(cluster) != null;
+        }
+
+        public synchronized boolean isEmpty() {
+            return this.needCloses.isEmpty();
+        }
+
+        public synchronized List<TestCluster> removeAll() {
+            final List<TestCluster> clusters = new ArrayList<>(this.needCloses.keySet());
+            this.needCloses.clear();
+            return clusters;
+        }
+    }
+
+    public static final Clusters                          CLUSTERS           = new Clusters();
+
     private final String                                  dataPath;
     private final String                                  name;                                              // groupId
     private final List<PeerId>                            peers;
@@ -62,7 +90,7 @@ public class TestCluster {
 
     private JRaftServiceFactory                           raftServiceFactory = new TestJRaftServiceFactory();
 
-    private LinkedHashSet<PeerId>                         learners           = new LinkedHashSet<>();
+    private LinkedHashSet<PeerId>                         learners;
 
     public JRaftServiceFactory getRaftServiceFactory() {
         return this.raftServiceFactory;
@@ -102,6 +130,7 @@ public class TestCluster {
         this.fsms = new LinkedHashMap<>(this.peers.size());
         this.electionTimeoutMs = electionTimeoutMs;
         this.learners = learners;
+        CLUSTERS.add(this);
     }
 
     public boolean start(final Endpoint addr) throws Exception {
@@ -220,6 +249,7 @@ public class TestCluster {
         for (final Node node : nodes) {
             node.join();
         }
+        CLUSTERS.remove(this);
     }
 
     public void clean(final Endpoint listenAddr) throws IOException {

--- a/jraft-core/src/test/java/com/alipay/sofa/jraft/core/TestCluster.java
+++ b/jraft-core/src/test/java/com/alipay/sofa/jraft/core/TestCluster.java
@@ -382,6 +382,7 @@ public class TestCluster {
             this.lock.unlock();
             return true;
         }
+        System.out.println("Start ensureSame, waitTimes=" + waitTimes);
         try {
             int nround = 0;
             final MockStateMachine first = fsmList.get(0);
@@ -433,6 +434,7 @@ public class TestCluster {
             return true;
         } finally {
             this.lock.unlock();
+            System.out.println("End ensureSame, waitTimes=" + waitTimes);
         }
     }
 }

--- a/jraft-core/src/test/java/com/alipay/sofa/jraft/test/TestUtils.java
+++ b/jraft-core/src/test/java/com/alipay/sofa/jraft/test/TestUtils.java
@@ -16,12 +16,12 @@
  */
 package com.alipay.sofa.jraft.test;
 
-import java.io.File;
 import java.net.Inet4Address;
 import java.net.InetAddress;
 import java.net.NetworkInterface;
 import java.net.SocketException;
 import java.nio.ByteBuffer;
+import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Enumeration;
 import java.util.List;
@@ -51,7 +51,7 @@ public class TestUtils {
     }
 
     public static String mkTempDir() {
-        return System.getProperty("java.io.tmpdir", "/tmp") + File.separator + "jraft_test_" + System.nanoTime();
+        return Paths.get(System.getProperty("java.io.tmpdir", "/tmp"), "jraft_test_" + System.nanoTime()).toString();
     }
 
     public static LogEntry mockEntry(final int index, final int term) {

--- a/jraft-rheakv/rheakv-core/src/main/java/com/alipay/sofa/jraft/rhea/rocks/support/RocksStatistics.java
+++ b/jraft-rheakv/rheakv-core/src/main/java/com/alipay/sofa/jraft/rhea/rocks/support/RocksStatistics.java
@@ -27,20 +27,21 @@ import com.alipay.sofa.jraft.rhea.storage.RocksRawKVStore;
 import com.alipay.sofa.jraft.rhea.util.ThrowUtil;
 import com.alipay.sofa.jraft.rhea.util.internal.ReferenceFieldUpdater;
 import com.alipay.sofa.jraft.rhea.util.internal.Updaters;
+import com.alipay.sofa.jraft.util.DebugStatistics;
 
 /**
  * @author jiachun.fjc
  */
 public final class RocksStatistics {
 
-    private static final ReferenceFieldUpdater<RocksRawKVStore, Statistics> statisticsGetter = Updaters
-                                                                                                 .newReferenceFieldUpdater(
-                                                                                                     RocksRawKVStore.class,
-                                                                                                     "statistics");
-    private static final ReferenceFieldUpdater<RocksRawKVStore, RocksDB>    dbGetter         = Updaters
-                                                                                                 .newReferenceFieldUpdater(
-                                                                                                     RocksRawKVStore.class,
-                                                                                                     "db");
+    private static final ReferenceFieldUpdater<RocksRawKVStore, DebugStatistics> statisticsGetter = Updaters
+                                                                                                      .newReferenceFieldUpdater(
+                                                                                                          RocksRawKVStore.class,
+                                                                                                          "statistics");
+    private static final ReferenceFieldUpdater<RocksRawKVStore, RocksDB>         dbGetter         = Updaters
+                                                                                                      .newReferenceFieldUpdater(
+                                                                                                          RocksRawKVStore.class,
+                                                                                                          "db");
 
     /**
      * Get the count for a ticker.

--- a/jraft-rheakv/rheakv-core/src/main/java/com/alipay/sofa/jraft/rhea/storage/RocksRawKVStore.java
+++ b/jraft-rheakv/rheakv-core/src/main/java/com/alipay/sofa/jraft/rhea/storage/RocksRawKVStore.java
@@ -78,6 +78,7 @@ import com.alipay.sofa.jraft.rhea.util.StackTraceUtil;
 import com.alipay.sofa.jraft.rhea.util.concurrent.DistributedLock;
 import com.alipay.sofa.jraft.util.Bits;
 import com.alipay.sofa.jraft.util.BytesUtil;
+import com.alipay.sofa.jraft.util.DebugStatistics;
 import com.alipay.sofa.jraft.util.Describer;
 import com.alipay.sofa.jraft.util.Requires;
 import com.alipay.sofa.jraft.util.StorageOptionsFactory;
@@ -122,7 +123,7 @@ public class RocksRawKVStore extends BatchRawKVStore<RocksDBOptions> implements 
     private RocksDBOptions                     opts;
     private DBOptions                          options;
     private WriteOptions                       writeOptions;
-    private Statistics                         statistics;
+    private DebugStatistics                    statistics;
     private RocksStatisticsCollector           statisticsCollector;
 
     @Override
@@ -137,7 +138,7 @@ public class RocksRawKVStore extends BatchRawKVStore<RocksDBOptions> implements 
             this.opts = opts;
             this.options = createDBOptions();
             if (opts.isOpenStatisticsCollector()) {
-                this.statistics = new Statistics();
+                this.statistics = new DebugStatistics();
                 this.options.setStatistics(this.statistics);
                 final long intervalSeconds = opts.getStatisticsCallbackIntervalSeconds();
                 if (intervalSeconds > 0) {
@@ -1588,7 +1589,7 @@ public class RocksRawKVStore extends BatchRawKVStore<RocksDBOptions> implements 
             }
             out.println("");
             if (this.statistics != null) {
-                out.println(this.statistics.toString());
+                out.println(this.statistics.getString());
             }
         } catch (final RocksDBException e) {
             out.println(e);

--- a/jraft-rheakv/rheakv-core/src/test/java/com/alipay/sofa/jraft/rhea/chaos/AbstractChaosTest.java
+++ b/jraft-rheakv/rheakv-core/src/test/java/com/alipay/sofa/jraft/rhea/chaos/AbstractChaosTest.java
@@ -24,8 +24,12 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 
+import org.junit.After;
 import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.TestName;
 
 import com.alipay.sofa.jraft.Status;
 import com.alipay.sofa.jraft.conf.Configuration;
@@ -56,6 +60,19 @@ public abstract class AbstractChaosTest {
     private static final int    RETRIES            = 10;
     private static final byte[] VALUE              = BytesUtil.writeUtf8("test");
 
+    @Rule
+    public TestName             testName           = new TestName();
+
+    @Before
+    public void setup() throws Exception {
+        System.out.println(">>>>>>>>>>>>>>> Start test method: " + this.testName.getMethodName());
+    }
+
+    @After
+    public void teardown() throws Exception {
+        System.out.println(">>>>>>>>>>>>>>> End test method: " + this.testName.getMethodName());
+    }
+
     @Test
     public void chaosGetTest() throws Exception {
         ChaosTestCluster cluster = null;
@@ -69,7 +86,7 @@ public abstract class AbstractChaosTest {
                         isAllowBatching(), isOnlyLeaderRead());
                 cluster.start();
 
-                // 在写入数据之前, 先移除一个节点 (node1), 后面再添加回来, 验证是否能保证读一致性
+                // Before writing data, remove a node (node1) and add it back later to verify that read consistency is guaranteed.
                 p1 = cluster.getRandomPeer();
                 cluster.removePeer(p1);
 
@@ -86,11 +103,11 @@ public abstract class AbstractChaosTest {
                     });
                 }
 
-                // 在写入数据过程中, 再移除一个节点 (node2)
+                // In the process of writing data, remove one node (node2)
                 p2 = cluster.getRandomPeer();
                 cluster.removePeer(p2);
 
-                // 等待写入全部完成
+                // Waiting for the write to be completed
                 CompletableFuture.allOf(allFutures.toArray(new CompletableFuture[0]))
                         .get(30, TimeUnit.SECONDS);
                 break;
@@ -117,14 +134,14 @@ public abstract class AbstractChaosTest {
     }
 
     private void chaosGetCheckData(final ChaosTestCluster cluster, final PeerId p2, final PeerId p1) {
-        // 随机选一个 client 验证数据一致性
+        // Randomly select a client to verify data consistency
         for (int i = 0; i < LOOP_1; i++) {
             for (int j = 0; j < LOOP_2; j++) {
                 Assert.assertArrayEquals(VALUE, cluster.getRandomStore().bGet("test_" + i + "_" + j));
             }
         }
 
-        // node2 重新加入, 并在 node2 上验证读一致性
+        // Node2 rejoins and verifies read consistency on node2
         cluster.addPeer(p2);
         for (int i = 0; i < LOOP_1; i++) {
             for (int j = 0; j < LOOP_2; j++) {
@@ -132,7 +149,7 @@ public abstract class AbstractChaosTest {
             }
         }
 
-        // node1 重新加入, 并在 node1 上验证读一致性 (node1 会从 leader 同步数据)
+        // Node1 rejoins and verifies read consistency on node1 (node1 will synchronize data from leader)
         cluster.addPeer(p1);
         for (int i = 0; i < LOOP_1; i++) {
             for (int j = 0; j < LOOP_2; j++) {

--- a/jraft-rheakv/rheakv-core/src/test/java/com/alipay/sofa/jraft/rhea/storage/rhea/AbstractRheaKVStoreTest.java
+++ b/jraft-rheakv/rheakv-core/src/test/java/com/alipay/sofa/jraft/rhea/storage/rhea/AbstractRheaKVStoreTest.java
@@ -27,7 +27,9 @@ import java.util.concurrent.TimeUnit;
 
 import org.junit.After;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.TestName;
 
 import com.alipay.sofa.jraft.JRaftUtils;
 import com.alipay.sofa.jraft.Status;
@@ -66,14 +68,19 @@ public abstract class AbstractRheaKVStoreTest extends RheaKVTestCluster {
 
     public abstract StorageType getStorageType();
 
+    @Rule
+    public TestName testName = new TestName();
+
     @Before
     public void setup() throws Exception {
+        System.out.println(">>>>>>>>>>>>>>> Start test method: " + this.testName.getMethodName());
         super.start(getStorageType());
     }
 
     @After
     public void tearDown() throws Exception {
         super.shutdown();
+        System.out.println(">>>>>>>>>>>>>>> End test method: " + this.testName.getMethodName());
     }
 
     private void checkRegion(RheaKVStore store, byte[] key, long expectedRegionId) {

--- a/jraft-rheakv/rheakv-core/src/test/java/com/alipay/sofa/jraft/rhea/storage/rhea/AbstractRheaKVStoreTest.java
+++ b/jraft-rheakv/rheakv-core/src/test/java/com/alipay/sofa/jraft/rhea/storage/rhea/AbstractRheaKVStoreTest.java
@@ -79,6 +79,7 @@ public abstract class AbstractRheaKVStoreTest extends RheaKVTestCluster {
 
     @After
     public void tearDown() throws Exception {
+        System.out.println(">>>>>>>>>>>>>>> Stopping test method: " + this.testName.getMethodName());
         super.shutdown();
         System.out.println(">>>>>>>>>>>>>>> End test method: " + this.testName.getMethodName());
     }


### PR DESCRIPTION
### Motivation:

add thread pool metric report on `kill -s SIGUSR2 $pid`


### Modification:

- [x] thread pool's metrics #338 
- [x] some test case may hang on travis #333 
- [x] shutdown order #338 
- [x] fix: forget to stop TestCluster on test failed, this may be the root cause by 'hang on travis'

### Result:

thread pool's metrics example:

`

  19-11-14 10:40:12 ==============================================================

  -- Timers ----------------------------------------------------------------------
  threadPool.JRAFT_CLOSURE_EXECUTOR
               count = 1574
           mean rate = 17.69 calls/second
       1-minute rate = 16.24 calls/second
       5-minute rate = 11.43 calls/second
      15-minute rate = 10.13 calls/second
                 min = 0.06 milliseconds
                 max = 2.63 milliseconds
                mean = 0.21 milliseconds
              stddev = 0.13 milliseconds
              median = 0.17 milliseconds
                75% <= 0.22 milliseconds
                95% <= 0.40 milliseconds
                98% <= 0.48 milliseconds
                99% <= 0.61 milliseconds
              99.9% <= 1.60 milliseconds
  threadPool.JRaft-RPC-Processor
               count = 2
           mean rate = 0.02 calls/second
       1-minute rate = 0.11 calls/second
       5-minute rate = 0.31 calls/second
      15-minute rate = 0.37 calls/second
                 min = 21.48 milliseconds
                 max = 31.71 milliseconds
                mean = 26.59 milliseconds
              stddev = 5.12 milliseconds
              median = 31.71 milliseconds
                75% <= 31.71 milliseconds
                95% <= 31.71 milliseconds
                98% <= 31.71 milliseconds
                99% <= 31.71 milliseconds
              99.9% <= 31.71 milliseconds
  threadPool.rheakv-cli-rpc-executor
               count = 2
           mean rate = 0.18 calls/second
       1-minute rate = 0.20 calls/second
       5-minute rate = 0.20 calls/second
      15-minute rate = 0.20 calls/second
                 min = 0.18 milliseconds
                 max = 2.56 milliseconds
                mean = 1.30 milliseconds
              stddev = 1.19 milliseconds
              median = 0.18 milliseconds
                75% <= 2.56 milliseconds
                95% <= 2.56 milliseconds
                98% <= 2.56 milliseconds
                99% <= 2.56 milliseconds
              99.9% <= 2.56 milliseconds
  threadPool.rheakv-kv-store-rpc-executor
               count = 36
           mean rate = 3.18 calls/second
       1-minute rate = 2.93 calls/second
       5-minute rate = 2.83 calls/second
      15-minute rate = 2.81 calls/second
                 min = 0.09 milliseconds
                 max = 82.06 milliseconds
                mean = 3.10 milliseconds
              stddev = 13.20 milliseconds
              median = 0.15 milliseconds
                75% <= 0.32 milliseconds
                95% <= 15.53 milliseconds
                98% <= 82.06 milliseconds
                99% <= 82.06 milliseconds
              99.9% <= 82.06 milliseconds
`
