### PR TITLE
Enable RocksDB force_consistency_checks = true

### DIFF
--- a/jraft-core/src/main/java/com/alipay/sofa/jraft/util/StorageOptionsFactory.java
+++ b/jraft-core/src/main/java/com/alipay/sofa/jraft/util/StorageOptionsFactory.java
@@ -253,6 +253,9 @@ public final class StorageOptionsFactory {
                 .optimizeLevelStyleCompaction();
         }
 
+        // https://github.com/facebook/rocksdb/pull/5744
+        opts.setForceConsistencyChecks(true);
+
         return opts;
     }
 

--- a/pom.xml
+++ b/pom.xml
@@ -73,7 +73,7 @@
         <project.encoding>UTF-8</project.encoding>
         <protobuf.version>3.5.1</protobuf.version>
         <protostuff.version>1.6.0</protostuff.version>
-        <rocksdb.version>6.5.2</rocksdb.version>
+        <rocksdb.version>5.18.3</rocksdb.version>
         <slf4j.version>1.7.21</slf4j.version>
     </properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -73,7 +73,7 @@
         <project.encoding>UTF-8</project.encoding>
         <protobuf.version>3.5.1</protobuf.version>
         <protostuff.version>1.6.0</protostuff.version>
-        <rocksdb.version>5.18.3</rocksdb.version>
+        <rocksdb.version>6.5.2</rocksdb.version>
         <slf4j.version>1.7.21</slf4j.version>
     </properties>
 


### PR DESCRIPTION
### Motivation:

Enable force_consistency_checks for all CFs. If rocksdb detects LSM corruption, it will either abort (before [facebook/rocksdb@a281822](https://github.com/facebook/rocksdb/commit/a28182233109f09e23e6336b5ed860ddf2c8eece)) or return background error in subsequent writes (after that patch). This is to prevent LSM corruption to propagate further and corrupt data in RocksRawKVStore. Therefore, method `getDefaultRocksDBColumnFamilyOptions` of `StorageOptionsFactory` support `force_consistency_checks` option for the latest version (6.5.2)[https://github.com/facebook/rocksdb/releases/tag/v6.5.2] of RocksDB.

### Modification:

Upgrade the dependency version of RocksDB  to 6.5.2. And method `getDefaultRocksDBColumnFamilyOptions` of `StorageOptionsFactory` add `force_consistency_checks` option for the latest version (6.5.2)[https://github.com/facebook/rocksdb/releases/tag/v6.5.2] of RocksDB. User-defined RocksDBColumnFamilyOptions could use ` com.alipay.sofa.jraft.util.StorageOptionsFactory#registerRocksDBColumnFamilyOptions` to define custom RocksDBColumnFamilyOptions.
6.5.2 version of RocksDB exists `delete` -> `ingest` bug cause that `get` method return wrong result when ingesting sst files after calling `delete` method. 

### Result:

Fixes #283
