### PR TITLE
Feature/some changes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,5 @@ cache:
 install:
   - mvn clean install -DskipTests=true -Dmaven.javadoc.skip=true -B -V
   - sh ./tools/check_format.sh
-
 script:
-  - travis_retry mvn --projects $TESTFOLDER test
-
+  - MAVEN_SKIP_RC=true MAVEN_OPTS="-Xmx1g -server -XX:+UseG1GC" travis_retry mvn --projects $TESTFOLDER test

--- a/jraft-core/src/main/java/com/alipay/sofa/jraft/core/FSMCallerImpl.java
+++ b/jraft-core/src/main/java/com/alipay/sofa/jraft/core/FSMCallerImpl.java
@@ -36,6 +36,7 @@ import com.alipay.sofa.jraft.closure.TaskClosure;
 import com.alipay.sofa.jraft.conf.Configuration;
 import com.alipay.sofa.jraft.conf.ConfigurationEntry;
 import com.alipay.sofa.jraft.entity.EnumOutter;
+import com.alipay.sofa.jraft.entity.EnumOutter.ErrorType;
 import com.alipay.sofa.jraft.entity.LeaderChangeContext;
 import com.alipay.sofa.jraft.entity.LogEntry;
 import com.alipay.sofa.jraft.entity.LogId;
@@ -231,7 +232,11 @@ public class FSMCallerImpl implements FSMCaller {
             LOG.warn("FSMCaller is stopped, can not apply new task.");
             return false;
         }
-        this.taskQueue.publishEvent(tpl);
+        if (!this.taskQueue.tryPublishEvent(tpl)) {
+            onError(new RaftException(ErrorType.ERROR_TYPE_STATE_MACHINE, new Status(RaftError.EBUSY,
+                "FSMCaller is overload.")));
+            return false;
+        }
         return true;
     }
 

--- a/jraft-core/src/main/java/com/alipay/sofa/jraft/core/ReadOnlyServiceImpl.java
+++ b/jraft-core/src/main/java/com/alipay/sofa/jraft/core/ReadOnlyServiceImpl.java
@@ -175,8 +175,8 @@ public class ReadOnlyServiceImpl implements ReadOnlyService, LastAppliedLogIndex
                 } else {
                     // Not applied, add it to pending-notify cache.
                     ReadOnlyServiceImpl.this.pendingNotifyStatus
-                        .computeIfAbsent(readIndexStatus.getIndex(), k -> new ArrayList<>(10)) //
-                        .add(readIndexStatus);
+                    .computeIfAbsent(readIndexStatus.getIndex(), k -> new ArrayList<>(10)) //
+                    .add(readIndexStatus);
                 }
             } finally {
                 if (doUnlock) {
@@ -225,32 +225,28 @@ public class ReadOnlyServiceImpl implements ReadOnlyService, LastAppliedLogIndex
         this.raftOptions = opts.getRaftOptions();
 
         this.scheduledExecutorService = Executors
-            .newSingleThreadScheduledExecutor(new NamedThreadFactory("ReadOnlyService-PendingNotify-Scanner", true));
+                .newSingleThreadScheduledExecutor(new NamedThreadFactory("ReadOnlyService-PendingNotify-Scanner", true));
         this.readIndexDisruptor = DisruptorBuilder.<ReadIndexEvent> newInstance() //
-            .setEventFactory(new ReadIndexEventFactory()) //
-            .setRingBufferSize(this.raftOptions.getDisruptorBufferSize()) //
-            .setThreadFactory(new NamedThreadFactory("JRaft-ReadOnlyService-Disruptor-", true)) //
-            .setWaitStrategy(new BlockingWaitStrategy()) //
-            .setProducerType(ProducerType.MULTI) //
-            .build();
+                .setEventFactory(new ReadIndexEventFactory()) //
+                .setRingBufferSize(this.raftOptions.getDisruptorBufferSize()) //
+                .setThreadFactory(new NamedThreadFactory("JRaft-ReadOnlyService-Disruptor-", true)) //
+                .setWaitStrategy(new BlockingWaitStrategy()) //
+                .setProducerType(ProducerType.MULTI) //
+                .build();
         this.readIndexDisruptor.handleEventsWith(new ReadIndexEventHandler());
         this.readIndexDisruptor
-            .setDefaultExceptionHandler(new LogExceptionHandler<Object>(this.getClass().getSimpleName()));
+        .setDefaultExceptionHandler(new LogExceptionHandler<Object>(this.getClass().getSimpleName()));
         this.readIndexQueue = this.readIndexDisruptor.start();
-        if(this.nodeMetrics.getMetricRegistry() != null) {
+        if (this.nodeMetrics.getMetricRegistry() != null) {
             this.nodeMetrics.getMetricRegistry() //
-                .register("jraft-read-only-service-disruptor", new DisruptorMetricSet(this.readIndexQueue));
+            .register("jraft-read-only-service-disruptor", new DisruptorMetricSet(this.readIndexQueue));
         }
         // listen on lastAppliedLogIndex change events.
         this.fsmCaller.addLastAppliedLogIndexListener(this);
 
         // start scanner
-        this.scheduledExecutorService.scheduleAtFixedRate(
-            () -> onApplied(this.fsmCaller.getLastAppliedIndex()),
-            this.raftOptions.getMaxElectionDelayMs(),
-            this.raftOptions.getMaxElectionDelayMs(),
-            TimeUnit.MILLISECONDS
-        );
+        this.scheduledExecutorService.scheduleAtFixedRate(() -> onApplied(this.fsmCaller.getLastAppliedIndex()),
+            this.raftOptions.getMaxElectionDelayMs(), this.raftOptions.getMaxElectionDelayMs(), TimeUnit.MILLISECONDS);
         return true;
     }
 
@@ -260,7 +256,9 @@ public class ReadOnlyServiceImpl implements ReadOnlyService, LastAppliedLogIndex
             return;
         }
         this.shutdownLatch = new CountDownLatch(1);
-        this.readIndexQueue.publishEvent((event, sequence) -> event.shutdownLatch = this.shutdownLatch);
+        Utils.runInThread(() -> {
+            this.readIndexQueue.publishEvent((event, sequence) -> event.shutdownLatch = this.shutdownLatch);
+        });
         this.scheduledExecutorService.shutdown();
     }
 

--- a/jraft-core/src/main/java/com/alipay/sofa/jraft/option/RaftOptions.java
+++ b/jraft-core/src/main/java/com/alipay/sofa/jraft/option/RaftOptions.java
@@ -80,6 +80,19 @@ public class RaftOptions implements Copiable<RaftOptions> {
      * in that case.
      */
     private ReadOnlyOption readOnlyOptions                      = ReadOnlyOption.ReadOnlySafe;
+    /**
+     * Candidate steps down when election reaching timeout, default is true(enabled).
+     * @since 1.3.0
+     */
+    private boolean        stepDownWhenVoteTimedout             = true;
+
+    public boolean isStepDownWhenVoteTimedout() {
+        return this.stepDownWhenVoteTimedout;
+    }
+
+    public void setStepDownWhenVoteTimedout(final boolean stepDownWhenVoteTimeout) {
+        this.stepDownWhenVoteTimedout = stepDownWhenVoteTimeout;
+    }
 
     public int getDisruptorPublishEventWaitTimeoutSecs() {
         return this.disruptorPublishEventWaitTimeoutSecs;
@@ -210,10 +223,10 @@ public class RaftOptions implements Copiable<RaftOptions> {
     }
 
     public boolean isOpenStatistics() {
-        return openStatistics;
+        return this.openStatistics;
     }
 
-    public void setOpenStatistics(boolean openStatistics) {
+    public void setOpenStatistics(final boolean openStatistics) {
         this.openStatistics = openStatistics;
     }
 
@@ -242,13 +255,15 @@ public class RaftOptions implements Copiable<RaftOptions> {
 
     @Override
     public String toString() {
-        return "RaftOptions{" + "maxByteCountPerRpc=" + maxByteCountPerRpc + ", fileCheckHole=" + fileCheckHole
-               + ", maxEntriesSize=" + maxEntriesSize + ", maxBodySize=" + maxBodySize + ", maxAppendBufferSize="
-               + maxAppendBufferSize + ", maxElectionDelayMs=" + maxElectionDelayMs + ", electionHeartbeatFactor="
-               + electionHeartbeatFactor + ", applyBatch=" + applyBatch + ", sync=" + sync + ", syncMeta=" + syncMeta
-               + ", openStatistics=" + openStatistics + ", replicatorPipeline=" + replicatorPipeline
-               + ", maxReplicatorInflightMsgs=" + maxReplicatorInflightMsgs + ", disruptorBufferSize="
-               + disruptorBufferSize + ", disruptorPublishEventWaitTimeoutSecs=" + disruptorPublishEventWaitTimeoutSecs
-               + ", enableLogEntryChecksum=" + enableLogEntryChecksum + ", readOnlyOptions=" + readOnlyOptions + '}';
+        return "RaftOptions{" + "maxByteCountPerRpc=" + this.maxByteCountPerRpc + ", fileCheckHole="
+               + this.fileCheckHole + ", maxEntriesSize=" + this.maxEntriesSize + ", maxBodySize=" + this.maxBodySize
+               + ", maxAppendBufferSize=" + this.maxAppendBufferSize + ", maxElectionDelayMs="
+               + this.maxElectionDelayMs + ", electionHeartbeatFactor=" + this.electionHeartbeatFactor
+               + ", applyBatch=" + this.applyBatch + ", sync=" + this.sync + ", syncMeta=" + this.syncMeta
+               + ", openStatistics=" + this.openStatistics + ", replicatorPipeline=" + this.replicatorPipeline
+               + ", maxReplicatorInflightMsgs=" + this.maxReplicatorInflightMsgs + ", disruptorBufferSize="
+               + this.disruptorBufferSize + ", disruptorPublishEventWaitTimeoutSecs="
+               + this.disruptorPublishEventWaitTimeoutSecs + ", enableLogEntryChecksum=" + this.enableLogEntryChecksum
+               + ", readOnlyOptions=" + this.readOnlyOptions + '}';
     }
 }

--- a/jraft-core/src/main/java/com/alipay/sofa/jraft/storage/impl/LogManagerImpl.java
+++ b/jraft-core/src/main/java/com/alipay/sofa/jraft/storage/impl/LogManagerImpl.java
@@ -752,13 +752,13 @@ public class LogManagerImpl implements LogManager {
         }
         this.readLock.lock();
         try {
-            // out of range, direct return NULL
-            if (index > this.lastLogIndex) {
-                return 0;
-            }
             // check index equal snapshot_index, return snapshot_term
             if (index == this.lastSnapshotId.getIndex()) {
                 return this.lastSnapshotId.getTerm();
+            }
+            // out of range, direct return 0
+            if (index > this.lastLogIndex || index < this.firstLogIndex) {
+                return 0;
             }
             final LogEntry entry = getEntryFromMemory(index);
             if (entry != null) {
@@ -832,12 +832,13 @@ public class LogManagerImpl implements LogManager {
         if (index == 0) {
             return 0;
         }
-        if (index > this.lastLogIndex) {
-            return 0;
-        }
+
         final LogId lss = this.lastSnapshotId;
         if (index == lss.getIndex()) {
             return lss.getTerm();
+        }
+        if (index > this.lastLogIndex || index < this.firstLogIndex) {
+            return 0;
         }
         final LogEntry entry = getEntryFromMemory(index);
         if (entry != null) {

--- a/jraft-core/src/test/java/com/alipay/sofa/jraft/core/NodeTest.java
+++ b/jraft-core/src/test/java/com/alipay/sofa/jraft/core/NodeTest.java
@@ -102,7 +102,7 @@ public class NodeTest {
     @BeforeClass
     public static void setupRocksdbOptions() {
         StorageOptionsFactory.registerRocksDBTableFormatConfig(RocksDBLogStorage.class, StorageOptionsFactory
-            .getDefaultRocksDBTableConfig().setBlockCacheSize(64 * SizeUnit.MB));
+            .getDefaultRocksDBTableConfig().setBlockCacheSize(256 * SizeUnit.MB));
     }
 
     @AfterClass

--- a/jraft-core/src/test/java/com/alipay/sofa/jraft/core/NodeTest.java
+++ b/jraft-core/src/test/java/com/alipay/sofa/jraft/core/NodeTest.java
@@ -44,11 +44,14 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 import org.apache.commons.io.FileUtils;
 import org.junit.After;
+import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TestName;
+import org.rocksdb.util.SizeUnit;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -75,10 +78,12 @@ import com.alipay.sofa.jraft.option.NodeOptions;
 import com.alipay.sofa.jraft.option.RaftOptions;
 import com.alipay.sofa.jraft.rpc.RaftRpcServerFactory;
 import com.alipay.sofa.jraft.storage.SnapshotThrottle;
+import com.alipay.sofa.jraft.storage.impl.RocksDBLogStorage;
 import com.alipay.sofa.jraft.storage.snapshot.SnapshotReader;
 import com.alipay.sofa.jraft.storage.snapshot.ThroughputSnapshotThrottle;
 import com.alipay.sofa.jraft.test.TestUtils;
 import com.alipay.sofa.jraft.util.Endpoint;
+import com.alipay.sofa.jraft.util.StorageOptionsFactory;
 import com.alipay.sofa.jraft.util.Utils;
 import com.codahale.metrics.ConsoleReporter;
 
@@ -93,6 +98,18 @@ public class NodeTest {
 
     @Rule
     public TestName             testName       = new TestName();
+
+    @BeforeClass
+    public static void setupRocksdbOptions() {
+        StorageOptionsFactory.registerRocksDBTableFormatConfig(RocksDBLogStorage.class, StorageOptionsFactory
+            .getDefaultRocksDBTableConfig().setBlockCacheSize(64 * SizeUnit.MB));
+    }
+
+    @AfterClass
+    public static void clearRocksdbOptions() {
+        StorageOptionsFactory.registerRocksDBTableFormatConfig(RocksDBLogStorage.class,
+            StorageOptionsFactory.getDefaultRocksDBTableConfig());
+    }
 
     @Before
     public void setup() throws Exception {

--- a/jraft-core/src/test/java/com/alipay/sofa/jraft/core/NodeTest.java
+++ b/jraft-core/src/test/java/com/alipay/sofa/jraft/core/NodeTest.java
@@ -44,7 +44,6 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 import org.apache.commons.io.FileUtils;
 import org.junit.After;
-import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.BeforeClass;
@@ -103,12 +102,6 @@ public class NodeTest {
     public static void setupRocksdbOptions() {
         StorageOptionsFactory.registerRocksDBTableFormatConfig(RocksDBLogStorage.class, StorageOptionsFactory
             .getDefaultRocksDBTableConfig().setBlockCacheSize(256 * SizeUnit.MB));
-    }
-
-    @AfterClass
-    public static void clearRocksdbOptions() {
-        StorageOptionsFactory.registerRocksDBTableFormatConfig(RocksDBLogStorage.class,
-            StorageOptionsFactory.getDefaultRocksDBTableConfig());
     }
 
     @Before


### PR DESCRIPTION
This PR contains following modifications:

* Randomize first snapshot timeout. In multi raft group, one java process may have several raft groups, they almost startup at same time and will do snapshot at the same time, make the java process has too much pressure.
* `LogManager#getTerm` should check if `index<firstLogIndex`.
* Candidate should steps down when election reaching vote timeout, this idea comes from https://github.com/brpc/braft/commit/725242dec9a9bbcf7a663282bcc65f1ac68568f8
* Adds `MAVEN_OPTS` to travis test.

