### PR TITLE
(feat) Support readIndex from learner

### DIFF
--- a/jraft-core/src/main/java/com/alipay/sofa/jraft/conf/ConfigurationEntry.java
+++ b/jraft-core/src/main/java/com/alipay/sofa/jraft/conf/ConfigurationEntry.java
@@ -114,6 +114,10 @@ public class ConfigurationEntry {
         return ret;
     }
 
+    public boolean containsLearner(final PeerId learner) {
+        return this.conf.getLearners().contains(learner) || this.oldConf.getLearners().contains(learner);
+    }
+
     public boolean contains(final PeerId peer) {
         return this.conf.contains(peer) || this.oldConf.contains(peer);
     }

--- a/jraft-core/src/main/java/com/alipay/sofa/jraft/core/NodeImpl.java
+++ b/jraft-core/src/main/java/com/alipay/sofa/jraft/core/NodeImpl.java
@@ -1365,12 +1365,12 @@ public class NodeImpl implements Node, RaftServerService {
         respBuilder.setIndex(lastCommittedIndex);
 
         if (request.getPeerId() != null) {
-            // request from follower, check if the follower is in current conf.
+            // request from follower or learner, check if the follower/learner is in current conf.
             final PeerId peer = new PeerId();
             peer.parse(request.getServerId());
-            if (!this.conf.contains(peer)) {
+            if (!this.conf.contains(peer) && !this.conf.containsLearner(peer)) {
                 closure
-                    .run(new Status(RaftError.EPERM, "Peer %s is not in current configuration: {}.", peer, this.conf));
+                    .run(new Status(RaftError.EPERM, "Peer %s is not in current configuration: %s.", peer, this.conf));
                 return;
             }
         }

--- a/jraft-core/src/main/java/com/alipay/sofa/jraft/storage/snapshot/SnapshotExecutorImpl.java
+++ b/jraft-core/src/main/java/com/alipay/sofa/jraft/storage/snapshot/SnapshotExecutorImpl.java
@@ -260,6 +260,7 @@ public class SnapshotExecutorImpl implements SnapshotExecutor {
             Utils.closeQuietly(reader);
             return false;
         }
+        LOG.info("Loading snapshot, meta={}.", this.loadingSnapshotMeta);
         this.loadingSnapshot = true;
         this.runningJobs.incrementAndGet();
         final FirstSnapshotLoadDone done = new FirstSnapshotLoadDone(reader);

--- a/jraft-core/src/test/java/com/alipay/sofa/jraft/core/NodeTest.java
+++ b/jraft-core/src/test/java/com/alipay/sofa/jraft/core/NodeTest.java
@@ -511,6 +511,7 @@ public class NodeTest {
         assertEquals(3, leader.listAliveLearners().size());
 
         this.sendTestTaskAndWait(leader);
+        Thread.sleep(500);
         List<MockStateMachine> fsms = cluster.getFsms();
         assertEquals(6, fsms.size());
         cluster.ensureSame();
@@ -527,6 +528,7 @@ public class NodeTest {
             assertEquals(2, leader.listAliveLearners().size());
             assertEquals(2, leader.listLearners().size());
             this.sendTestTaskAndWait(leader);
+            Thread.sleep(500);
 
             assertEquals(6, fsms.size());
 
@@ -544,6 +546,7 @@ public class NodeTest {
             assertTrue(done.await().isOk());
 
             this.sendTestTaskAndWait(leader);
+            Thread.sleep(500);
             MockStateMachine fsm = fsms.remove(3); // get the removed learner's fsm
             assertEquals(fsm.getAddress(), learnerPeer.getEndpoint());
             // Ensure no more logs replicated to the removed learner.


### PR DESCRIPTION
### Motivation:

Make Leader supports processing `readIndex` request from learner.

### Modification:

* `NodeImpl#readLeader`

### Result:


