### PR TITLE
Improve first snapshot time

### DIFF
--- a/jraft-core/src/main/java/com/alipay/sofa/jraft/core/NodeImpl.java
+++ b/jraft-core/src/main/java/com/alipay/sofa/jraft/core/NodeImpl.java
@@ -922,7 +922,8 @@ public class NodeImpl implements Node, RaftServerService {
                 // Randomize the first snapshot trigger timeout
                 this.firstSchedule = false;
                 if (timeoutMs > 0) {
-                    return ThreadLocalRandom.current().nextInt(timeoutMs) + 1;
+                    int half = timeoutMs / 2;
+                    return half + ThreadLocalRandom.current().nextInt(half);
                 } else {
                     return timeoutMs;
                 }


### PR DESCRIPTION

### Motivation:

Right now, we randomize the first snapshot timeout in the range `[1..snapshotIntervalSecs)`.

This timeout range is too large, and we don't want to trigger snapshot too early and i think we should try to respect the user setting `snapshotIntervalSecs`. So in this PR we change the range to `[snapshotIntervalSecs/2, snapshotIntervalSecs)`,then the randomized timeout value is at least the half of `snapshotIntervalSecs`.

