### PR TITLE
Limit NodeManager cannot be new

### DIFF
--- a/jraft-core/src/main/java/com/alipay/sofa/jraft/NodeManager.java
+++ b/jraft-core/src/main/java/com/alipay/sofa/jraft/NodeManager.java
@@ -142,4 +142,7 @@ public class NodeManager {
     public List<Node> getAllNodes() {
         return this.groupMap.values().stream().flatMap(Collection::stream).collect(Collectors.toList());
     }
+
+    private NodeManager() {
+    }
 }


### PR DESCRIPTION
### Motivation:

NodeManager is hungry , so limit NodeManager cannot be new

### Modification:

Add private initialization method

### Result:

No other impact