### PR TITLE
(fix) Iterator#setErrorAndRollback may break ReadIndex promise, #317

### DIFF
--- a/jraft-core/pom.xml
+++ b/jraft-core/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>jraft-parent</artifactId>
         <groupId>com.alipay.sofa</groupId>
-        <version>1.2.6</version>
+        <version>1.3.0</version>
     </parent>
     <artifactId>jraft-core</artifactId>
     <packaging>jar</packaging>

--- a/jraft-core/src/main/java/com/alipay/sofa/jraft/Iterator.java
+++ b/jraft-core/src/main/java/com/alipay/sofa/jraft/Iterator.java
@@ -69,7 +69,7 @@ public interface Iterator extends java.util.Iterator<ByteBuffer> {
      * would be allowed and you should try to repair this replica or just drop it.
      *
      * @param ntail the number of tasks (starting from the last iterated one)  considered as not to be applied.
-     * @param st Status to describe the detail of the error.
+     * @param st    Status to describe the detail of the error.
      */
     void setErrorAndRollback(final long ntail, final Status st);
 }

--- a/jraft-core/src/main/java/com/alipay/sofa/jraft/Iterator.java
+++ b/jraft-core/src/main/java/com/alipay/sofa/jraft/Iterator.java
@@ -67,8 +67,9 @@ public interface Iterator extends java.util.Iterator<ByteBuffer> {
      * |ntail| tasks (starting from the last iterated one) as not applied. After
      * this point, no further changes on the StateMachine as well as the Node
      * would be allowed and you should try to repair this replica or just drop it.
-     * 
-     * If |statInfo| is not NULL, it should describe the detail of the error.
+     *
+     * @param ntail the number of tasks (starting from the last iterated one)  consider to not be applied.
+     * @param st Status to describe the detail of the error.
      */
     void setErrorAndRollback(final long ntail, final Status st);
 }

--- a/jraft-core/src/main/java/com/alipay/sofa/jraft/Iterator.java
+++ b/jraft-core/src/main/java/com/alipay/sofa/jraft/Iterator.java
@@ -68,7 +68,7 @@ public interface Iterator extends java.util.Iterator<ByteBuffer> {
      * this point, no further changes on the StateMachine as well as the Node
      * would be allowed and you should try to repair this replica or just drop it.
      *
-     * @param ntail the number of tasks (starting from the last iterated one)  consider to not be applied.
+     * @param ntail the number of tasks (starting from the last iterated one)  considered as not to be applied.
      * @param st Status to describe the detail of the error.
      */
     void setErrorAndRollback(final long ntail, final Status st);

--- a/jraft-core/src/main/java/com/alipay/sofa/jraft/ReadOnlyService.java
+++ b/jraft-core/src/main/java/com/alipay/sofa/jraft/ReadOnlyService.java
@@ -46,8 +46,8 @@ public interface ReadOnlyService extends Lifecycle<ReadOnlyServiceOptions> {
 
     /**
      * Called when the node is turned into error state.
-     * @param error
+     * @param error error with raft info
      */
-    public void setError(final RaftException error);
+    void setError(final RaftException error);
 
 }

--- a/jraft-core/src/main/java/com/alipay/sofa/jraft/ReadOnlyService.java
+++ b/jraft-core/src/main/java/com/alipay/sofa/jraft/ReadOnlyService.java
@@ -17,6 +17,7 @@
 package com.alipay.sofa.jraft;
 
 import com.alipay.sofa.jraft.closure.ReadIndexClosure;
+import com.alipay.sofa.jraft.error.RaftException;
 import com.alipay.sofa.jraft.option.ReadOnlyServiceOptions;
 
 /**
@@ -42,5 +43,11 @@ public interface ReadOnlyService extends Lifecycle<ReadOnlyServiceOptions> {
      *         while waiting
      */
     void join() throws InterruptedException;
+
+    /**
+     * Called when the node is turned into error state.
+     * @param error
+     */
+    public void setError(final RaftException error);
 
 }

--- a/jraft-core/src/main/java/com/alipay/sofa/jraft/core/FSMCallerImpl.java
+++ b/jraft-core/src/main/java/com/alipay/sofa/jraft/core/FSMCallerImpl.java
@@ -515,10 +515,10 @@ public class FSMCallerImpl implements FSMCaller {
             final long lastIndex = iterImpl.getIndex() - 1;
             final long lastTerm = this.logManager.getTerm(lastIndex);
             final LogId lastAppliedId = new LogId(lastIndex, lastTerm);
-            this.lastAppliedIndex.set(committedIndex);
+            this.lastAppliedIndex.set(lastIndex);
             this.lastAppliedTerm = lastTerm;
             this.logManager.setAppliedId(lastAppliedId);
-            notifyLastAppliedIndexUpdated(committedIndex);
+            notifyLastAppliedIndexUpdated(lastIndex);
         } finally {
             this.nodeMetrics.recordLatency("fsm-commit", Utils.monotonicMs() - startMs);
         }

--- a/jraft-core/src/main/java/com/alipay/sofa/jraft/core/NodeImpl.java
+++ b/jraft-core/src/main/java/com/alipay/sofa/jraft/core/NodeImpl.java
@@ -2373,6 +2373,9 @@ public class NodeImpl implements Node, RaftServerService {
             // onError of fsmCaller is guaranteed to be executed once.
             this.fsmCaller.onError(error);
         }
+        if (this.readOnlyService != null) {
+            this.readOnlyService.setError(error);
+        }
         this.writeLock.lock();
         try {
             // If it is leader, need to wake up a new one;

--- a/jraft-core/src/main/java/com/alipay/sofa/jraft/core/ReadOnlyServiceImpl.java
+++ b/jraft-core/src/main/java/com/alipay/sofa/jraft/core/ReadOnlyServiceImpl.java
@@ -39,6 +39,7 @@ import com.alipay.sofa.jraft.closure.ReadIndexClosure;
 import com.alipay.sofa.jraft.entity.ReadIndexState;
 import com.alipay.sofa.jraft.entity.ReadIndexStatus;
 import com.alipay.sofa.jraft.error.RaftError;
+import com.alipay.sofa.jraft.error.RaftException;
 import com.alipay.sofa.jraft.option.RaftOptions;
 import com.alipay.sofa.jraft.option.ReadOnlyServiceOptions;
 import com.alipay.sofa.jraft.rpc.RpcRequests.ReadIndexRequest;
@@ -81,6 +82,8 @@ public class ReadOnlyServiceImpl implements ReadOnlyService, LastAppliedLogIndex
     private ScheduledExecutorService                   scheduledExecutorService;
 
     private NodeMetrics                                nodeMetrics;
+
+    private volatile RaftException                     error;
 
     // <logIndex, statusList>
     private final TreeMap<Long, List<ReadIndexStatus>> pendingNotifyStatus         = new TreeMap<>();
@@ -217,6 +220,20 @@ public class ReadOnlyServiceImpl implements ReadOnlyService, LastAppliedLogIndex
         this.node.handleReadIndexRequest(request, new ReadIndexResponseClosure(states, request));
     }
 
+    private void resetPendingStatusError(final Status st) {
+        this.lock.lock();
+        try {
+            for (List<ReadIndexStatus> statuses : this.pendingNotifyStatus.values()) {
+                for (ReadIndexStatus status : statuses) {
+                    reportError(status, st);
+                }
+            }
+            this.pendingNotifyStatus.clear();
+        } finally {
+            this.lock.unlock();
+        }
+    }
+
     @Override
     public boolean init(final ReadOnlyServiceOptions opts) {
         this.node = opts.getNode();
@@ -251,6 +268,13 @@ public class ReadOnlyServiceImpl implements ReadOnlyService, LastAppliedLogIndex
     }
 
     @Override
+    public synchronized void setError(final RaftException error) {
+        if (this.error == null) {
+            this.error = error;
+        }
+    }
+
+    @Override
     public synchronized void shutdown() {
         if (this.shutdownLatch != null) {
             return;
@@ -268,6 +292,7 @@ public class ReadOnlyServiceImpl implements ReadOnlyService, LastAppliedLogIndex
             this.shutdownLatch.await();
         }
         this.readIndexDisruptor.shutdown();
+        resetPendingStatusError(new Status(RaftError.ESTOP, "Node is quit."));
         this.scheduledExecutorService.awaitTermination(5, TimeUnit.SECONDS);
     }
 
@@ -332,6 +357,10 @@ public class ReadOnlyServiceImpl implements ReadOnlyService, LastAppliedLogIndex
                 }
 
             }
+            // Remaining statuses are notified by error if presents.
+            if (this.error != null) {
+                resetPendingStatusError(this.error.getStatus());
+            }
         } finally {
             this.lock.unlock();
             if (pendingStatuses != null && !pendingStatuses.isEmpty()) {
@@ -355,6 +384,20 @@ public class ReadOnlyServiceImpl implements ReadOnlyService, LastAppliedLogIndex
     @OnlyForTest
     TreeMap<Long, List<ReadIndexStatus>> getPendingNotifyStatus() {
         return this.pendingNotifyStatus;
+    }
+
+    private void reportError(final ReadIndexStatus status, final Status st) {
+        final long nowMs = Utils.monotonicMs();
+        final List<ReadIndexState> states = status.getStates();
+        final int taskCount = states.size();
+        for (int i = 0; i < taskCount; i++) {
+            final ReadIndexState task = states.get(i);
+            final ReadIndexClosure done = task.getDone();
+            if (done != null) {
+                this.nodeMetrics.recordLatency("read-index", nowMs - task.getStartTimeMs());
+                done.run(st);
+            }
+        }
     }
 
     private void notifySuccess(final ReadIndexStatus status) {

--- a/jraft-core/src/main/java/com/alipay/sofa/jraft/core/ReadOnlyServiceImpl.java
+++ b/jraft-core/src/main/java/com/alipay/sofa/jraft/core/ReadOnlyServiceImpl.java
@@ -357,7 +357,13 @@ public class ReadOnlyServiceImpl implements ReadOnlyService, LastAppliedLogIndex
                 }
 
             }
-            // Remaining statuses are notified by error if presents.
+
+            /**
+             * Remaining pending statuses are notified by error if it is presented.
+             * When the node is in error state, consider following situations:
+             * 1. If commitIndex > appliedIndex, then all pending statuses should be notified by error status.
+             * 2. When commitIndex == appliedIndex, there will be no more pending statuses.
+             */
             if (this.error != null) {
                 resetPendingStatusError(this.error.getStatus());
             }

--- a/jraft-core/src/main/java/com/alipay/sofa/jraft/core/ReadOnlyServiceImpl.java
+++ b/jraft-core/src/main/java/com/alipay/sofa/jraft/core/ReadOnlyServiceImpl.java
@@ -223,8 +223,8 @@ public class ReadOnlyServiceImpl implements ReadOnlyService, LastAppliedLogIndex
     private void resetPendingStatusError(final Status st) {
         this.lock.lock();
         try {
-            for (List<ReadIndexStatus> statuses : this.pendingNotifyStatus.values()) {
-                for (ReadIndexStatus status : statuses) {
+            for (final List<ReadIndexStatus> statuses : this.pendingNotifyStatus.values()) {
+                for (final ReadIndexStatus status : statuses) {
                     reportError(status, st);
                 }
             }
@@ -280,9 +280,8 @@ public class ReadOnlyServiceImpl implements ReadOnlyService, LastAppliedLogIndex
             return;
         }
         this.shutdownLatch = new CountDownLatch(1);
-        Utils.runInThread(() -> {
-            this.readIndexQueue.publishEvent((event, sequence) -> event.shutdownLatch = this.shutdownLatch);
-        });
+        Utils.runInThread(
+                () -> this.readIndexQueue.publishEvent((event, sequence) -> event.shutdownLatch = this.shutdownLatch));
         this.scheduledExecutorService.shutdown();
     }
 
@@ -358,7 +357,7 @@ public class ReadOnlyServiceImpl implements ReadOnlyService, LastAppliedLogIndex
 
             }
 
-            /**
+            /*
              * Remaining pending statuses are notified by error if it is presented.
              * When the node is in error state, consider following situations:
              * 1. If commitIndex > appliedIndex, then all pending statuses should be notified by error status.

--- a/jraft-core/src/main/java/com/alipay/sofa/jraft/core/Replicator.java
+++ b/jraft-core/src/main/java/com/alipay/sofa/jraft/core/Replicator.java
@@ -753,7 +753,7 @@ public class Replicator implements ThreadId.OnError {
         }
         emb.setTerm(entry.getId().getTerm());
         if (entry.hasChecksum()) {
-            emb.setChecksum(entry.getChecksum()); //since 1.2.6
+            emb.setChecksum(entry.getChecksum()); // since 1.2.6
         }
         emb.setType(entry.getType());
         if (entry.getPeers() != null) {

--- a/jraft-core/src/main/java/com/alipay/sofa/jraft/entity/ReadIndexStatus.java
+++ b/jraft-core/src/main/java/com/alipay/sofa/jraft/entity/ReadIndexStatus.java
@@ -27,9 +27,9 @@ import com.alipay.sofa.jraft.rpc.RpcRequests.ReadIndexRequest;
  */
 public class ReadIndexStatus {
 
-    private final ReadIndexRequest     request; //raw request
-    private final List<ReadIndexState> states; //read index requests in batch.
-    private final long                 index;  //committed log index.
+    private final ReadIndexRequest     request; // raw request
+    private final List<ReadIndexState> states; // read index requests in batch.
+    private final long                 index;  // committed log index.
 
     public ReadIndexStatus(List<ReadIndexState> states, ReadIndexRequest request, long index) {
         super();

--- a/jraft-core/src/test/java/com/alipay/sofa/jraft/core/NodeTest.java
+++ b/jraft-core/src/test/java/com/alipay/sofa/jraft/core/NodeTest.java
@@ -207,6 +207,10 @@ public class NodeTest {
         }
     }
 
+    /**
+     * Test rollback stateMachine with readIndex for issue 317:
+     * https://github.com/sofastack/sofa-jraft/issues/317
+     */
     @Test
     public void testRollbackStateMachineWithReadIndex_Issue317() throws Exception {
         final Endpoint addr = new Endpoint(TestUtils.getMyIp(), TestUtils.INIT_PORT);

--- a/jraft-core/src/test/java/com/alipay/sofa/jraft/core/NodeTest.java
+++ b/jraft-core/src/test/java/com/alipay/sofa/jraft/core/NodeTest.java
@@ -288,6 +288,9 @@ public class NodeTest {
                         } else {
                             assertTrue(status.getErrorMsg().contains(errorMsg));
                         }
+                    } catch (Exception e) {
+                        System.out.println("unexpected status: " + status);
+                        e.printStackTrace();
                     } finally {
                         latch.countDown();
                     }

--- a/jraft-example/pom.xml
+++ b/jraft-example/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>jraft-parent</artifactId>
         <groupId>com.alipay.sofa</groupId>
-        <version>1.2.6</version>
+        <version>1.3.0</version>
     </parent>
     <artifactId>jraft-example</artifactId>
     <packaging>jar</packaging>

--- a/jraft-rheakv/pom.xml
+++ b/jraft-rheakv/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>jraft-parent</artifactId>
         <groupId>com.alipay.sofa</groupId>
-        <version>1.2.6</version>
+        <version>1.3.0</version>
     </parent>
 
     <artifactId>jraft-rheakv</artifactId>

--- a/jraft-rheakv/rheakv-core/pom.xml
+++ b/jraft-rheakv/rheakv-core/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>jraft-rheakv</artifactId>
         <groupId>com.alipay.sofa</groupId>
-        <version>1.2.6</version>
+        <version>1.3.0</version>
     </parent>
 
     <artifactId>jraft-rheakv-core</artifactId>

--- a/jraft-rheakv/rheakv-pd/pom.xml
+++ b/jraft-rheakv/rheakv-pd/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>jraft-rheakv</artifactId>
         <groupId>com.alipay.sofa</groupId>
-        <version>1.2.6</version>
+        <version>1.3.0</version>
     </parent>
 
     <artifactId>jraft-rheakv-pd</artifactId>

--- a/jraft-test/pom.xml
+++ b/jraft-test/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>jraft-parent</artifactId>
         <groupId>com.alipay.sofa</groupId>
-        <version>1.2.6</version>
+        <version>1.3.0</version>
     </parent>
     <artifactId>jraft-test</artifactId>
     <packaging>jar</packaging>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>com.alipay.sofa</groupId>
     <artifactId>jraft-parent</artifactId>
-    <version>1.2.6</version>
+    <version>1.3.0</version>
     <packaging>pom</packaging>
 
     <name>${project.groupId}:${project.artifactId}</name>


### PR DESCRIPTION
### Motivation:

Try to fix #317 

### Modification:

* A test case to reproduce this issue.
* Notify with `lastIndex` instead of `commitIndex` in `FSMCaller#doCommit`
* Reset pending read index statuses with error if it presents.

### Result:

Fixes #317 
