### PR TITLE
(feat) Impl SegmentList to replace ArrayDequeue in LogManagerImpl, #335

### DIFF
--- a/jraft-core/src/main/java/com/alipay/sofa/jraft/core/Replicator.java
+++ b/jraft-core/src/main/java/com/alipay/sofa/jraft/core/Replicator.java
@@ -1048,7 +1048,6 @@ public class Replicator implements ThreadId.OnError {
     void destroy() {
         final ThreadId savedId = this.id;
         LOG.info("Replicator {} is going to quit", savedId);
-        this.id = null;
         releaseReader();
         // Unregister replicator metric set
         if (this.nodeMetrics.isEnabled()) {
@@ -1058,6 +1057,7 @@ public class Replicator implements ThreadId.OnError {
         this.state = State.Destroyed;
         notifyReplicatorStatusListener((Replicator) savedId.getData(), ReplicatorEvent.DESTROYED);
         savedId.unlockAndDestroy();
+        this.id = null;
     }
 
     private void releaseReader() {

--- a/jraft-core/src/main/java/com/alipay/sofa/jraft/storage/impl/LogManagerImpl.java
+++ b/jraft-core/src/main/java/com/alipay/sofa/jraft/storage/impl/LogManagerImpl.java
@@ -56,6 +56,7 @@ import com.alipay.sofa.jraft.util.DisruptorMetricSet;
 import com.alipay.sofa.jraft.util.LogExceptionHandler;
 import com.alipay.sofa.jraft.util.NamedThreadFactory;
 import com.alipay.sofa.jraft.util.Requires;
+import com.alipay.sofa.jraft.util.SegmentList;
 import com.alipay.sofa.jraft.util.ThreadHelper;
 import com.alipay.sofa.jraft.util.Utils;
 import com.lmax.disruptor.EventFactory;
@@ -91,7 +92,7 @@ public class LogManagerImpl implements LogManager {
     private LogId                                            diskId                 = new LogId(0, 0);
     private LogId                                            appliedId              = new LogId(0, 0);
     // TODO  use a lock-free concurrent list instead?
-    private ArrayDeque<LogEntry>                             logsInMemory           = new ArrayDeque<>();
+    private final SegmentList<LogEntry>                      logsInMemory           = new SegmentList<>();
     private volatile long                                    firstLogIndex;
     private volatile long                                    lastLogIndex;
     private volatile LogId                                   lastSnapshotId         = new LogId(0, 0);
@@ -253,16 +254,8 @@ public class LogManagerImpl implements LogManager {
     private void clearMemoryLogs(final LogId id) {
         this.writeLock.lock();
         try {
-            int index = 0;
-            for (final int size = this.logsInMemory.size(); index < size; index++) {
-                final LogEntry entry = this.logsInMemory.get(index);
-                if (entry.getId().compareTo(id) > 0) {
-                    break;
-                }
-            }
-            if (index > 0) {
-                this.logsInMemory.removeRange(0, index);
-            }
+
+            this.logsInMemory.removeFromFirstWhen(entry -> entry.getId().compareTo(id) <= 0);
         } finally {
             this.writeLock.unlock();
         }
@@ -698,7 +691,8 @@ public class LogManagerImpl implements LogManager {
     private String descLogsInMemory() {
         final StringBuilder sb = new StringBuilder();
         boolean wasFirst = true;
-        for (final LogEntry logEntry : this.logsInMemory) {
+        for (int i = 0; i < this.logsInMemory.size(); i++) {
+            LogEntry logEntry = this.logsInMemory.get(i);
             if (!wasFirst) {
                 sb.append(",");
             } else {
@@ -933,20 +927,12 @@ public class LogManagerImpl implements LogManager {
     }
 
     private boolean truncatePrefix(final long firstIndexKept) {
-        int index = 0;
-        for (final int size = this.logsInMemory.size(); index < size; index++) {
-            final LogEntry entry = this.logsInMemory.get(index);
-            if (entry.getId().getIndex() >= firstIndexKept) {
-                break;
-            }
-        }
-        if (index > 0) {
-            this.logsInMemory.removeRange(0, index);
-        }
+
+        this.logsInMemory.removeFromFirstWhen(entry -> entry.getId().getIndex() < firstIndexKept);
 
         // TODO  maybe it's fine here
         Requires.requireTrue(firstIndexKept >= this.firstLogIndex,
-            "Try to truncate logs before %d, but the firstLogIndex is %d", firstIndexKept, this.firstLogIndex);
+                "Try to truncate logs before %d, but the firstLogIndex is %d", firstIndexKept, this.firstLogIndex);
 
         this.firstLogIndex = firstIndexKept;
         if (firstIndexKept > this.lastLogIndex) {
@@ -963,7 +949,7 @@ public class LogManagerImpl implements LogManager {
     private boolean reset(final long nextLogIndex) {
         this.writeLock.lock();
         try {
-            this.logsInMemory = new ArrayDeque<>();
+            this.logsInMemory.clear();
             this.firstLogIndex = nextLogIndex;
             this.lastLogIndex = nextLogIndex - 1;
             this.configManager.truncatePrefix(this.firstLogIndex);
@@ -982,14 +968,9 @@ public class LogManagerImpl implements LogManager {
                 lastIndexKept);
             return;
         }
-        while (!this.logsInMemory.isEmpty()) {
-            final LogEntry entry = this.logsInMemory.peekLast();
-            if (entry.getId().getIndex() > lastIndexKept) {
-                this.logsInMemory.pollLast();
-            } else {
-                break;
-            }
-        }
+
+        this.logsInMemory.removeFromLastWhen(entry -> entry.getId().getIndex() > lastIndexKept);
+
         this.lastLogIndex = lastIndexKept;
         final long lastTermKept = unsafeGetTerm(lastIndexKept);
         Requires.requireTrue(this.lastLogIndex == 0 || lastTermKept != 0);

--- a/jraft-core/src/main/java/com/alipay/sofa/jraft/storage/impl/LogManagerImpl.java
+++ b/jraft-core/src/main/java/com/alipay/sofa/jraft/storage/impl/LogManagerImpl.java
@@ -91,7 +91,6 @@ public class LogManagerImpl implements LogManager {
     private long                                             nextWaitId;
     private LogId                                            diskId                 = new LogId(0, 0);
     private LogId                                            appliedId              = new LogId(0, 0);
-    // TODO  use a lock-free concurrent list instead?
     private final SegmentList<LogEntry>                      logsInMemory           = new SegmentList<>(true);
     private volatile long                                    firstLogIndex;
     private volatile long                                    lastLogIndex;
@@ -166,62 +165,62 @@ public class LogManagerImpl implements LogManager {
     }
 
     @Override
-        public boolean init(final LogManagerOptions opts) {
-            this.writeLock.lock();
-            try {
-                if (opts.getLogStorage() == null) {
-                    LOG.error("Fail to init log manager, log storage is null");
-                    return false;
-                }
-                this.raftOptions = opts.getRaftOptions();
-                this.nodeMetrics = opts.getNodeMetrics();
-                this.logStorage = opts.getLogStorage();
-                this.configManager = opts.getConfigurationManager();
-
-                LogStorageOptions lsOpts = new LogStorageOptions();
-                lsOpts.setConfigurationManager(this.configManager);
-                lsOpts.setLogEntryCodecFactory(opts.getLogEntryCodecFactory());
-
-                if (!this.logStorage.init(lsOpts)) {
-                    LOG.error("Fail to init logStorage");
-                    return false;
-                }
-                this.firstLogIndex = this.logStorage.getFirstLogIndex();
-                this.lastLogIndex = this.logStorage.getLastLogIndex();
-                this.diskId = new LogId(this.lastLogIndex, getTermFromLogStorage(this.lastLogIndex));
-                this.fsmCaller = opts.getFsmCaller();
-                this.disruptor = DisruptorBuilder.<StableClosureEvent> newInstance() //
-                        .setEventFactory(new StableClosureEventFactory()) //
-                        .setRingBufferSize(opts.getDisruptorBufferSize()) //
-                        .setThreadFactory(new NamedThreadFactory("JRaft-LogManager-Disruptor-", true)) //
-                        .setProducerType(ProducerType.MULTI) //
-                        /*
-                         *  Use timeout strategy in log manager. If timeout happens, it will called reportError to halt the node.
-                         */
-                        .setWaitStrategy(new TimeoutBlockingWaitStrategy(
-                            this.raftOptions.getDisruptorPublishEventWaitTimeoutSecs(), TimeUnit.SECONDS)) //
-                        .build();
-                this.disruptor.handleEventsWith(new StableClosureEventHandler());
-                this.disruptor.setDefaultExceptionHandler(new LogExceptionHandler<Object>(this.getClass().getSimpleName(),
-                        (event, ex) -> reportError(-1, "LogManager handle event error")));
-                this.diskQueue = this.disruptor.start();
-                if (this.nodeMetrics.getMetricRegistry() != null) {
-                    this.nodeMetrics.getMetricRegistry().register("jraft-log-manager-disruptor",
-                        new DisruptorMetricSet(this.diskQueue));
-                }
-            } finally {
-                this.writeLock.unlock();
+    public boolean init(final LogManagerOptions opts) {
+        this.writeLock.lock();
+        try {
+            if (opts.getLogStorage() == null) {
+                LOG.error("Fail to init log manager, log storage is null");
+                return false;
             }
-            return true;
+            this.raftOptions = opts.getRaftOptions();
+            this.nodeMetrics = opts.getNodeMetrics();
+            this.logStorage = opts.getLogStorage();
+            this.configManager = opts.getConfigurationManager();
+
+            LogStorageOptions lsOpts = new LogStorageOptions();
+            lsOpts.setConfigurationManager(this.configManager);
+            lsOpts.setLogEntryCodecFactory(opts.getLogEntryCodecFactory());
+
+            if (!this.logStorage.init(lsOpts)) {
+                LOG.error("Fail to init logStorage");
+                return false;
+            }
+            this.firstLogIndex = this.logStorage.getFirstLogIndex();
+            this.lastLogIndex = this.logStorage.getLastLogIndex();
+            this.diskId = new LogId(this.lastLogIndex, getTermFromLogStorage(this.lastLogIndex));
+            this.fsmCaller = opts.getFsmCaller();
+            this.disruptor = DisruptorBuilder.<StableClosureEvent> newInstance() //
+                    .setEventFactory(new StableClosureEventFactory()) //
+                    .setRingBufferSize(opts.getDisruptorBufferSize()) //
+                    .setThreadFactory(new NamedThreadFactory("JRaft-LogManager-Disruptor-", true)) //
+                    .setProducerType(ProducerType.MULTI) //
+                    /*
+                     *  Use timeout strategy in log manager. If timeout happens, it will called reportError to halt the node.
+                     */
+                    .setWaitStrategy(new TimeoutBlockingWaitStrategy(
+                        this.raftOptions.getDisruptorPublishEventWaitTimeoutSecs(), TimeUnit.SECONDS)) //
+                    .build();
+            this.disruptor.handleEventsWith(new StableClosureEventHandler());
+            this.disruptor.setDefaultExceptionHandler(new LogExceptionHandler<Object>(this.getClass().getSimpleName(),
+                    (event, ex) -> reportError(-1, "LogManager handle event error")));
+            this.diskQueue = this.disruptor.start();
+            if (this.nodeMetrics.getMetricRegistry() != null) {
+                this.nodeMetrics.getMetricRegistry().register("jraft-log-manager-disruptor",
+                    new DisruptorMetricSet(this.diskQueue));
+            }
+        } finally {
+            this.writeLock.unlock();
         }
+        return true;
+    }
 
     private void stopDiskThread() {
-            this.shutDownLatch = new CountDownLatch(1);
-            Utils.runInThread(() -> this.diskQueue.publishEvent((event, sequence) -> {
-                event.reset();
-                event.type = EventType.SHUTDOWN;
-            }));
-        }
+        this.shutDownLatch = new CountDownLatch(1);
+        Utils.runInThread(() -> this.diskQueue.publishEvent((event, sequence) -> {
+            event.reset();
+            event.type = EventType.SHUTDOWN;
+        }));
+    }
 
     @Override
     public void join() throws InterruptedException {
@@ -252,14 +251,14 @@ public class LogManagerImpl implements LogManager {
     }
 
     private void clearMemoryLogs(final LogId id) {
-            this.writeLock.lock();
-            try {
+        this.writeLock.lock();
+        try {
 
-                this.logsInMemory.removeFromFirstWhen(entry -> entry.getId().compareTo(id) <= 0);
-            } finally {
-                this.writeLock.unlock();
-            }
+            this.logsInMemory.removeFromFirstWhen(entry -> entry.getId().compareTo(id) <= 0);
+        } finally {
+            this.writeLock.unlock();
         }
+    }
 
     private static class LastLogIdClosure extends StableClosure {
 
@@ -288,86 +287,86 @@ public class LogManagerImpl implements LogManager {
     }
 
     @Override
-        public void appendEntries(final List<LogEntry> entries, final StableClosure done) {
-            Requires.requireNonNull(done, "done");
-            if (this.hasError) {
+    public void appendEntries(final List<LogEntry> entries, final StableClosure done) {
+        Requires.requireNonNull(done, "done");
+        if (this.hasError) {
+            entries.clear();
+            Utils.runClosureInThread(done, new Status(RaftError.EIO, "Corrupted LogStorage"));
+            return;
+        }
+        boolean doUnlock = true;
+        this.writeLock.lock();
+        try {
+            if (!entries.isEmpty() && !checkAndResolveConflict(entries, done)) {
                 entries.clear();
-                Utils.runClosureInThread(done, new Status(RaftError.EIO, "Corrupted LogStorage"));
+                Utils.runClosureInThread(done, new Status(RaftError.EINTERNAL, "Fail to checkAndResolveConflict."));
                 return;
             }
-            boolean doUnlock = true;
-            this.writeLock.lock();
-            try {
-                if (!entries.isEmpty() && !checkAndResolveConflict(entries, done)) {
-                    entries.clear();
-                    Utils.runClosureInThread(done, new Status(RaftError.EINTERNAL, "Fail to checkAndResolveConflict."));
-                    return;
+            for (int i = 0; i < entries.size(); i++) {
+                final LogEntry entry = entries.get(i);
+                // Set checksum after checkAndResolveConflict
+                if (this.raftOptions.isEnableLogEntryChecksum()) {
+                    entry.setChecksum(entry.checksum());
                 }
-                for (int i = 0; i < entries.size(); i++) {
-                    final LogEntry entry = entries.get(i);
-                    // Set checksum after checkAndResolveConflict
-                    if (this.raftOptions.isEnableLogEntryChecksum()) {
-                        entry.setChecksum(entry.checksum());
+                if (entry.getType() == EntryType.ENTRY_TYPE_CONFIGURATION) {
+                    Configuration oldConf = new Configuration();
+                    if (entry.getOldPeers() != null) {
+                        oldConf = new Configuration(entry.getOldPeers(), entry.getOldLearners());
                     }
-                    if (entry.getType() == EntryType.ENTRY_TYPE_CONFIGURATION) {
-                        Configuration oldConf = new Configuration();
-                        if (entry.getOldPeers() != null) {
-                            oldConf = new Configuration(entry.getOldPeers(), entry.getOldLearners());
-                        }
-                        final ConfigurationEntry conf = new ConfigurationEntry(entry.getId(),
-                            new Configuration(entry.getPeers(), entry.getLearners()), oldConf);
-                        this.configManager.add(conf);
-                    }
-                }
-                if (!entries.isEmpty()) {
-                    done.setFirstLogIndex(entries.get(0).getId().getIndex());
-                    this.logsInMemory.addAll(entries);
-                }
-                done.setEntries(entries);
-
-                int retryTimes = 0;
-                final EventTranslator<StableClosureEvent> translator = (event, sequence) -> {
-                    event.reset();
-                    event.type = EventType.OTHER;
-                    event.done = done;
-                };
-                while (true) {
-                    if (tryOfferEvent(done, translator)) {
-                        break;
-                    } else {
-                        retryTimes++;
-                        if (retryTimes > APPEND_LOG_RETRY_TIMES) {
-                            reportError(RaftError.EBUSY.getNumber(), "LogManager is busy, disk queue overload.");
-                            return;
-                        }
-                        ThreadHelper.onSpinWait();
-                    }
-                }
-                doUnlock = false;
-                if (!wakeupAllWaiter(this.writeLock)) {
-                    notifyLastLogIndexListeners();
-                }
-            } finally {
-                if (doUnlock) {
-                    this.writeLock.unlock();
+                    final ConfigurationEntry conf = new ConfigurationEntry(entry.getId(),
+                        new Configuration(entry.getPeers(), entry.getLearners()), oldConf);
+                    this.configManager.add(conf);
                 }
             }
+            if (!entries.isEmpty()) {
+                done.setFirstLogIndex(entries.get(0).getId().getIndex());
+                this.logsInMemory.addAll(entries);
+            }
+            done.setEntries(entries);
+
+            int retryTimes = 0;
+            final EventTranslator<StableClosureEvent> translator = (event, sequence) -> {
+                event.reset();
+                event.type = EventType.OTHER;
+                event.done = done;
+            };
+            while (true) {
+                if (tryOfferEvent(done, translator)) {
+                    break;
+                } else {
+                    retryTimes++;
+                    if (retryTimes > APPEND_LOG_RETRY_TIMES) {
+                        reportError(RaftError.EBUSY.getNumber(), "LogManager is busy, disk queue overload.");
+                        return;
+                    }
+                    ThreadHelper.onSpinWait();
+                }
+            }
+            doUnlock = false;
+            if (!wakeupAllWaiter(this.writeLock)) {
+                notifyLastLogIndexListeners();
+            }
+        } finally {
+            if (doUnlock) {
+                this.writeLock.unlock();
+            }
         }
+    }
 
     private void offerEvent(final StableClosure done, final EventType type) {
-            if (this.stopped) {
-                Utils.runClosureInThread(done, new Status(RaftError.ESTOP, "Log manager is stopped."));
-                return;
-            }
-            if (!this.diskQueue.tryPublishEvent((event, sequence) -> {
-                event.reset();
-                event.type = type;
-                event.done = done;
-            })) {
-                reportError(RaftError.EBUSY.getNumber(), "Log manager is overload.");
-                Utils.runClosureInThread(done, new Status(RaftError.EBUSY, "Log manager is overload."));
-            }
+        if (this.stopped) {
+            Utils.runClosureInThread(done, new Status(RaftError.ESTOP, "Log manager is stopped."));
+            return;
         }
+        if (!this.diskQueue.tryPublishEvent((event, sequence) -> {
+            event.reset();
+            event.type = type;
+            event.done = done;
+        })) {
+            reportError(RaftError.EBUSY.getNumber(), "Log manager is overload.");
+            Utils.runClosureInThread(done, new Status(RaftError.EBUSY, "Log manager is overload."));
+        }
+    }
 
     private boolean tryOfferEvent(final StableClosure done, final EventTranslator<StableClosureEvent> translator) {
         if (this.stopped) {
@@ -391,23 +390,23 @@ public class LogManagerImpl implements LogManager {
     }
 
     private boolean wakeupAllWaiter(final Lock lock) {
-            if (this.waitMap.isEmpty()) {
-                lock.unlock();
-                return false;
-            }
-            final List<WaitMeta> wms = new ArrayList<>(this.waitMap.values());
-            final int errCode = this.stopped ? RaftError.ESTOP.getNumber() : RaftError.SUCCESS.getNumber();
-            this.waitMap.clear();
+        if (this.waitMap.isEmpty()) {
             lock.unlock();
-
-            final int waiterCount = wms.size();
-            for (int i = 0; i < waiterCount; i++) {
-                final WaitMeta wm = wms.get(i);
-                wm.errorCode = errCode;
-                Utils.runInThread(() -> runOnNewLog(wm));
-            }
-            return true;
+            return false;
         }
+        final List<WaitMeta> wms = new ArrayList<>(this.waitMap.values());
+        final int errCode = this.stopped ? RaftError.ESTOP.getNumber() : RaftError.SUCCESS.getNumber();
+        this.waitMap.clear();
+        lock.unlock();
+
+        final int waiterCount = wms.size();
+        for (int i = 0; i < waiterCount; i++) {
+            final WaitMeta wm = wms.get(i);
+            wm.errorCode = errCode;
+            Utils.runInThread(() -> runOnNewLog(wm));
+        }
+        return true;
+    }
 
     private LogId appendToStorage(final List<LogEntry> toAppend) {
         LogId lastId = null;
@@ -928,23 +927,23 @@ public class LogManagerImpl implements LogManager {
 
     private boolean truncatePrefix(final long firstIndexKept) {
 
-            this.logsInMemory.removeFromFirstWhen(entry -> entry.getId().getIndex() < firstIndexKept);
+        this.logsInMemory.removeFromFirstWhen(entry -> entry.getId().getIndex() < firstIndexKept);
 
-            // TODO  maybe it's fine here
-            Requires.requireTrue(firstIndexKept >= this.firstLogIndex,
-                    "Try to truncate logs before %d, but the firstLogIndex is %d", firstIndexKept, this.firstLogIndex);
+        // TODO  maybe it's fine here
+        Requires.requireTrue(firstIndexKept >= this.firstLogIndex,
+                "Try to truncate logs before %d, but the firstLogIndex is %d", firstIndexKept, this.firstLogIndex);
 
-            this.firstLogIndex = firstIndexKept;
-            if (firstIndexKept > this.lastLogIndex) {
-                // The entry log is dropped
-                this.lastLogIndex = firstIndexKept - 1;
-            }
-            LOG.debug("Truncate prefix, firstIndexKept is :{}", firstIndexKept);
-            this.configManager.truncatePrefix(firstIndexKept);
-            final TruncatePrefixClosure c = new TruncatePrefixClosure(firstIndexKept);
-            offerEvent(c, EventType.TRUNCATE_PREFIX);
-            return true;
+        this.firstLogIndex = firstIndexKept;
+        if (firstIndexKept > this.lastLogIndex) {
+            // The entry log is dropped
+            this.lastLogIndex = firstIndexKept - 1;
         }
+        LOG.debug("Truncate prefix, firstIndexKept is :{}", firstIndexKept);
+        this.configManager.truncatePrefix(firstIndexKept);
+        final TruncatePrefixClosure c = new TruncatePrefixClosure(firstIndexKept);
+        offerEvent(c, EventType.TRUNCATE_PREFIX);
+        return true;
+    }
 
     private boolean reset(final long nextLogIndex) {
         this.writeLock.lock();
@@ -963,22 +962,22 @@ public class LogManagerImpl implements LogManager {
     }
 
     private void unsafeTruncateSuffix(final long lastIndexKept) {
-            if (lastIndexKept < this.appliedId.getIndex()) {
-                LOG.error("FATAL ERROR: Can't truncate logs before appliedId={}, lastIndexKept={}", this.appliedId,
-                    lastIndexKept);
-                return;
-            }
-
-            this.logsInMemory.removeFromLastWhen(entry -> entry.getId().getIndex() > lastIndexKept);
-
-            this.lastLogIndex = lastIndexKept;
-            final long lastTermKept = unsafeGetTerm(lastIndexKept);
-            Requires.requireTrue(this.lastLogIndex == 0 || lastTermKept != 0);
-            LOG.debug("Truncate suffix :{}", lastIndexKept);
-            this.configManager.truncateSuffix(lastIndexKept);
-            final TruncateSuffixClosure c = new TruncateSuffixClosure(lastIndexKept, lastTermKept);
-            offerEvent(c, EventType.TRUNCATE_SUFFIX);
+        if (lastIndexKept < this.appliedId.getIndex()) {
+            LOG.error("FATAL ERROR: Can't truncate logs before appliedId={}, lastIndexKept={}", this.appliedId,
+                lastIndexKept);
+            return;
         }
+
+        this.logsInMemory.removeFromLastWhen(entry -> entry.getId().getIndex() > lastIndexKept);
+
+        this.lastLogIndex = lastIndexKept;
+        final long lastTermKept = unsafeGetTerm(lastIndexKept);
+        Requires.requireTrue(this.lastLogIndex == 0 || lastTermKept != 0);
+        LOG.debug("Truncate suffix :{}", lastIndexKept);
+        this.configManager.truncateSuffix(lastIndexKept);
+        final TruncateSuffixClosure c = new TruncateSuffixClosure(lastIndexKept, lastTermKept);
+        offerEvent(c, EventType.TRUNCATE_SUFFIX);
+    }
 
     @SuppressWarnings("NonAtomicOperationOnVolatileField")
     private boolean checkAndResolveConflict(final List<LogEntry> entries, final StableClosure done) {
@@ -1075,23 +1074,23 @@ public class LogManagerImpl implements LogManager {
     }
 
     private long notifyOnNewLog(final long expectedLastLogIndex, final WaitMeta wm) {
-            this.writeLock.lock();
-            try {
-                if (expectedLastLogIndex != this.lastLogIndex || this.stopped) {
-                    wm.errorCode = this.stopped ? RaftError.ESTOP.getNumber() : 0;
-                    Utils.runInThread(() -> runOnNewLog(wm));
-                    return 0L;
-                }
-                if (this.nextWaitId == 0) { //skip 0
-                    ++this.nextWaitId;
-                }
-                final long waitId = this.nextWaitId++;
-                this.waitMap.put(waitId, wm);
-                return waitId;
-            } finally {
-                this.writeLock.unlock();
+        this.writeLock.lock();
+        try {
+            if (expectedLastLogIndex != this.lastLogIndex || this.stopped) {
+                wm.errorCode = this.stopped ? RaftError.ESTOP.getNumber() : 0;
+                Utils.runInThread(() -> runOnNewLog(wm));
+                return 0L;
             }
+            if (this.nextWaitId == 0) { //skip 0
+                ++this.nextWaitId;
+            }
+            final long waitId = this.nextWaitId++;
+            this.waitMap.put(waitId, wm);
+            return waitId;
+        } finally {
+            this.writeLock.unlock();
         }
+    }
 
     @Override
     public boolean removeWaiter(final long id) {

--- a/jraft-core/src/main/java/com/alipay/sofa/jraft/util/RepeatedTimer.java
+++ b/jraft-core/src/main/java/com/alipay/sofa/jraft/util/RepeatedTimer.java
@@ -44,8 +44,8 @@ public abstract class RepeatedTimer implements Describer {
     private Timeout            timeout;
     private boolean            stopped;
     private volatile boolean   running;
-    private boolean            destroyed;
-    private boolean            invoking;
+    private volatile boolean   destroyed;
+    private volatile boolean   invoking;
     private volatile int       timeoutMs;
     private final String       name;
 
@@ -53,11 +53,11 @@ public abstract class RepeatedTimer implements Describer {
         return this.timeoutMs;
     }
 
-    public RepeatedTimer(String name, int timeoutMs) {
+    public RepeatedTimer(final String name, final int timeoutMs) {
         this(name, timeoutMs, new HashedWheelTimer(new NamedThreadFactory(name, true), 1, TimeUnit.MILLISECONDS, 2048));
     }
 
-    public RepeatedTimer(String name, int timeoutMs, Timer timer) {
+    public RepeatedTimer(final String name, final int timeoutMs, final Timer timer) {
         super();
         this.name = name;
         this.timeoutMs = timeoutMs;
@@ -81,12 +81,7 @@ public abstract class RepeatedTimer implements Describer {
     }
 
     public void run() {
-        this.lock.lock();
-        try {
-            this.invoking = true;
-        } finally {
-            this.lock.unlock();
-        }
+        this.invoking = true;
         try {
             onTrigger();
         } catch (final Throwable t) {
@@ -157,7 +152,7 @@ public abstract class RepeatedTimer implements Describer {
     }
 
     private void schedule() {
-        if(this.timeout != null) {
+        if (this.timeout != null) {
             this.timeout.cancel();
         }
         final TimerTask timerTask = timeout -> {
@@ -216,8 +211,6 @@ public abstract class RepeatedTimer implements Describer {
             if (!this.running) {
                 invokeDestroyed = true;
             }
-            // Timer#stop is idempotent
-            this.timer.stop();
             if (this.stopped) {
                 return;
             }
@@ -231,6 +224,7 @@ public abstract class RepeatedTimer implements Describer {
             }
         } finally {
             this.lock.unlock();
+            this.timer.stop();
             if (invokeDestroyed) {
                 onDestroy();
             }
@@ -272,8 +266,8 @@ public abstract class RepeatedTimer implements Describer {
 
     @Override
     public String toString() {
-        return "RepeatedTimer{" + "timeout=" + timeout + ", stopped=" + stopped + ", running=" + running
-               + ", destroyed=" + destroyed + ", invoking=" + invoking + ", timeoutMs=" + timeoutMs + ", name='" + name
-               + '\'' + '}';
+        return "RepeatedTimer{" + "timeout=" + this.timeout + ", stopped=" + this.stopped + ", running=" + this.running
+               + ", destroyed=" + this.destroyed + ", invoking=" + this.invoking + ", timeoutMs=" + this.timeoutMs
+               + ", name='" + this.name + '\'' + '}';
     }
 }

--- a/jraft-core/src/main/java/com/alipay/sofa/jraft/util/SegmentList.java
+++ b/jraft-core/src/main/java/com/alipay/sofa/jraft/util/SegmentList.java
@@ -22,7 +22,7 @@ import java.util.function.Predicate;
 
 /**
  * A list implementation based on segments.Only supports removing elements from start or end.
- * The list keep the elements in a segment list, every segment contains at most 256 elements.
+ * The list keep the elements in a segment list, every segment contains at most 128 elements.
  *
  * @author boyan(boyan@antfin.com)
  *
@@ -44,6 +44,12 @@ public class SegmentList<T> {
         this.firstOffset = 0;
     }
 
+    /**
+     *  A recyclable segment.
+     * @author boyan(boyan@antfin.com)
+     *
+     * @param <T>
+     */
     private final static class Segment<T> implements Recyclable {
         private static final Recyclers<Segment<?>> recyclers = new Recyclers<Segment<?>>(16_382 / SEGMENT_SIZE) {
 

--- a/jraft-core/src/main/java/com/alipay/sofa/jraft/util/SegmentList.java
+++ b/jraft-core/src/main/java/com/alipay/sofa/jraft/util/SegmentList.java
@@ -1,0 +1,341 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alipay.sofa.jraft.util;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.function.Predicate;
+
+/**
+ * A list implementation based on segments.Only supports removing elements from start or end.
+ * The list keep the elements in a segment list, every segment contains at most 256 elements.
+ *
+ * @author boyan(boyan@antfin.com)
+ *
+ */
+public class SegmentList<T> {
+    private static final int             SEGMENT_SHIFT = 8;
+    public static final int              SEGMENT_SIZE  = 2 << (SEGMENT_SHIFT - 1);
+
+    private final ArrayDeque<Segment<T>> segments;
+
+    private int                          size;
+
+    // Cached offset in first segment.
+    private int                          firstOffset;
+
+    public SegmentList() {
+        this.segments = new ArrayDeque<>();
+        this.size = 0;
+        this.firstOffset = 0;
+    }
+
+    private final static class Segment<T> implements Recyclable {
+        private static final Recyclers<Segment<?>> recyclers = new Recyclers<Segment<?>>(16_382 / SEGMENT_SIZE) {
+
+                                                                 @Override
+                                                                 protected Segment<?> newObject(final Handle handle) {
+                                                                     return new Segment<>(handle);
+                                                                 }
+                                                             };
+
+        public static Segment<?> newInstance() {
+            return recyclers.get();
+        }
+
+        private transient final Recyclers.Handle handle;
+
+        final T[]                                elements;
+        int                                      pos;     // end offset(exclusive)
+        int                                      offset;  // start offset(inclusive)
+
+        @SuppressWarnings("unchecked")
+        Segment(final Recyclers.Handle handle) {
+            this.elements = (T[]) new Object[SEGMENT_SIZE];
+            this.pos = this.offset = 0;
+            this.handle = handle;
+        }
+
+        void clear() {
+            this.pos = this.offset = 0;
+            Arrays.fill(this.elements, null);
+        }
+
+        @Override
+        public boolean recycle() {
+            clear();
+            return recyclers.recycle(this, this.handle);
+        }
+
+        int cap() {
+            return SEGMENT_SIZE - this.pos;
+        }
+
+        private void addAll(final Object[] src, final int srcPos, final int len) {
+            System.arraycopy(src, srcPos, this.elements, this.pos, len);
+            this.pos += len;
+        }
+
+        boolean isReachEnd() {
+            return this.pos == SEGMENT_SIZE;
+        }
+
+        boolean isEmpty() {
+            return this.size() == 0;
+        }
+
+        void add(final T e) {
+            this.elements[this.pos++] = e;
+        }
+
+        T get(final int index) {
+            if (index >= this.pos || index < this.offset) {
+                throw new IndexOutOfBoundsException("Index=" + index + ", Offset=" + this.offset + ", Pos=" + this.pos);
+            }
+            return this.elements[index];
+        }
+
+        T peekLast() {
+            return this.elements[this.pos - 1];
+        }
+
+        int size() {
+            return this.pos - this.offset;
+        }
+
+        T peekFirst() {
+            return this.elements[this.offset];
+        }
+
+        int removeFromLastWhen(final Predicate<T> predicate) {
+            int removed = 0;
+            for (int i = this.pos - 1; i >= this.offset; i--) {
+                T e = this.elements[i];
+                if (predicate.test(e)) {
+                    this.elements[i] = null;
+                    removed++;
+                } else {
+                    break;
+                }
+            }
+            this.pos -= removed;
+            return removed;
+        }
+
+        int removeFromFirstWhen(final Predicate<T> predicate) {
+            int removed = 0;
+            for (int i = this.offset; i < this.pos; i++) {
+                T e = this.elements[i];
+                if (predicate.test(e)) {
+                    this.elements[i] = null;
+                    removed++;
+                } else {
+                    break;
+                }
+            }
+            this.offset += removed;
+            return removed;
+        }
+
+        int removeFromFirst(final int toIndex) {
+            int removed = 0;
+            for (int i = this.offset; i < Math.min(toIndex, this.pos); i++) {
+                this.elements[i] = null;
+                removed++;
+            }
+            this.offset += removed;
+            return removed;
+        }
+
+        @Override
+        public String toString() {
+            StringBuilder b = new StringBuilder();
+            for (int i = this.offset; i < this.pos; i++) {
+                b.append(this.elements[i]);
+                if (i != this.pos - 1) {
+                    b.append(", ");
+                }
+            }
+            return "Segment [elements=" + b.toString() + ", offset=" + this.offset + ", pos=" + this.pos + "]";
+        }
+
+    }
+
+    public T get(int index) {
+        index += this.firstOffset;
+        return this.segments.get(index >> SEGMENT_SHIFT).get(index & (SEGMENT_SIZE - 1));
+    }
+
+    public T peekLast() {
+        Segment<T> lastSeg = getLast();
+        return lastSeg == null ? null : lastSeg.peekLast();
+    }
+
+    public T peekFirst() {
+        Segment<T> firstSeg = getFirst();
+        return firstSeg == null ? null : firstSeg.peekFirst();
+    }
+
+    private Segment<T> getFirst() {
+        if (!this.segments.isEmpty()) {
+            return this.segments.peekFirst();
+        }
+        return null;
+    }
+
+    @SuppressWarnings("unchecked")
+    public void add(final T e) {
+        Segment<T> lastSeg = getLast();
+        if (lastSeg == null || lastSeg.isReachEnd()) {
+            lastSeg = (Segment<T>) Segment.newInstance();
+            this.segments.add(lastSeg);
+        }
+        lastSeg.add(e);
+        this.size++;
+    }
+
+    private Segment<T> getLast() {
+        if (!this.segments.isEmpty()) {
+            return this.segments.peekLast();
+        }
+        return null;
+    }
+
+    public int size() {
+        return this.size;
+    }
+
+    public int segmentSize() {
+        return this.segments.size();
+    }
+
+    public boolean isEmpty() {
+        return this.size == 0;
+    }
+
+    /**
+     * Remove elements from first until predicate returns false.
+     * @param predicate
+     */
+    public void removeFromFirstWhen(final Predicate<T> predicate) {
+        Segment<T> firstSeg = getFirst();
+        while (true) {
+            if (firstSeg == null) {
+                this.firstOffset = this.size = 0;
+                return;
+            }
+            int removed = firstSeg.removeFromFirstWhen(predicate);
+            if (removed == 0) {
+                break;
+            }
+            this.size -= removed;
+            this.firstOffset = firstSeg.offset;
+            if (firstSeg.isEmpty()) {
+                RecycleUtil.recycle(this.segments.pollFirst());
+                firstSeg = getFirst();
+                this.firstOffset = 0;
+            }
+        }
+    }
+
+    public void clear() {
+        while (!this.segments.isEmpty()) {
+            RecycleUtil.recycle(this.segments.pollLast());
+        }
+        this.size = this.firstOffset = 0;
+    }
+
+    /**
+     * Remove elements from last until predicate returns false.
+     * @param predicate
+     */
+    public void removeFromLastWhen(final Predicate<T> predicate) {
+        Segment<T> lastSeg = getLast();
+        while (true) {
+            if (lastSeg == null) {
+                this.firstOffset = this.size = 0;
+                return;
+            }
+            int removed = lastSeg.removeFromLastWhen(predicate);
+            if (removed == 0) {
+                break;
+            }
+            this.size -= removed;
+            if (lastSeg.isEmpty()) {
+                RecycleUtil.recycle(this.segments.pollLast());
+                lastSeg = getLast();
+            }
+        }
+    }
+
+    /**
+     *
+     * Removes from this list all of the elements whose index is between
+     * 0, inclusive, and {@code toIndex}, exclusive.
+     * Shifts any succeeding elements to the left (reduces their index).
+     */
+    public void removeFromFirst(final int toIndex) {
+        int alignedIndex = toIndex + this.firstOffset;
+        int toSegmentIndex = alignedIndex >> SEGMENT_SHIFT;
+
+        int toIndexInSeg = alignedIndex & (SEGMENT_SIZE - 1);
+
+        if (toSegmentIndex > 0) {
+            this.segments.removeRange(0, toSegmentIndex);
+            this.size -= ((toSegmentIndex << SEGMENT_SHIFT) - this.firstOffset);
+        }
+
+        Segment<T> firstSeg = this.getFirst();
+        if (firstSeg != null) {
+            this.size -= firstSeg.removeFromFirst(toIndexInSeg);
+            this.firstOffset = firstSeg.offset;
+            if (firstSeg.isEmpty()) {
+                RecycleUtil.recycle(this.segments.pollFirst());
+                this.firstOffset = 0;
+            }
+        } else {
+            this.firstOffset = this.size = 0;
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    public void addAll(final Collection<T> coll) {
+        Object[] src = coll.toArray();
+        int srcPos = 0;
+        int srcSize = src.length;
+
+        Segment<T> lastSeg = getLast();
+        while (srcPos < srcSize) {
+            if (lastSeg == null || lastSeg.isReachEnd()) {
+                lastSeg = (Segment<T>) Segment.newInstance();
+                this.segments.add(lastSeg);
+            }
+
+            int len = Math.min(lastSeg.cap(), srcSize - srcPos);
+            lastSeg.addAll(src, srcPos, len);
+            srcPos += len;
+            this.size += len;
+        }
+    }
+
+    @Override
+    public String toString() {
+        return "SegmentList [segments=" + this.segments + ", size=" + this.size + ", firstOffset=" + this.firstOffset
+               + "]";
+    }
+
+}

--- a/jraft-core/src/main/java/com/alipay/sofa/jraft/util/SegmentList.java
+++ b/jraft-core/src/main/java/com/alipay/sofa/jraft/util/SegmentList.java
@@ -372,10 +372,8 @@ public class SegmentList<T> {
 
     private Object[] coll2Array(final Collection<T> coll) {
         Object[] src = null;
-        if (coll instanceof ArrayList) {
-            if (UnsafeUtil.hasUnsafe()) {
-                src = LIST_ARRAY_GETTER.get((ArrayList<T>) coll);
-            }
+        if (coll instanceof ArrayList && UnsafeUtil.hasUnsafe()) {
+            src = LIST_ARRAY_GETTER.get((ArrayList<T>) coll);
         } else {
             src = coll.toArray();
         }

--- a/jraft-core/src/main/java/com/alipay/sofa/jraft/util/SegmentList.java
+++ b/jraft-core/src/main/java/com/alipay/sofa/jraft/util/SegmentList.java
@@ -25,10 +25,11 @@ import java.util.function.Predicate;
  * The list keep the elements in a segment list, every segment contains at most 128 elements.
  *
  * @author boyan(boyan@antfin.com)
+ * @since 1.3.1
  *
  */
 public class SegmentList<T> {
-    private static final int             SEGMENT_SHIFT = 8;
+    private static final int             SEGMENT_SHIFT = 7;
     public static final int              SEGMENT_SIZE  = 2 << (SEGMENT_SHIFT - 1);
 
     private final ArrayDeque<Segment<T>> segments;

--- a/jraft-core/src/main/java/com/alipay/sofa/jraft/util/internal/IntegerFieldUpdater.java
+++ b/jraft-core/src/main/java/com/alipay/sofa/jraft/util/internal/IntegerFieldUpdater.java
@@ -14,7 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.alipay.sofa.jraft.rhea.util.internal;
+package com.alipay.sofa.jraft.util.internal;
 
 /**
  * @author jiachun.fjc

--- a/jraft-core/src/main/java/com/alipay/sofa/jraft/util/internal/LongFieldUpdater.java
+++ b/jraft-core/src/main/java/com/alipay/sofa/jraft/util/internal/LongFieldUpdater.java
@@ -14,7 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.alipay.sofa.jraft.rhea.util.internal;
+package com.alipay.sofa.jraft.util.internal;
 
 /**
  * @author jiachun.fjc

--- a/jraft-core/src/main/java/com/alipay/sofa/jraft/util/internal/ReferenceFieldUpdater.java
+++ b/jraft-core/src/main/java/com/alipay/sofa/jraft/util/internal/ReferenceFieldUpdater.java
@@ -14,7 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.alipay.sofa.jraft.rhea.util.internal;
+package com.alipay.sofa.jraft.util.internal;
 
 /**
  * @author jiachun.fjc

--- a/jraft-core/src/main/java/com/alipay/sofa/jraft/util/internal/ReflectionIntegerFieldUpdater.java
+++ b/jraft-core/src/main/java/com/alipay/sofa/jraft/util/internal/ReflectionIntegerFieldUpdater.java
@@ -14,38 +14,38 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.alipay.sofa.jraft.rhea.util.internal;
+package com.alipay.sofa.jraft.util.internal;
 
 import java.lang.reflect.Field;
-
-import sun.misc.Unsafe;
 
 /**
  *
  * @author jiachun.fjc
  */
-@SuppressWarnings("unchecked")
-final class UnsafeReferenceFieldUpdater<U, W> implements ReferenceFieldUpdater<U, W> {
+final class ReflectionIntegerFieldUpdater<U> implements IntegerFieldUpdater<U> {
 
-    private final long   offset;
-    private final Unsafe unsafe;
+    private final Field field;
 
-    UnsafeReferenceFieldUpdater(Unsafe unsafe, Class<? super U> tClass, String fieldName) throws NoSuchFieldException {
-        final Field field = tClass.getDeclaredField(fieldName);
-        if (unsafe == null) {
-            throw new NullPointerException("unsafe");
+    ReflectionIntegerFieldUpdater(Class<? super U> tClass, String fieldName) throws NoSuchFieldException {
+        this.field = tClass.getDeclaredField(fieldName);
+        this.field.setAccessible(true);
+    }
+
+    @Override
+    public void set(final U obj, final int newValue) {
+        try {
+            this.field.set(obj, newValue);
+        } catch (final IllegalAccessException e) {
+            throw new RuntimeException(e);
         }
-        this.unsafe = unsafe;
-        this.offset = unsafe.objectFieldOffset(field);
     }
 
     @Override
-    public void set(final U obj, final W newValue) {
-        this.unsafe.putObject(obj, this.offset, newValue);
-    }
-
-    @Override
-    public W get(final U obj) {
-        return (W) this.unsafe.getObject(obj, this.offset);
+    public int get(final U obj) {
+        try {
+            return (Integer) this.field.get(obj);
+        } catch (final IllegalAccessException e) {
+            throw new RuntimeException(e);
+        }
     }
 }

--- a/jraft-core/src/main/java/com/alipay/sofa/jraft/util/internal/ReflectionLongFieldUpdater.java
+++ b/jraft-core/src/main/java/com/alipay/sofa/jraft/util/internal/ReflectionLongFieldUpdater.java
@@ -14,7 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.alipay.sofa.jraft.rhea.util.internal;
+package com.alipay.sofa.jraft.util.internal;
 
 import java.lang.reflect.Field;
 
@@ -22,18 +22,17 @@ import java.lang.reflect.Field;
  *
  * @author jiachun.fjc
  */
-@SuppressWarnings("unchecked")
-final class ReflectionReferenceFieldUpdater<U, W> implements ReferenceFieldUpdater<U, W> {
+final class ReflectionLongFieldUpdater<U> implements LongFieldUpdater<U> {
 
     private final Field field;
 
-    ReflectionReferenceFieldUpdater(Class<? super U> tClass, String fieldName) throws NoSuchFieldException {
+    ReflectionLongFieldUpdater(Class<? super U> tClass, String fieldName) throws NoSuchFieldException {
         this.field = tClass.getDeclaredField(fieldName);
         this.field.setAccessible(true);
     }
 
     @Override
-    public void set(final U obj, final W newValue) {
+    public void set(final U obj, final long newValue) {
         try {
             this.field.set(obj, newValue);
         } catch (final IllegalAccessException e) {
@@ -42,9 +41,9 @@ final class ReflectionReferenceFieldUpdater<U, W> implements ReferenceFieldUpdat
     }
 
     @Override
-    public W get(final U obj) {
+    public long get(final U obj) {
         try {
-            return (W) this.field.get(obj);
+            return (Long) this.field.get(obj);
         } catch (final IllegalAccessException e) {
             throw new RuntimeException(e);
         }

--- a/jraft-core/src/main/java/com/alipay/sofa/jraft/util/internal/ReflectionReferenceFieldUpdater.java
+++ b/jraft-core/src/main/java/com/alipay/sofa/jraft/util/internal/ReflectionReferenceFieldUpdater.java
@@ -14,7 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.alipay.sofa.jraft.rhea.util.internal;
+package com.alipay.sofa.jraft.util.internal;
 
 import java.lang.reflect.Field;
 
@@ -22,17 +22,18 @@ import java.lang.reflect.Field;
  *
  * @author jiachun.fjc
  */
-final class ReflectionLongFieldUpdater<U> implements LongFieldUpdater<U> {
+@SuppressWarnings("unchecked")
+final class ReflectionReferenceFieldUpdater<U, W> implements ReferenceFieldUpdater<U, W> {
 
     private final Field field;
 
-    ReflectionLongFieldUpdater(Class<? super U> tClass, String fieldName) throws NoSuchFieldException {
+    ReflectionReferenceFieldUpdater(Class<? super U> tClass, String fieldName) throws NoSuchFieldException {
         this.field = tClass.getDeclaredField(fieldName);
         this.field.setAccessible(true);
     }
 
     @Override
-    public void set(final U obj, final long newValue) {
+    public void set(final U obj, final W newValue) {
         try {
             this.field.set(obj, newValue);
         } catch (final IllegalAccessException e) {
@@ -41,9 +42,9 @@ final class ReflectionLongFieldUpdater<U> implements LongFieldUpdater<U> {
     }
 
     @Override
-    public long get(final U obj) {
+    public W get(final U obj) {
         try {
-            return (Long) this.field.get(obj);
+            return (W) this.field.get(obj);
         } catch (final IllegalAccessException e) {
             throw new RuntimeException(e);
         }

--- a/jraft-core/src/main/java/com/alipay/sofa/jraft/util/internal/UnsafeLongFieldUpdater.java
+++ b/jraft-core/src/main/java/com/alipay/sofa/jraft/util/internal/UnsafeLongFieldUpdater.java
@@ -14,22 +14,21 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.alipay.sofa.jraft.rhea.util.internal;
+package com.alipay.sofa.jraft.util.internal;
 
 import java.lang.reflect.Field;
-
 import sun.misc.Unsafe;
 
 /**
  *
  * @author jiachun.fjc
  */
-final class UnsafeIntegerFieldUpdater<U> implements IntegerFieldUpdater<U> {
+final class UnsafeLongFieldUpdater<U> implements LongFieldUpdater<U> {
 
     private final long   offset;
     private final Unsafe unsafe;
 
-    UnsafeIntegerFieldUpdater(Unsafe unsafe, Class<? super U> tClass, String fieldName) throws NoSuchFieldException {
+    UnsafeLongFieldUpdater(Unsafe unsafe, Class<? super U> tClass, String fieldName) throws NoSuchFieldException {
         final Field field = tClass.getDeclaredField(fieldName);
         if (unsafe == null) {
             throw new NullPointerException("unsafe");
@@ -39,12 +38,12 @@ final class UnsafeIntegerFieldUpdater<U> implements IntegerFieldUpdater<U> {
     }
 
     @Override
-    public void set(final U obj, final int newValue) {
-        this.unsafe.putInt(obj, this.offset, newValue);
+    public void set(final U obj, final long newValue) {
+        this.unsafe.putLong(obj, this.offset, newValue);
     }
 
     @Override
-    public int get(final U obj) {
-        return this.unsafe.getInt(obj, this.offset);
+    public long get(final U obj) {
+        return this.unsafe.getLong(obj, this.offset);
     }
 }

--- a/jraft-core/src/main/java/com/alipay/sofa/jraft/util/internal/UnsafeReferenceFieldUpdater.java
+++ b/jraft-core/src/main/java/com/alipay/sofa/jraft/util/internal/UnsafeReferenceFieldUpdater.java
@@ -14,22 +14,22 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.alipay.sofa.jraft.rhea.util.internal;
+package com.alipay.sofa.jraft.util.internal;
 
 import java.lang.reflect.Field;
-
 import sun.misc.Unsafe;
 
 /**
  *
  * @author jiachun.fjc
  */
-final class UnsafeLongFieldUpdater<U> implements LongFieldUpdater<U> {
+@SuppressWarnings("unchecked")
+final class UnsafeReferenceFieldUpdater<U, W> implements ReferenceFieldUpdater<U, W> {
 
     private final long   offset;
     private final Unsafe unsafe;
 
-    UnsafeLongFieldUpdater(Unsafe unsafe, Class<? super U> tClass, String fieldName) throws NoSuchFieldException {
+    UnsafeReferenceFieldUpdater(Unsafe unsafe, Class<? super U> tClass, String fieldName) throws NoSuchFieldException {
         final Field field = tClass.getDeclaredField(fieldName);
         if (unsafe == null) {
             throw new NullPointerException("unsafe");
@@ -39,12 +39,12 @@ final class UnsafeLongFieldUpdater<U> implements LongFieldUpdater<U> {
     }
 
     @Override
-    public void set(final U obj, final long newValue) {
-        this.unsafe.putLong(obj, this.offset, newValue);
+    public void set(final U obj, final W newValue) {
+        this.unsafe.putObject(obj, this.offset, newValue);
     }
 
     @Override
-    public long get(final U obj) {
-        return this.unsafe.getLong(obj, this.offset);
+    public W get(final U obj) {
+        return (W) this.unsafe.getObject(obj, this.offset);
     }
 }

--- a/jraft-core/src/main/java/com/alipay/sofa/jraft/util/internal/Updaters.java
+++ b/jraft-core/src/main/java/com/alipay/sofa/jraft/util/internal/Updaters.java
@@ -14,9 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.alipay.sofa.jraft.rhea.util.internal;
-
-import com.alipay.sofa.jraft.util.internal.UnsafeUtil;
+package com.alipay.sofa.jraft.util.internal;
 
 /**
  * Sometime instead of reflection, better performance.

--- a/jraft-core/src/test/java/com/alipay/sofa/jraft/core/MockStateMachine.java
+++ b/jraft-core/src/test/java/com/alipay/sofa/jraft/core/MockStateMachine.java
@@ -164,6 +164,7 @@ public class MockStateMachine extends StateMachineAdapter {
 
     @Override
     public boolean onSnapshotLoad(final SnapshotReader reader) {
+        this.lastAppliedIndex.set(0);
         this.loadSnapshotTimes++;
         final String path = reader.getPath() + File.separator + "data";
         final File file = new File(path);

--- a/jraft-core/src/test/java/com/alipay/sofa/jraft/core/MockStateMachine.java
+++ b/jraft-core/src/test/java/com/alipay/sofa/jraft/core/MockStateMachine.java
@@ -25,6 +25,7 @@ import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
 
@@ -55,7 +56,7 @@ public class MockStateMachine extends StateMachineAdapter {
         return this.address;
     }
 
-    public MockStateMachine(Endpoint address) {
+    public MockStateMachine(final Endpoint address) {
         super();
         this.address = address;
     }
@@ -101,21 +102,28 @@ public class MockStateMachine extends StateMachineAdapter {
         try {
             return this.logs;
         } finally {
-            lock.unlock();
+            this.lock.unlock();
         }
     }
 
+    private final AtomicLong lastAppliedIndex = new AtomicLong(-1);
+
     @Override
-    public void onApply(Iterator iter) {
+    public void onApply(final Iterator iter) {
         while (iter.hasNext()) {
-            lock.lock();
+            this.lock.lock();
             try {
-                logs.add(iter.getData().slice());
+                if (iter.getIndex() <= this.lastAppliedIndex.get()) {
+                    //prevent duplication
+                    continue;
+                }
+                this.lastAppliedIndex.set(iter.getIndex());
+                this.logs.add(iter.getData().slice());
                 if (iter.done() != null) {
                     iter.done().run(Status.OK());
                 }
             } finally {
-                lock.unlock();
+                this.lock.unlock();
             }
             this.appliedIndex = iter.getIndex();
             iter.next();
@@ -127,13 +135,13 @@ public class MockStateMachine extends StateMachineAdapter {
     }
 
     @Override
-    public void onSnapshotSave(SnapshotWriter writer, Closure done) {
+    public void onSnapshotSave(final SnapshotWriter writer, final Closure done) {
         this.saveSnapshotTimes++;
         final String path = writer.getPath() + File.separator + "data";
         final File file = new File(path);
         try (FileOutputStream fout = new FileOutputStream(file);
                 BufferedOutputStream out = new BufferedOutputStream(fout)) {
-            lock.lock();
+            this.lock.lock();
             try {
                 for (final ByteBuffer buf : this.logs) {
                     final byte[] bs = new byte[4];
@@ -141,11 +149,11 @@ public class MockStateMachine extends StateMachineAdapter {
                     out.write(bs);
                     out.write(buf.array());
                 }
-                snapshotIndex = appliedIndex;
+                this.snapshotIndex = this.appliedIndex;
             } finally {
-                lock.unlock();
+                this.lock.unlock();
             }
-            System.out.println("Node<" + address + "> saved snapshot into " + file);
+            System.out.println("Node<" + this.address + "> saved snapshot into " + file);
             writer.addFile("data");
             done.run(Status.OK());
         } catch (final IOException e) {
@@ -155,7 +163,7 @@ public class MockStateMachine extends StateMachineAdapter {
     }
 
     @Override
-    public boolean onSnapshotLoad(SnapshotReader reader) {
+    public boolean onSnapshotLoad(final SnapshotReader reader) {
         this.loadSnapshotTimes++;
         final String path = reader.getPath() + File.separator + "data";
         final File file = new File(path);
@@ -163,8 +171,8 @@ public class MockStateMachine extends StateMachineAdapter {
             return false;
         }
         try (FileInputStream fin = new FileInputStream(file); BufferedInputStream in = new BufferedInputStream(fin)) {
-            lock.lock();
-            logs.clear();
+            this.lock.lock();
+            this.logs.clear();
             try {
                 while (true) {
                     final byte[] bs = new byte[4];
@@ -174,15 +182,15 @@ public class MockStateMachine extends StateMachineAdapter {
                         if (in.read(buf) != len) {
                             break;
                         }
-                        logs.add(ByteBuffer.wrap(buf));
+                        this.logs.add(ByteBuffer.wrap(buf));
                     } else {
                         break;
                     }
                 }
             } finally {
-                lock.unlock();
+                this.lock.unlock();
             }
-            System.out.println("Node<" + address + "> loaded snapshot from " + path);
+            System.out.println("Node<" + this.address + "> loaded snapshot from " + path);
             return true;
         } catch (final IOException e) {
             e.printStackTrace();
@@ -191,25 +199,25 @@ public class MockStateMachine extends StateMachineAdapter {
     }
 
     @Override
-    public void onLeaderStart(long term) {
+    public void onLeaderStart(final long term) {
         super.onLeaderStart(term);
         this.leaderTerm = term;
     }
 
     @Override
-    public void onLeaderStop(Status status) {
+    public void onLeaderStop(final Status status) {
         super.onLeaderStop(status);
         this.leaderTerm = -1;
     }
 
     @Override
-    public void onStopFollowing(LeaderChangeContext ctx) {
+    public void onStopFollowing(final LeaderChangeContext ctx) {
         super.onStopFollowing(ctx);
         this.onStopFollowingTimes++;
     }
 
     @Override
-    public void onStartFollowing(LeaderChangeContext ctx) {
+    public void onStartFollowing(final LeaderChangeContext ctx) {
         super.onStartFollowing(ctx);
         this.onStartFollowingTimes++;
     }

--- a/jraft-core/src/test/java/com/alipay/sofa/jraft/core/NodeTest.java
+++ b/jraft-core/src/test/java/com/alipay/sofa/jraft/core/NodeTest.java
@@ -16,6 +16,16 @@
  */
 package com.alipay.sofa.jraft.core;
 
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
 import java.io.File;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
@@ -78,16 +88,6 @@ import com.alipay.sofa.jraft.util.Endpoint;
 import com.alipay.sofa.jraft.util.StorageOptionsFactory;
 import com.alipay.sofa.jraft.util.Utils;
 import com.codahale.metrics.ConsoleReporter;
-
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNotSame;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
 
 public class NodeTest {
 
@@ -308,7 +308,7 @@ public class NodeTest {
         }
         // No read-index request succeed.
         assertEquals(0, readIndexSuccesses.get());
-        assertEquals(n - 1, currentValue.get());
+        assertTrue(n - 1 >= currentValue.get());
 
         node.shutdown();
         node.join();

--- a/jraft-core/src/test/java/com/alipay/sofa/jraft/util/SegmentListTest.java
+++ b/jraft-core/src/test/java/com/alipay/sofa/jraft/util/SegmentListTest.java
@@ -202,6 +202,8 @@ public class SegmentListTest {
         int warmupRepeats = 10_0000;
         int repeats = 100_0000;
 
+        double arrayDequeOps = 0;
+        double segListOps = 0;
         // test ArrayDequeue
         {
             ArrayDeque<Integer> deque = new ArrayDeque<>();
@@ -213,8 +215,8 @@ public class SegmentListTest {
             long startNs = System.nanoTime();
             benchArrayDequeue(repeats, deque);
             long costMs = (System.nanoTime() - startNs) / repeats;
-            double ops = repeats * 3.0 / costMs * 1000;
-            System.out.println("ArrayDeque, cost:" + costMs + ", ops: " + ops);
+            arrayDequeOps = repeats * 3.0 / costMs * 1000;
+            System.out.println("ArrayDeque, cost:" + costMs + ", ops: " + arrayDequeOps);
         }
         // test SegmentList
         {
@@ -228,10 +230,12 @@ public class SegmentListTest {
             long startNs = System.nanoTime();
             benchSegmentList(repeats);
             long costMs = (System.nanoTime() - startNs) / repeats;
-            double ops = repeats * 3.0 / costMs * 1000;
-            System.out.println("SegmentList, cost:" + costMs + ", ops: " + ops);
+            segListOps = repeats * 3.0 / costMs * 1000;
+            System.out.println("SegmentList, cost:" + costMs + ", ops: " + segListOps);
             this.list.clear();
         }
+
+        System.out.println("Improvement:" + Math.round((segListOps - arrayDequeOps) / arrayDequeOps * 100) + "%");
 
     }
 

--- a/jraft-core/src/test/java/com/alipay/sofa/jraft/util/SegmentListTest.java
+++ b/jraft-core/src/test/java/com/alipay/sofa/jraft/util/SegmentListTest.java
@@ -1,0 +1,275 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alipay.sofa.jraft.util;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import io.netty.util.internal.ThreadLocalRandom;
+
+public class SegmentListTest {
+
+    private SegmentList<Integer> list;
+
+    @Before
+    public void setup() {
+        this.list = new SegmentList<>();
+    }
+
+    @Test
+    public void testAddGet() {
+        assertTrue(this.list.isEmpty());
+        fillList();
+        assertFilledList();
+        System.out.println(this.list);
+    }
+
+    private void assertFilledList() {
+        for (int i = 0; i < 1000; i++) {
+            assertEquals(i, (int) this.list.get(i));
+        }
+        assertEquals(1000, this.list.size());
+        assertFalse(this.list.isEmpty());
+        assertEquals(1000 / SegmentList.SEGMENT_SIZE + 1, this.list.segmentSize());
+    }
+
+    private void fillList() {
+        int originSize = this.list.size();
+        for (int i = 0; i < 1000; i++) {
+            this.list.add(i);
+            assertEquals(originSize + i + 1, this.list.size());
+        }
+    }
+
+    @Test
+    public void testAddAllGet() {
+        List<Integer> tmpList = new ArrayList<>();
+        for (int i = 0; i < 1000; i++) {
+            tmpList.add(i);
+        }
+
+        this.list.addAll(tmpList);
+        assertFilledList();
+
+        this.list.removeFromFirstWhen(x -> x < 100);
+        assertEquals(900, this.list.size());
+
+        this.list.addAll(tmpList);
+        assertEquals(1900, this.list.size());
+
+        for (int i = 0; i < 1900; i++) {
+            if (i < 900) {
+                assertEquals(i + 100, (int) this.list.get(i));
+            } else {
+                assertEquals(i - 900, (int) this.list.get(i));
+            }
+        }
+
+    }
+
+    @Test
+    public void testRemoveFromFirst() {
+        fillList();
+
+        this.list.removeFromFirst(31);
+
+        assertEquals(1000 - 31, this.list.size());
+
+        for (int i = 0; i < 1000 - 31; i++) {
+            assertEquals(i + 31, (int) this.list.get(i));
+        }
+
+        this.list.removeFromFirst(100);
+        assertEquals(1000 - 31 - 100, this.list.size());
+
+        for (int i = 0; i < 1000 - 31 - 100; i++) {
+            assertEquals(i + 31 + 100, (int) this.list.get(i));
+        }
+
+        this.list.removeFromFirst(1000 - 31 - 100);
+        assertTrue(this.list.isEmpty());
+        assertEquals(0, this.list.segmentSize());
+        assertNull(this.list.peekFirst());
+        assertNull(this.list.peekLast());
+    }
+
+    @Test
+    public void testRemoveFromFirstWhen() {
+        fillList();
+        this.list.removeFromFirstWhen(x -> x < 100);
+        assertEquals(900, this.list.size());
+        assertEquals(100, (int) this.list.get(0));
+
+        for (int i = 0; i < 900; i++) {
+            assertEquals(100 + i, (int) this.list.get(i));
+        }
+
+        this.list.removeFromFirstWhen(x -> x < 500);
+        assertEquals(500, this.list.size());
+        for (int i = 0; i < 500; i++) {
+            assertEquals(500 + i, (int) this.list.get(i));
+        }
+
+        this.list.removeFromFirstWhen(x -> x < 1000);
+        assertTrue(this.list.isEmpty());
+        assertEquals(0, this.list.segmentSize());
+
+        fillList();
+        assertFilledList();
+    }
+
+    @Test
+    public void testRemoveFromLastWhen() {
+        fillList();
+
+        // remove elements is greater or equal to 50.
+        this.list.removeFromLastWhen(x -> x >= 50);
+        assertEquals(50, this.list.size());
+        assertFalse(this.list.isEmpty());
+        for (int i = 0; i < 50; i++) {
+            assertEquals(i, (int) this.list.get(i));
+        }
+        try {
+            this.list.get(50);
+            fail();
+        } catch (IndexOutOfBoundsException e) {
+
+        }
+        assertEquals(50 / SegmentList.SEGMENT_SIZE + 1, this.list.segmentSize());
+
+        // remove  elements is greater or equal to 32.
+        this.list.removeFromLastWhen(x -> x >= 32);
+        assertEquals(32, this.list.size());
+        assertFalse(this.list.isEmpty());
+        for (int i = 0; i < 32; i++) {
+            assertEquals(i, (int) this.list.get(i));
+        }
+        try {
+            this.list.get(32);
+            fail();
+        } catch (IndexOutOfBoundsException e) {
+
+        }
+        assertEquals(1, this.list.segmentSize());
+
+        // Add elements again.
+        fillList();
+        assertEquals(1032, this.list.size());
+        for (int i = 0; i < 1032; i++) {
+            if (i < 32) {
+                assertEquals(i, (int) this.list.get(i));
+            } else {
+                assertEquals(i - 32, (int) this.list.get(i));
+            }
+        }
+    }
+
+    @Test
+    public void simpleBenchmark() {
+        // test SegmentList
+        int warmupRepeats = 10_0000;
+        int repeats = 100_0000;
+
+        // test ArrayDequeue
+        {
+            ArrayDeque<Integer> deque = new ArrayDeque<>();
+            System.gc();
+            // wramup
+            benchArrayDequeue(warmupRepeats, deque);
+            deque.clear();
+            System.gc();
+            long startNs = System.nanoTime();
+            benchArrayDequeue(repeats, deque);
+            long costMs = (System.nanoTime() - startNs) / repeats;
+            double ops = repeats * 3.0 / costMs * 1000;
+            System.out.println("ArrayDeque, cost:" + costMs + ", ops: " + ops);
+        }
+
+        {
+            System.gc();
+            // warmup
+            benchSegmentList(warmupRepeats);
+
+            this.list.clear();
+            System.gc();
+
+            long startNs = System.nanoTime();
+            benchSegmentList(repeats);
+            long costMs = (System.nanoTime() - startNs) / repeats;
+            double ops = repeats * 3.0 / costMs * 1000;
+            System.out.println("SegmentList, cost:" + costMs + ", ops: " + ops);
+            this.list.clear();
+        }
+
+    }
+
+    private void benchArrayDequeue(final int repeats, final ArrayDeque<Integer> deque) {
+        int start = 0;
+        for (int i = 0; i < repeats; i++) {
+            List<Integer> tmpList = genData(start);
+            deque.addAll(tmpList);
+            int removePos = start + ThreadLocalRandom.current().nextInt(tmpList.size());
+
+            deque.get(removePos - start);
+
+            int index = 0;
+            for (int j = 0; j < deque.size(); j++) {
+                if (deque.get(j) > removePos) {
+                    index = j;
+                    break;
+                }
+            }
+
+            if (index > 0) {
+                deque.removeRange(0, index);
+            }
+
+            start += tmpList.size();
+        }
+    }
+
+    private List<Integer> genData(final int start) {
+        int n = ThreadLocalRandom.current().nextInt(500) + 10;
+        List<Integer> tmpList = new ArrayList<>(n);
+        for (int i = 0; i < n; i++) {
+            tmpList.add(i + start);
+        }
+        return tmpList;
+    }
+
+    private void benchSegmentList(final int repeats) {
+        int start = 0;
+
+        for (int i = 0; i < repeats; i++) {
+            List<Integer> tmpList = genData(start);
+            this.list.addAll(tmpList);
+            int removePos = start + ThreadLocalRandom.current().nextInt(tmpList.size());
+            this.list.get(removePos - start);
+            this.list.removeFromFirstWhen(x -> x <= removePos);
+            start += tmpList.size();
+        }
+    }
+}

--- a/jraft-core/src/test/java/com/alipay/sofa/jraft/util/SegmentListTest.java
+++ b/jraft-core/src/test/java/com/alipay/sofa/jraft/util/SegmentListTest.java
@@ -189,7 +189,6 @@ public class SegmentListTest {
 
     @Test
     public void simpleBenchmark() {
-        // test SegmentList
         int warmupRepeats = 10_0000;
         int repeats = 100_0000;
 
@@ -207,7 +206,7 @@ public class SegmentListTest {
             double ops = repeats * 3.0 / costMs * 1000;
             System.out.println("ArrayDeque, cost:" + costMs + ", ops: " + ops);
         }
-
+        // test SegmentList
         {
             System.gc();
             // warmup

--- a/jraft-core/src/test/java/com/alipay/sofa/jraft/util/SegmentListTest.java
+++ b/jraft-core/src/test/java/com/alipay/sofa/jraft/util/SegmentListTest.java
@@ -94,22 +94,23 @@ public class SegmentListTest {
     public void testRemoveFromFirst() {
         fillList();
 
-        this.list.removeFromFirst(31);
+        int len = SegmentList.SEGMENT_SIZE - 1;
+        this.list.removeFromFirst(len);
 
-        assertEquals(1000 - 31, this.list.size());
+        assertEquals(1000 - len, this.list.size());
 
-        for (int i = 0; i < 1000 - 31; i++) {
-            assertEquals(i + 31, (int) this.list.get(i));
+        for (int i = 0; i < 1000 - len; i++) {
+            assertEquals(i + len, (int) this.list.get(i));
         }
 
         this.list.removeFromFirst(100);
-        assertEquals(1000 - 31 - 100, this.list.size());
+        assertEquals(1000 - len - 100, this.list.size());
 
-        for (int i = 0; i < 1000 - 31 - 100; i++) {
-            assertEquals(i + 31 + 100, (int) this.list.get(i));
+        for (int i = 0; i < 1000 - len - 100; i++) {
+            assertEquals(i + len + 100, (int) this.list.get(i));
         }
 
-        this.list.removeFromFirst(1000 - 31 - 100);
+        this.list.removeFromFirst(1000 - len - 100);
         assertTrue(this.list.isEmpty());
         assertEquals(0, this.list.segmentSize());
         assertNull(this.list.peekFirst());
@@ -119,12 +120,12 @@ public class SegmentListTest {
     @Test
     public void testRemoveFromFirstWhen() {
         fillList();
-        this.list.removeFromFirstWhen(x -> x < 100);
-        assertEquals(900, this.list.size());
-        assertEquals(100, (int) this.list.get(0));
+        this.list.removeFromFirstWhen(x -> x < 200);
+        assertEquals(800, this.list.size());
+        assertEquals(200, (int) this.list.get(0));
 
-        for (int i = 0; i < 900; i++) {
-            assertEquals(100 + i, (int) this.list.get(i));
+        for (int i = 0; i < 800; i++) {
+            assertEquals(200 + i, (int) this.list.get(i));
         }
 
         this.list.removeFromFirstWhen(x -> x < 500);
@@ -145,20 +146,20 @@ public class SegmentListTest {
     public void testRemoveFromLastWhen() {
         fillList();
 
-        // remove elements is greater or equal to 50.
-        this.list.removeFromLastWhen(x -> x >= 50);
-        assertEquals(50, this.list.size());
+        // remove elements is greater or equal to 150.
+        this.list.removeFromLastWhen(x -> x >= 150);
+        assertEquals(150, this.list.size());
         assertFalse(this.list.isEmpty());
-        for (int i = 0; i < 50; i++) {
+        for (int i = 0; i < 150; i++) {
             assertEquals(i, (int) this.list.get(i));
         }
         try {
-            this.list.get(50);
+            this.list.get(151);
             fail();
         } catch (IndexOutOfBoundsException e) {
 
         }
-        assertEquals(50 / SegmentList.SEGMENT_SIZE + 1, this.list.segmentSize());
+        assertEquals(150 / SegmentList.SEGMENT_SIZE + 1, this.list.segmentSize());
 
         // remove  elements is greater or equal to 32.
         this.list.removeFromLastWhen(x -> x >= 32);
@@ -184,6 +185,15 @@ public class SegmentListTest {
             } else {
                 assertEquals(i - 32, (int) this.list.get(i));
             }
+        }
+    }
+
+    @Test
+    public void testAddPeek() {
+        for (int i = 0; i < 1000; i++) {
+            this.list.add(i);
+            assertEquals(i, (int) this.list.peekLast());
+            assertEquals(0, (int) this.list.peekFirst());
         }
     }
 

--- a/jraft-core/src/test/java/com/alipay/sofa/jraft/util/SegmentListTest.java
+++ b/jraft-core/src/test/java/com/alipay/sofa/jraft/util/SegmentListTest.java
@@ -36,7 +36,7 @@ public class SegmentListTest {
 
     @Before
     public void setup() {
-        this.list = new SegmentList<>();
+        this.list = new SegmentList<>(true);
     }
 
     @Test
@@ -244,6 +244,9 @@ public class SegmentListTest {
         for (int i = 0; i < repeats; i++) {
             List<Integer> tmpList = genData(start);
             deque.addAll(tmpList);
+            //            for (Integer o : tmpList) {
+            //                deque.add(o);
+            //            }
             int removePos = start + ThreadLocalRandom.current().nextInt(tmpList.size());
 
             deque.get(removePos - start);
@@ -279,6 +282,9 @@ public class SegmentListTest {
         for (int i = 0; i < repeats; i++) {
             List<Integer> tmpList = genData(start);
             this.list.addAll(tmpList);
+            //            for(Integer o: tmpList) {
+            //                list.add(o);
+            //            }
             int removePos = start + ThreadLocalRandom.current().nextInt(tmpList.size());
             this.list.get(removePos - start);
             this.list.removeFromFirstWhen(x -> x <= removePos);

--- a/jraft-rheakv/rheakv-core/src/main/java/com/alipay/sofa/jraft/rhea/rocks/support/RocksStatistics.java
+++ b/jraft-rheakv/rheakv-core/src/main/java/com/alipay/sofa/jraft/rhea/rocks/support/RocksStatistics.java
@@ -25,9 +25,9 @@ import org.rocksdb.TickerType;
 
 import com.alipay.sofa.jraft.rhea.storage.RocksRawKVStore;
 import com.alipay.sofa.jraft.rhea.util.ThrowUtil;
-import com.alipay.sofa.jraft.rhea.util.internal.ReferenceFieldUpdater;
-import com.alipay.sofa.jraft.rhea.util.internal.Updaters;
 import com.alipay.sofa.jraft.util.DebugStatistics;
+import com.alipay.sofa.jraft.util.internal.ReferenceFieldUpdater;
+import com.alipay.sofa.jraft.util.internal.Updaters;
 
 /**
  * @author jiachun.fjc

--- a/jraft-rheakv/rheakv-core/src/main/java/com/alipay/sofa/jraft/rhea/serialization/impl/protostuff/io/NioBufOutput.java
+++ b/jraft-rheakv/rheakv-core/src/main/java/com/alipay/sofa/jraft/rhea/serialization/impl/protostuff/io/NioBufOutput.java
@@ -26,10 +26,9 @@ import io.protostuff.Schema;
 
 import com.alipay.sofa.jraft.rhea.serialization.io.OutputBuf;
 import com.alipay.sofa.jraft.rhea.util.VarInts;
-import com.alipay.sofa.jraft.rhea.util.internal.ReferenceFieldUpdater;
-import com.alipay.sofa.jraft.rhea.util.internal.Updaters;
+import com.alipay.sofa.jraft.util.internal.ReferenceFieldUpdater;
 import com.alipay.sofa.jraft.util.internal.UnsafeUtf8Util;
-
+import com.alipay.sofa.jraft.util.internal.Updaters;
 import static io.protostuff.ProtobufOutput.encodeZigZag32;
 import static io.protostuff.ProtobufOutput.encodeZigZag64;
 import static io.protostuff.WireFormat.WIRETYPE_END_GROUP;

--- a/jraft-rheakv/rheakv-core/src/main/java/com/alipay/sofa/jraft/rhea/serialization/io/OutputStreams.java
+++ b/jraft-rheakv/rheakv-core/src/main/java/com/alipay/sofa/jraft/rhea/serialization/io/OutputStreams.java
@@ -19,8 +19,8 @@ package com.alipay.sofa.jraft.rhea.serialization.io;
 import java.io.ByteArrayOutputStream;
 
 import com.alipay.sofa.jraft.rhea.serialization.Serializer;
-import com.alipay.sofa.jraft.rhea.util.internal.ReferenceFieldUpdater;
-import com.alipay.sofa.jraft.rhea.util.internal.Updaters;
+import com.alipay.sofa.jraft.util.internal.ReferenceFieldUpdater;
+import com.alipay.sofa.jraft.util.internal.Updaters;
 
 /**
  *

--- a/jraft-rheakv/rheakv-core/src/main/java/com/alipay/sofa/jraft/rhea/util/StringBuilderHelper.java
+++ b/jraft-rheakv/rheakv-core/src/main/java/com/alipay/sofa/jraft/rhea/util/StringBuilderHelper.java
@@ -16,8 +16,8 @@
  */
 package com.alipay.sofa.jraft.rhea.util;
 
-import com.alipay.sofa.jraft.rhea.util.internal.ReferenceFieldUpdater;
-import com.alipay.sofa.jraft.rhea.util.internal.Updaters;
+import com.alipay.sofa.jraft.util.internal.ReferenceFieldUpdater;
+import com.alipay.sofa.jraft.util.internal.Updaters;
 
 /**
  * Reuse {@link StringBuilder} based on {@link ThreadLocal}.

--- a/jraft-rheakv/rheakv-core/src/main/java/com/alipay/sofa/jraft/rhea/util/ThrowUtil.java
+++ b/jraft-rheakv/rheakv-core/src/main/java/com/alipay/sofa/jraft/rhea/util/ThrowUtil.java
@@ -16,9 +16,9 @@
  */
 package com.alipay.sofa.jraft.rhea.util;
 
-import com.alipay.sofa.jraft.rhea.util.internal.ReferenceFieldUpdater;
-import com.alipay.sofa.jraft.rhea.util.internal.Updaters;
+import com.alipay.sofa.jraft.util.internal.ReferenceFieldUpdater;
 import com.alipay.sofa.jraft.util.internal.UnsafeUtil;
+import com.alipay.sofa.jraft.util.internal.Updaters;
 
 /**
  * Throwing tool.


### PR DESCRIPTION
### Motivation:

See #335 

### Modification:

* Introduce a new data structure `SegmentList`  that is a list of segment, every segment is an array contains 128 elements, and only supports removing elements from start or end:

```
                            segments
       /                        |                       \
segment                      segment                      segment 
[0, 1 ...  127]             [128, 129 ... 255]          [256, 1 ... 383] 
```

The `removeFromFirstWhen` and `removeFromLastWhen` methods accept a predicate and delete the elements from start or end until the predicate returns false. The ` remove` operation only set the elements to be null and remeber the deleted poistion,do not have any array elements movement at all. If a segment is empty after `remove`, it will  be removed from segment list too.
Also, I use the `Recyclable` to reuse the `Segment` instances.

The `SegmentList` performance in benchmark is alaways better than `ArrayDequeue` in `SegmentListTest#simpleBenchmark`, at most 10% improvement(The benchmark has some random factor). 

* Replace `ArrayDeque` in `LogManagerImpl` with `SegmentList`
* Fixed deadlock in `RepeatedTimer#destroy` and `RepeatedTimer#run`

### Result:

Fixes #335 

