### PR TITLE
Replace connect with isConnected

### DIFF
--- a/jraft-core/src/main/java/com/alipay/sofa/jraft/RouteTable.java
+++ b/jraft-core/src/main/java/com/alipay/sofa/jraft/RouteTable.java
@@ -240,7 +240,7 @@ public class RouteTable {
         final CliRequests.GetLeaderRequest request = rb.build();
         TimeoutException timeoutException = null;
         for (final PeerId peer : conf) {
-            if (!cliClientService.connect(peer.getEndpoint())) {
+            if (!cliClientService.isConnected(peer.getEndpoint())) {
                 if (st.isOk()) {
                     st.setError(-1, "Fail to init channel to %s", peer);
                 } else {
@@ -302,7 +302,7 @@ public class RouteTable {
             st.setError(-1, "Fail to get leader of group %s", groupId);
             return st;
         }
-        if (!cliClientService.connect(leaderId.getEndpoint())) {
+        if (!cliClientService.isConnected(leaderId.getEndpoint())) {
             st.setError(-1, "Fail to init channel to %s", leaderId);
             return st;
         }

--- a/jraft-core/src/main/java/com/alipay/sofa/jraft/core/CliServiceImpl.java
+++ b/jraft-core/src/main/java/com/alipay/sofa/jraft/core/CliServiceImpl.java
@@ -110,7 +110,7 @@ public class CliServiceImpl implements CliService {
             return st;
         }
 
-        if (!this.cliClientService.connect(leaderId.getEndpoint())) {
+        if (!this.cliClientService.isConnected(leaderId.getEndpoint())) {
             return new Status(-1, "Fail to init channel to leader %s", leaderId);
         }
         final AddPeerRequest.Builder rb = AddPeerRequest.newBuilder() //
@@ -164,7 +164,7 @@ public class CliServiceImpl implements CliService {
             return st;
         }
 
-        if (!this.cliClientService.connect(leaderId.getEndpoint())) {
+        if (!this.cliClientService.isConnected(leaderId.getEndpoint())) {
             return new Status(-1, "Fail to init channel to leader %s", leaderId);
         }
 
@@ -214,7 +214,7 @@ public class CliServiceImpl implements CliService {
             return st;
         }
 
-        if (!this.cliClientService.connect(leaderId.getEndpoint())) {
+        if (!this.cliClientService.isConnected(leaderId.getEndpoint())) {
             return new Status(-1, "Fail to init channel to leader %s", leaderId);
         }
 
@@ -259,7 +259,7 @@ public class CliServiceImpl implements CliService {
         Requires.requireNonNull(peerId, "Null peerId");
         Requires.requireNonNull(newPeers, "Null new peers");
 
-        if (!this.cliClientService.connect(peerId.getEndpoint())) {
+        if (!this.cliClientService.isConnected(peerId.getEndpoint())) {
             return new Status(-1, "Fail to init channel to %s", peerId);
         }
 
@@ -294,7 +294,7 @@ public class CliServiceImpl implements CliService {
             return st;
         }
 
-        if (!this.cliClientService.connect(leaderId.getEndpoint())) {
+        if (!this.cliClientService.isConnected(leaderId.getEndpoint())) {
             return new Status(-1, "Fail to init channel to leader %s", leaderId);
         }
         final AddLearnersRequest.Builder rb = AddLearnersRequest.newBuilder() //
@@ -355,7 +355,7 @@ public class CliServiceImpl implements CliService {
             return st;
         }
 
-        if (!this.cliClientService.connect(leaderId.getEndpoint())) {
+        if (!this.cliClientService.isConnected(leaderId.getEndpoint())) {
             return new Status(-1, "Fail to init channel to leader %s", leaderId);
         }
         final RemoveLearnersRequest.Builder rb = RemoveLearnersRequest.newBuilder() //
@@ -384,7 +384,7 @@ public class CliServiceImpl implements CliService {
             return st;
         }
 
-        if (!this.cliClientService.connect(leaderId.getEndpoint())) {
+        if (!this.cliClientService.isConnected(leaderId.getEndpoint())) {
             return new Status(-1, "Fail to init channel to leader %s", leaderId);
         }
         final ResetLearnersRequest.Builder rb = ResetLearnersRequest.newBuilder() //
@@ -415,7 +415,7 @@ public class CliServiceImpl implements CliService {
             return st;
         }
 
-        if (!this.cliClientService.connect(leaderId.getEndpoint())) {
+        if (!this.cliClientService.isConnected(leaderId.getEndpoint())) {
             return new Status(-1, "Fail to init channel to leader %s", leaderId);
         }
 
@@ -439,7 +439,7 @@ public class CliServiceImpl implements CliService {
         Requires.requireTrue(!StringUtils.isBlank(groupId), "Blank group id");
         Requires.requireNonNull(peer, "Null peer");
 
-        if (!this.cliClientService.connect(peer.getEndpoint())) {
+        if (!this.cliClientService.isConnected(peer.getEndpoint())) {
             return new Status(-1, "Fail to init channel to %s", peer);
         }
 
@@ -466,7 +466,7 @@ public class CliServiceImpl implements CliService {
 
         final Status st = new Status(-1, "Fail to get leader of group %s", groupId);
         for (final PeerId peer : conf) {
-            if (!this.cliClientService.connect(peer.getEndpoint())) {
+            if (!this.cliClientService.isConnected(peer.getEndpoint())) {
                 LOG.error("Fail to connect peer {} to get leader for group {}.", peer, groupId);
                 continue;
             }
@@ -622,7 +622,7 @@ public class CliServiceImpl implements CliService {
             throw new IllegalStateException(st.getErrorMsg());
         }
 
-        if (!this.cliClientService.connect(leaderId.getEndpoint())) {
+        if (!this.cliClientService.isConnected(leaderId.getEndpoint())) {
             throw new IllegalStateException("Fail to init channel to leader " + leaderId);
         }
 

--- a/jraft-core/src/main/java/com/alipay/sofa/jraft/core/NodeImpl.java
+++ b/jraft-core/src/main/java/com/alipay/sofa/jraft/core/NodeImpl.java
@@ -1114,7 +1114,7 @@ public class NodeImpl implements Node, RaftServerService {
                 if (peer.equals(this.serverId)) {
                     continue;
                 }
-                if (!this.rpcService.connect(peer.getEndpoint())) {
+                if (!this.rpcService.isConnected(peer.getEndpoint())) {
                     LOG.warn("Node {} channel init failed, address={}.", getNodeId(), peer.getEndpoint());
                     continue;
                 }
@@ -2563,7 +2563,7 @@ public class NodeImpl implements Node, RaftServerService {
                 if (peer.equals(this.serverId)) {
                     continue;
                 }
-                if (!this.rpcService.connect(peer.getEndpoint())) {
+                if (!this.rpcService.isConnected(peer.getEndpoint())) {
                     LOG.warn("Node {} channel init failed, address={}.", getNodeId(), peer.getEndpoint());
                     continue;
                 }

--- a/jraft-core/src/main/java/com/alipay/sofa/jraft/core/Replicator.java
+++ b/jraft-core/src/main/java/com/alipay/sofa/jraft/core/Replicator.java
@@ -798,7 +798,7 @@ public class Replicator implements ThreadId.OnError {
             throw new IllegalArgumentException("Invalid ReplicatorOptions.");
         }
         final Replicator r = new Replicator(opts, raftOptions);
-        if (!r.rpcService.connect(opts.getPeerId().getEndpoint())) {
+        if (!r.rpcService.isConnected(opts.getPeerId().getEndpoint())) {
             LOG.error("Fail to init sending channel to {}.", opts.getPeerId());
             // Return and it will be retried later.
             return null;

--- a/jraft-core/src/main/java/com/alipay/sofa/jraft/storage/snapshot/remote/RemoteFileCopier.java
+++ b/jraft-core/src/main/java/com/alipay/sofa/jraft/storage/snapshot/remote/RemoteFileCopier.java
@@ -89,7 +89,7 @@ public class RemoteFileCopier {
             LOG.error("Fail to parse readerId or endpoint.", e);
             return false;
         }
-        if (!this.rpcService.connect(this.endpoint)) {
+        if (!this.rpcService.isConnected(this.endpoint)) {
             LOG.error("Fail to init channel to {}.", this.endpoint);
             return false;
         }

--- a/jraft-core/src/test/java/com/alipay/sofa/jraft/core/ReplicatorGroupTest.java
+++ b/jraft-core/src/test/java/com/alipay/sofa/jraft/core/ReplicatorGroupTest.java
@@ -115,7 +115,7 @@ public class ReplicatorGroupTest {
 
     @Test
     public void testAddLearnerSuccess() {
-        Mockito.when(this.rpcService.connect(this.peerId1.getEndpoint())).thenReturn(true);
+        Mockito.when(this.rpcService.isConnected(this.peerId1.getEndpoint())).thenReturn(true);
         this.replicatorGroup.resetTerm(1);
         assertTrue(this.replicatorGroup.addReplicator(this.peerId1, ReplicatorType.Learner));
         assertNotNull(this.replicatorGroup.getReplicatorMap().get(this.peerId1));
@@ -124,7 +124,7 @@ public class ReplicatorGroupTest {
 
     @Test
     public void testAddReplicatorSuccess() {
-        Mockito.when(this.rpcService.connect(this.peerId1.getEndpoint())).thenReturn(true);
+        Mockito.when(this.rpcService.isConnected(this.peerId1.getEndpoint())).thenReturn(true);
         this.replicatorGroup.resetTerm(1);
         assertTrue(this.replicatorGroup.addReplicator(this.peerId1));
         assertNull(this.replicatorGroup.getFailureReplicators().get(this.peerId1));
@@ -132,7 +132,7 @@ public class ReplicatorGroupTest {
 
     @Test
     public void testStopReplicator() {
-        Mockito.when(this.rpcService.connect(this.peerId1.getEndpoint())).thenReturn(true);
+        Mockito.when(this.rpcService.isConnected(this.peerId1.getEndpoint())).thenReturn(true);
         this.replicatorGroup.resetTerm(1);
         this.replicatorGroup.addReplicator(this.peerId1);
         assertTrue(this.replicatorGroup.stopReplicator(this.peerId1));
@@ -140,9 +140,9 @@ public class ReplicatorGroupTest {
 
     @Test
     public void testStopAllReplicator() {
-        Mockito.when(this.rpcService.connect(this.peerId1.getEndpoint())).thenReturn(true);
-        Mockito.when(this.rpcService.connect(this.peerId2.getEndpoint())).thenReturn(true);
-        Mockito.when(this.rpcService.connect(this.peerId3.getEndpoint())).thenReturn(true);
+        Mockito.when(this.rpcService.isConnected(this.peerId1.getEndpoint())).thenReturn(true);
+        Mockito.when(this.rpcService.isConnected(this.peerId2.getEndpoint())).thenReturn(true);
+        Mockito.when(this.rpcService.isConnected(this.peerId3.getEndpoint())).thenReturn(true);
         this.replicatorGroup.resetTerm(1);
         this.replicatorGroup.addReplicator(this.peerId1);
         this.replicatorGroup.addReplicator(this.peerId2);
@@ -155,9 +155,9 @@ public class ReplicatorGroupTest {
 
     @Test
     public void testReplicatorWithNoRepliactorStateListener() {
-        Mockito.when(this.rpcService.connect(this.peerId1.getEndpoint())).thenReturn(true);
-        Mockito.when(this.rpcService.connect(this.peerId2.getEndpoint())).thenReturn(true);
-        Mockito.when(this.rpcService.connect(this.peerId3.getEndpoint())).thenReturn(true);
+        Mockito.when(this.rpcService.isConnected(this.peerId1.getEndpoint())).thenReturn(true);
+        Mockito.when(this.rpcService.isConnected(this.peerId2.getEndpoint())).thenReturn(true);
+        Mockito.when(this.rpcService.isConnected(this.peerId3.getEndpoint())).thenReturn(true);
         this.replicatorGroup.resetTerm(1);
         this.replicatorGroup.addReplicator(this.peerId1);
         this.replicatorGroup.addReplicator(this.peerId2);
@@ -191,9 +191,9 @@ public class ReplicatorGroupTest {
 
     @Test
     public void testTransferLeadershipToAndStop() {
-        Mockito.when(this.rpcService.connect(this.peerId1.getEndpoint())).thenReturn(true);
-        Mockito.when(this.rpcService.connect(this.peerId2.getEndpoint())).thenReturn(true);
-        Mockito.when(this.rpcService.connect(this.peerId3.getEndpoint())).thenReturn(true);
+        Mockito.when(this.rpcService.isConnected(this.peerId1.getEndpoint())).thenReturn(true);
+        Mockito.when(this.rpcService.isConnected(this.peerId2.getEndpoint())).thenReturn(true);
+        Mockito.when(this.rpcService.isConnected(this.peerId3.getEndpoint())).thenReturn(true);
         this.replicatorGroup.resetTerm(1);
         this.replicatorGroup.addReplicator(this.peerId1);
         this.replicatorGroup.addReplicator(this.peerId2);
@@ -212,9 +212,9 @@ public class ReplicatorGroupTest {
         final PeerId p1 = new PeerId("localhost", 18881, 0, 60);
         final PeerId p2 = new PeerId("localhost", 18882, 0, 80);
         final PeerId p3 = new PeerId("localhost", 18883, 0, 100);
-        Mockito.when(this.rpcService.connect(p1.getEndpoint())).thenReturn(true);
-        Mockito.when(this.rpcService.connect(p2.getEndpoint())).thenReturn(true);
-        Mockito.when(this.rpcService.connect(p3.getEndpoint())).thenReturn(true);
+        Mockito.when(this.rpcService.isConnected(p1.getEndpoint())).thenReturn(true);
+        Mockito.when(this.rpcService.isConnected(p2.getEndpoint())).thenReturn(true);
+        Mockito.when(this.rpcService.isConnected(p3.getEndpoint())).thenReturn(true);
         this.replicatorGroup.resetTerm(1);
         this.replicatorGroup.addReplicator(p1);
         this.replicatorGroup.addReplicator(p2);
@@ -230,9 +230,9 @@ public class ReplicatorGroupTest {
         final PeerId p1 = new PeerId("localhost", 18881, 0, 0);
         final PeerId p2 = new PeerId("localhost", 18882, 0, 0);
         final PeerId p3 = new PeerId("localhost", 18883, 0, -1);
-        Mockito.when(this.rpcService.connect(p1.getEndpoint())).thenReturn(true);
-        Mockito.when(this.rpcService.connect(p2.getEndpoint())).thenReturn(true);
-        Mockito.when(this.rpcService.connect(p3.getEndpoint())).thenReturn(true);
+        Mockito.when(this.rpcService.isConnected(p1.getEndpoint())).thenReturn(true);
+        Mockito.when(this.rpcService.isConnected(p2.getEndpoint())).thenReturn(true);
+        Mockito.when(this.rpcService.isConnected(p3.getEndpoint())).thenReturn(true);
         this.replicatorGroup.resetTerm(1);
         this.replicatorGroup.addReplicator(p1);
         this.replicatorGroup.addReplicator(p2);

--- a/jraft-core/src/test/java/com/alipay/sofa/jraft/core/ReplicatorTest.java
+++ b/jraft-core/src/test/java/com/alipay/sofa/jraft/core/ReplicatorTest.java
@@ -104,7 +104,7 @@ public class ReplicatorTest {
 
         Mockito.when(this.logManager.getLastLogIndex()).thenReturn(10L);
         Mockito.when(this.logManager.getTerm(10)).thenReturn(1L);
-        Mockito.when(this.rpcService.connect(this.peerId.getEndpoint())).thenReturn(true);
+        Mockito.when(this.rpcService.isConnected(this.peerId.getEndpoint())).thenReturn(true);
         Mockito.when(this.node.getNodeMetrics()).thenReturn(new NodeMetrics(true));
         // mock send empty entries
         mockSendEmptyEntries();

--- a/jraft-core/src/test/java/com/alipay/sofa/jraft/storage/SnapshotExecutorTest.java
+++ b/jraft-core/src/test/java/com/alipay/sofa/jraft/storage/SnapshotExecutorTest.java
@@ -149,7 +149,7 @@ public class SnapshotExecutorTest extends BaseStorageTest {
         irb.setTerm(0);
         irb.setMeta(RaftOutter.SnapshotMeta.newBuilder().setLastIncludedIndex(1).setLastIncludedTerm(2));
 
-        Mockito.when(this.raftClientService.connect(new Endpoint("localhost", 8080))).thenReturn(true);
+        Mockito.when(this.raftClientService.isConnected(new Endpoint("localhost", 8080))).thenReturn(true);
 
         final FutureImpl<Message> future = new FutureImpl<>();
         final RpcRequests.GetFileRequest.Builder rb = RpcRequests.GetFileRequest.newBuilder().setReaderId(99)
@@ -218,7 +218,7 @@ public class SnapshotExecutorTest extends BaseStorageTest {
         irb.setTerm(0);
         irb.setMeta(RaftOutter.SnapshotMeta.newBuilder().setLastIncludedIndex(1).setLastIncludedTerm(1));
 
-        Mockito.when(this.raftClientService.connect(new Endpoint("localhost", 8080))).thenReturn(true);
+        Mockito.when(this.raftClientService.isConnected(new Endpoint("localhost", 8080))).thenReturn(true);
 
         final FutureImpl<Message> future = new FutureImpl<>();
         final RpcRequests.GetFileRequest.Builder rb = RpcRequests.GetFileRequest.newBuilder().setReaderId(99)

--- a/jraft-core/src/test/java/com/alipay/sofa/jraft/storage/snapshot/local/LocalSnapshotCopierTest.java
+++ b/jraft-core/src/test/java/com/alipay/sofa/jraft/storage/snapshot/local/LocalSnapshotCopierTest.java
@@ -92,7 +92,7 @@ public class LocalSnapshotCopierTest extends BaseStorageTest {
         this.uri = "remote://" + this.hostPort + "/" + this.readerId;
         this.copier = new LocalSnapshotCopier();
         this.copyOpts = new CopyOptions();
-        Mockito.when(this.raftClientService.connect(new Endpoint("localhost", 8081))).thenReturn(true);
+        Mockito.when(this.raftClientService.isConnected(new Endpoint("localhost", 8081))).thenReturn(true);
         assertTrue(this.copier.init(this.uri, new SnapshotCopierOptions(this.raftClientService, this.timerManager,
             this.raftOptions, new NodeOptions())));
         this.copier.setStorage(this.snapshotStorage);

--- a/jraft-core/src/test/java/com/alipay/sofa/jraft/storage/snapshot/remote/RemoteFileCopierTest.java
+++ b/jraft-core/src/test/java/com/alipay/sofa/jraft/storage/snapshot/remote/RemoteFileCopierTest.java
@@ -51,7 +51,7 @@ public class RemoteFileCopierTest {
 
     @Test
     public void testInit() {
-        Mockito.when(rpcService.connect(new Endpoint("localhost", 8081))).thenReturn(true);
+        Mockito.when(rpcService.isConnected(new Endpoint("localhost", 8081))).thenReturn(true);
         assertTrue(copier.init("remote://localhost:8081/999", null, new SnapshotCopierOptions(rpcService, timerManager,
             new RaftOptions(), new NodeOptions())));
         assertEquals(999, copier.getReaderId());
@@ -61,7 +61,7 @@ public class RemoteFileCopierTest {
 
     @Test
     public void testInitFail() {
-        Mockito.when(rpcService.connect(new Endpoint("localhost", 8081))).thenReturn(false);
+        Mockito.when(rpcService.isConnected(new Endpoint("localhost", 8081))).thenReturn(false);
         assertFalse(copier.init("remote://localhost:8081/999", null, new SnapshotCopierOptions(rpcService,
             timerManager, new RaftOptions(), new NodeOptions())));
     }


### PR DESCRIPTION
### Motivation:

Method `connect` of `ClientService` uses `PingRequest` which `ping` is a blocking call and isn't needed, there we should let rpc framework `SOFABolt` to check connections.

### Modification:

Replace `connect` method calling with `isConnected`

### Result:

Fixes #386