### PR TITLE
(fix) Forgot to check learner replicator.

### DIFF
--- a/jraft-core/src/main/java/com/alipay/sofa/jraft/core/NodeImpl.java
+++ b/jraft-core/src/main/java/com/alipay/sofa/jraft/core/NodeImpl.java
@@ -2101,6 +2101,11 @@ public class NodeImpl implements Node, RaftServerService {
     }
 
     private void checkDeadNodes(final Configuration conf, final long monotonicNowMs) {
+        // Check learner replicators at first.
+        for (PeerId peer : conf.listLearners()) {
+            checkReplicator(peer);
+        }
+        // Ensure quorum nodes alive.
         final List<PeerId> peers = conf.listPeers();
         final Configuration deadNodes = new Configuration();
         if (checkDeadNodes0(peers, monotonicNowMs, true, deadNodes)) {

--- a/jraft-core/src/main/java/com/alipay/sofa/jraft/core/NodeImpl.java
+++ b/jraft-core/src/main/java/com/alipay/sofa/jraft/core/NodeImpl.java
@@ -677,8 +677,10 @@ public class NodeImpl implements Node, RaftServerService {
                 // Update target priority value
                 final int prevTargetPriority = this.targetPriority;
                 this.targetPriority = getMaxPriorityOfNodes(this.conf.getConf().getPeers());
-                LOG.info("Node {} target priority value has changed from: {}, to: {}.", getNodeId(),
-                    prevTargetPriority, this.targetPriority);
+                if (prevTargetPriority != this.targetPriority) {
+                    LOG.info("Node {} target priority value has changed from: {}, to: {}.", getNodeId(),
+                        prevTargetPriority, this.targetPriority);
+                }
                 this.electionTimeoutCounter = 0;
             }
         } finally {
@@ -2102,7 +2104,7 @@ public class NodeImpl implements Node, RaftServerService {
 
     private void checkDeadNodes(final Configuration conf, final long monotonicNowMs) {
         // Check learner replicators at first.
-        for (PeerId peer : conf.listLearners()) {
+        for (PeerId peer : conf.getLearners()) {
             checkReplicator(peer);
         }
         // Ensure quorum nodes alive.

--- a/jraft-core/src/main/java/com/alipay/sofa/jraft/core/ReplicatorGroupImpl.java
+++ b/jraft-core/src/main/java/com/alipay/sofa/jraft/core/ReplicatorGroupImpl.java
@@ -126,7 +126,7 @@ public class ReplicatorGroupImpl implements ReplicatorGroup {
         opts.setPeerId(peer);
         final ThreadId rid = Replicator.start(opts, this.raftOptions);
         if (rid == null) {
-            LOG.error("Fail to start replicator to peer={}.", peer);
+            LOG.error("Fail to start replicator to peer={}, replicatorType={}.", peer, replicatorType);
             this.failureReplicators.put(peer, replicatorType);
             return false;
         }


### PR DESCRIPTION
### Motivation:

If the learner node is not started when a new leader is elected, then the replicator to this learner will not be created, so the new logs will not be replicated to this learner even when it is started in future.

### Modification:

We should check learner replicator state in stepdown timeout handler, just like checking the follower replicator in `checkDeadNodes0`.

