### PR TITLE
Feature/segment storage improvement

### DIFF
--- a/jraft-core/pom.xml
+++ b/jraft-core/pom.xml
@@ -36,6 +36,11 @@
             <groupId>org.rocksdb</groupId>
             <artifactId>rocksdbjni</artifactId>
         </dependency>
+        <!--  jna -->
+        <dependency>
+            <groupId>net.java.dev.jna</groupId>
+            <artifactId>jna</artifactId>
+        </dependency>
         <!-- jctools -->
         <dependency>
             <groupId>org.jctools</groupId>

--- a/jraft-core/src/main/java/com/alipay/sofa/jraft/core/DefaultJRaftServiceFactory.java
+++ b/jraft-core/src/main/java/com/alipay/sofa/jraft/core/DefaultJRaftServiceFactory.java
@@ -26,7 +26,7 @@ import com.alipay.sofa.jraft.storage.LogStorage;
 import com.alipay.sofa.jraft.storage.RaftMetaStorage;
 import com.alipay.sofa.jraft.storage.SnapshotStorage;
 import com.alipay.sofa.jraft.storage.impl.LocalRaftMetaStorage;
-import com.alipay.sofa.jraft.storage.log.RocksDBSegmentLogStorage;
+import com.alipay.sofa.jraft.storage.impl.RocksDBLogStorage;
 import com.alipay.sofa.jraft.storage.snapshot.local.LocalSnapshotStorage;
 import com.alipay.sofa.jraft.util.Requires;
 import com.alipay.sofa.jraft.util.SPI;
@@ -47,7 +47,7 @@ public class DefaultJRaftServiceFactory implements JRaftServiceFactory {
     @Override
     public LogStorage createLogStorage(final String uri, final RaftOptions raftOptions) {
         Requires.requireTrue(StringUtils.isNotBlank(uri), "Blank log storage uri.");
-        return new RocksDBSegmentLogStorage(uri, raftOptions);
+        return new RocksDBLogStorage(uri, raftOptions);
     }
 
     @Override

--- a/jraft-core/src/main/java/com/alipay/sofa/jraft/core/DefaultJRaftServiceFactory.java
+++ b/jraft-core/src/main/java/com/alipay/sofa/jraft/core/DefaultJRaftServiceFactory.java
@@ -26,7 +26,7 @@ import com.alipay.sofa.jraft.storage.LogStorage;
 import com.alipay.sofa.jraft.storage.RaftMetaStorage;
 import com.alipay.sofa.jraft.storage.SnapshotStorage;
 import com.alipay.sofa.jraft.storage.impl.LocalRaftMetaStorage;
-import com.alipay.sofa.jraft.storage.impl.RocksDBLogStorage;
+import com.alipay.sofa.jraft.storage.log.RocksDBSegmentLogStorage;
 import com.alipay.sofa.jraft.storage.snapshot.local.LocalSnapshotStorage;
 import com.alipay.sofa.jraft.util.Requires;
 import com.alipay.sofa.jraft.util.SPI;
@@ -47,7 +47,7 @@ public class DefaultJRaftServiceFactory implements JRaftServiceFactory {
     @Override
     public LogStorage createLogStorage(final String uri, final RaftOptions raftOptions) {
         Requires.requireTrue(StringUtils.isNotBlank(uri), "Blank log storage uri.");
-        return new RocksDBLogStorage(uri, raftOptions);
+        return new RocksDBSegmentLogStorage(uri, raftOptions);
     }
 
     @Override

--- a/jraft-core/src/main/java/com/alipay/sofa/jraft/core/FSMCallerImpl.java
+++ b/jraft-core/src/main/java/com/alipay/sofa/jraft/core/FSMCallerImpl.java
@@ -233,7 +233,7 @@ public class FSMCallerImpl implements FSMCaller {
             return false;
         }
         if (!this.taskQueue.tryPublishEvent(tpl)) {
-            onError(new RaftException(ErrorType.ERROR_TYPE_STATE_MACHINE, new Status(RaftError.EBUSY,
+            setError(new RaftException(ErrorType.ERROR_TYPE_STATE_MACHINE, new Status(RaftError.EBUSY,
                 "FSMCaller is overload.")));
             return false;
         }

--- a/jraft-core/src/main/java/com/alipay/sofa/jraft/storage/impl/LogManagerImpl.java
+++ b/jraft-core/src/main/java/com/alipay/sofa/jraft/storage/impl/LogManagerImpl.java
@@ -620,6 +620,9 @@ public class LogManagerImpl implements LogManager {
             if (this.lastSnapshotId.compareTo(this.appliedId) > 0) {
                 this.appliedId = this.lastSnapshotId.copy();
             }
+            if (this.lastSnapshotId.compareTo(this.diskId) > 0) {
+                this.diskId = this.lastSnapshotId.copy();
+            }
 
             if (term == 0) {
                 // last_included_index is larger than last_index

--- a/jraft-core/src/main/java/com/alipay/sofa/jraft/storage/impl/RocksDBLogStorage.java
+++ b/jraft-core/src/main/java/com/alipay/sofa/jraft/storage/impl/RocksDBLogStorage.java
@@ -100,7 +100,7 @@ public class RocksDBLogStorage implements LogStorage, Describer {
         }
 
         /**
-         * finish a sub job
+         * Finish a sub job
          */
         default void finishJob() {
         }
@@ -113,7 +113,7 @@ public class RocksDBLogStorage implements LogStorage, Describer {
         }
 
         /**
-         * wait for all sub jobs finish.
+         * Wait for all sub jobs finish.
          */
         default void joinAll() throws InterruptedException, IOException {
         }

--- a/jraft-core/src/main/java/com/alipay/sofa/jraft/storage/impl/RocksDBLogStorage.java
+++ b/jraft-core/src/main/java/com/alipay/sofa/jraft/storage/impl/RocksDBLogStorage.java
@@ -657,6 +657,7 @@ public class RocksDBLogStorage implements LogStorage, Describer {
      */
     protected byte[] onDataAppend(final long logIndex, final byte[] value, final CountDownLatch latch)
                                                                                                       throws IOException {
+        latch.countDown();
         return value;
     }
 

--- a/jraft-core/src/main/java/com/alipay/sofa/jraft/storage/impl/RocksDBLogStorage.java
+++ b/jraft-core/src/main/java/com/alipay/sofa/jraft/storage/impl/RocksDBLogStorage.java
@@ -465,9 +465,7 @@ public class RocksDBLogStorage implements LogStorage, Describer {
     }
 
     private void doSync() throws IOException {
-        if (this.sync) {
-            onSync();
-        }
+        onSync();
     }
 
     @Override
@@ -621,6 +619,10 @@ public class RocksDBLogStorage implements LogStorage, Describer {
      * Called when sync data into file system.
      */
     protected void onSync() throws IOException {
+    }
+
+    protected boolean isSync() {
+        return this.sync;
     }
 
     /**

--- a/jraft-core/src/main/java/com/alipay/sofa/jraft/storage/impl/RocksDBLogStorage.java
+++ b/jraft-core/src/main/java/com/alipay/sofa/jraft/storage/impl/RocksDBLogStorage.java
@@ -437,7 +437,8 @@ public class RocksDBLogStorage implements LogStorage, Describer {
 
     private void addDataBatch(final LogEntry entry, final WriteBatch batch, final CountDownEvent events)
                                                                                                         throws RocksDBException,
-                                                                                                        IOException {
+                                                                                                        IOException,
+                                                                                                        InterruptedException {
         final long logIndex = entry.getId().getIndex();
         final byte[] content = this.logEntryEncoder.encode(entry);
         batch.put(this.defaultHandle, getKeyBytes(logIndex), onDataAppend(logIndex, content, events));
@@ -477,7 +478,7 @@ public class RocksDBLogStorage implements LogStorage, Describer {
         }
     }
 
-    private void doSync() throws IOException {
+    private void doSync() throws IOException, InterruptedException {
         onSync();
     }
 
@@ -641,7 +642,7 @@ public class RocksDBLogStorage implements LogStorage, Describer {
     /**
      * Called when sync data into file system.
      */
-    protected void onSync() throws IOException {
+    protected void onSync() throws IOException, InterruptedException {
     }
 
     protected boolean isSync() {
@@ -664,7 +665,8 @@ public class RocksDBLogStorage implements LogStorage, Describer {
      * @return the new value
      */
     protected byte[] onDataAppend(final long logIndex, final byte[] value, final CountDownEvent events)
-                                                                                                       throws IOException {
+                                                                                                       throws IOException,
+                                                                                                       InterruptedException {
         events.countDown();
         return value;
     }

--- a/jraft-core/src/main/java/com/alipay/sofa/jraft/storage/impl/RocksDBLogStorage.java
+++ b/jraft-core/src/main/java/com/alipay/sofa/jraft/storage/impl/RocksDBLogStorage.java
@@ -92,31 +92,31 @@ public class RocksDBLogStorage implements LogStorage, Describer {
      * @author boyan(boyan@antfin.com)
      *
      */
-    public static interface WriteContext {
+    public interface WriteContext {
         /**
          * Start a sub job.
          */
         default void startJob() {
-        };
+        }
 
         /**
          * finish a sub job
          */
         default void finishJob() {
-        };
+        }
 
         /**
          * Set an exception to context.
          * @param e
          */
         default void setError(final Exception e) {
-        };
+        }
 
         /**
          * wait for all sub jobs finish.
          */
         default void joinAll() throws InterruptedException, IOException {
-        };
+        }
     }
 
     /**

--- a/jraft-core/src/main/java/com/alipay/sofa/jraft/storage/impl/RocksDBLogStorage.java
+++ b/jraft-core/src/main/java/com/alipay/sofa/jraft/storage/impl/RocksDBLogStorage.java
@@ -290,7 +290,7 @@ public class RocksDBLogStorage implements LogStorage, Describer {
         } catch (final IOException e) {
             LOG.error("Execute batch failed with io exception.", e);
             return false;
-        } catch (InterruptedException e) {
+        } catch (final InterruptedException e) {
             LOG.error("Execute batch failed with interrupt.", e);
             Thread.currentThread().interrupt();
             return false;
@@ -469,7 +469,7 @@ public class RocksDBLogStorage implements LogStorage, Describer {
             } catch (final RocksDBException | IOException e) {
                 LOG.error("Fail to append entry.", e);
                 return false;
-            } catch (InterruptedException e) {
+            } catch (final InterruptedException e) {
                 Thread.currentThread().interrupt();
                 return false;
             } finally {
@@ -513,7 +513,7 @@ public class RocksDBLogStorage implements LogStorage, Describer {
     private void awaitEvents(final CountDownEvent events) throws InterruptedException, IOException {
         events.await();
         if (events.getAttachment() != null) {
-            throw new IOException("Fail to append entires", (Exception) events.getAttachment());
+            throw new IOException("Fail to append entries", (Exception) events.getAttachment());
         }
     }
 

--- a/jraft-core/src/main/java/com/alipay/sofa/jraft/storage/log/AbortFile.java
+++ b/jraft-core/src/main/java/com/alipay/sofa/jraft/storage/log/AbortFile.java
@@ -48,7 +48,8 @@ public class AbortFile {
         final File file = new File(this.path);
         if (file.createNewFile()) {
             try (FileWriter writer = new FileWriter(file, false)) {
-                writer.write(new Date().toGMTString() + "\r\n");
+                writer.write(new Date().toGMTString());
+                writer.write(System.lineSeparator());
             }
             return true;
         } else {

--- a/jraft-core/src/main/java/com/alipay/sofa/jraft/storage/log/AbortFile.java
+++ b/jraft-core/src/main/java/com/alipay/sofa/jraft/storage/log/AbortFile.java
@@ -17,9 +17,9 @@
 package com.alipay.sofa.jraft.storage.log;
 
 import java.io.File;
+import java.io.FileWriter;
 import java.io.IOException;
-
-import com.alipay.sofa.jraft.util.Utils;
+import java.util.Date;
 
 /**
  * Abort file
@@ -40,13 +40,24 @@ public class AbortFile {
     }
 
     public boolean create() throws IOException {
-        return new File(this.path) //
-            .createNewFile();
+        return writeDate();
     }
 
-    public boolean touch() {
-        return new File(this.path) //
-            .setLastModified(Utils.nowMs());
+    @SuppressWarnings("deprecation")
+    private boolean writeDate() throws IOException {
+        final File file = new File(this.path);
+        if (file.createNewFile()) {
+            try (FileWriter writer = new FileWriter(file, false)) {
+                writer.write(new Date().toGMTString() + "\r\n");
+            }
+            return true;
+        } else {
+            return false;
+        }
+    }
+
+    public boolean touch() throws IOException {
+        return writeDate();
     }
 
     public boolean exists() {

--- a/jraft-core/src/main/java/com/alipay/sofa/jraft/storage/log/CheckpointFile.java
+++ b/jraft-core/src/main/java/com/alipay/sofa/jraft/storage/log/CheckpointFile.java
@@ -23,8 +23,8 @@ import org.apache.commons.io.FileUtils;
 
 import com.alipay.sofa.jraft.entity.LocalFileMetaOutter.LocalFileMeta;
 import com.alipay.sofa.jraft.storage.io.ProtoBufFile;
+import com.alipay.sofa.jraft.util.AsciiStringUtil;
 import com.alipay.sofa.jraft.util.Bits;
-import com.alipay.sofa.jraft.util.Utils;
 import com.google.protobuf.ZeroByteStringHelper;
 
 /**
@@ -54,10 +54,9 @@ public class CheckpointFile {
          * commitPos (4 bytes) + path(4 byte len + string bytes)
          */
         byte[] encode() {
-            byte[] bs = new byte[8 + this.segFilename.length()];
+            byte[] ps = AsciiStringUtil.unsafeEncode(this.segFilename);
+            byte[] bs = new byte[8 + ps.length];
             Bits.putInt(bs, 0, this.committedPos);
-
-            byte[] ps = Utils.getBytes(this.segFilename);
             Bits.putInt(bs, 4, ps.length);
             System.arraycopy(ps, 0, bs, 8, ps.length);
             return bs;
@@ -69,7 +68,7 @@ public class CheckpointFile {
             }
             this.committedPos = Bits.getInt(bs, 0);
             int len = Bits.getInt(bs, 4);
-            this.segFilename = Utils.getString(bs, 8, len);
+            this.segFilename = AsciiStringUtil.unsafeDecode(bs, 8, len);
             return this.committedPos >= 0 && !this.segFilename.isEmpty();
         }
 

--- a/jraft-core/src/main/java/com/alipay/sofa/jraft/storage/log/CheckpointFile.java
+++ b/jraft-core/src/main/java/com/alipay/sofa/jraft/storage/log/CheckpointFile.java
@@ -39,14 +39,14 @@ public class CheckpointFile {
      * @author boyan(boyan@antfin.com)
      */
     public static final class Checkpoint {
-        // Segment file path
-        public String segPath;
+        // Segment file name
+        public String segFilename;
         // Segment file current commit position.
         public int    committedPos;
 
-        public Checkpoint(final String segPath, final int committedPos) {
+        public Checkpoint(final String segFilename, final int committedPos) {
             super();
-            this.segPath = segPath;
+            this.segFilename = segFilename;
             this.committedPos = committedPos;
         }
 
@@ -54,10 +54,10 @@ public class CheckpointFile {
          * commitPos (4 bytes) + path(4 byte len + string bytes)
          */
         byte[] encode() {
-            byte[] bs = new byte[8 + this.segPath.length()];
+            byte[] bs = new byte[8 + this.segFilename.length()];
             Bits.putInt(bs, 0, this.committedPos);
 
-            byte[] ps = Utils.getBytes(this.segPath);
+            byte[] ps = Utils.getBytes(this.segFilename);
             Bits.putInt(bs, 4, ps.length);
             System.arraycopy(ps, 0, bs, 8, ps.length);
             return bs;
@@ -69,13 +69,13 @@ public class CheckpointFile {
             }
             this.committedPos = Bits.getInt(bs, 0);
             int len = Bits.getInt(bs, 4);
-            this.segPath = Utils.getString(bs, 8, len);
-            return this.committedPos >= 0 && !this.segPath.isEmpty();
+            this.segFilename = Utils.getString(bs, 8, len);
+            return this.committedPos >= 0 && !this.segFilename.isEmpty();
         }
 
         @Override
         public String toString() {
-            return "Checkpoint [segPath=" + this.segPath + ", committedPos=" + this.committedPos + "]";
+            return "Checkpoint [segFilename=" + this.segFilename + ", committedPos=" + this.committedPos + "]";
         }
     }
 

--- a/jraft-core/src/main/java/com/alipay/sofa/jraft/storage/log/LibC.java
+++ b/jraft-core/src/main/java/com/alipay/sofa/jraft/storage/log/LibC.java
@@ -1,0 +1,60 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alipay.sofa.jraft.storage.log;
+
+import com.sun.jna.Library;
+import com.sun.jna.Native;
+import com.sun.jna.NativeLong;
+import com.sun.jna.Platform;
+import com.sun.jna.Pointer;
+
+/**
+ * Moved from rocketmq.
+ *
+ *  https://raw.githubusercontent.com/apache/rocketmq/master/store/src/main/java/org/apache/rocketmq/store/util/LibC.java
+ * @author boyan(boyan@antfin.com)
+ *
+ */
+public interface LibC extends Library {
+    LibC INSTANCE      = Native.load(Platform.isWindows() ? "msvcrt" : "c", LibC.class);
+
+    int  MADV_WILLNEED = 3;
+    int  MADV_DONTNEED = 4;
+
+    int  MCL_CURRENT   = 1;
+    int  MCL_FUTURE    = 2;
+    int  MCL_ONFAULT   = 4;
+
+    /* sync memory asynchronously */
+    int  MS_ASYNC      = 0x0001;
+    /* invalidate mappings & caches */
+    int  MS_INVALIDATE = 0x0002;
+    /* synchronous memory sync */
+    int  MS_SYNC       = 0x0004;
+
+    int mlock(Pointer var1, NativeLong var2);
+
+    int munlock(Pointer var1, NativeLong var2);
+
+    int madvise(Pointer var1, NativeLong var2, int var3);
+
+    Pointer memset(Pointer p, int v, long len);
+
+    int mlockall(int flags);
+
+    int msync(Pointer p, NativeLong length, int flags);
+}

--- a/jraft-core/src/main/java/com/alipay/sofa/jraft/storage/log/RocksDBSegmentLogStorage.java
+++ b/jraft-core/src/main/java/com/alipay/sofa/jraft/storage/log/RocksDBSegmentLogStorage.java
@@ -112,9 +112,9 @@ public class RocksDBSegmentLogStorage extends RocksDBLogStorage {
         this.abortFile = new AbortFile(this.segmentsPath + File.separator + "abort");
         this.checkpointFile = new CheckpointFile(this.segmentsPath + File.separator + "checkpoint");
         this.valueSizeThreshold = valueSizeThreshold;
-        this.writeExecutor = ThreadPoolUtil.newThreadPool("RocksDBSegmentLogStorage-write-pool", true, 10, 100, 60,
-            new ArrayBlockingQueue<>(10000), new NamedThreadFactory("RocksDBSegmentLogStorageWriter"),
-            new ThreadPoolExecutor.CallerRunsPolicy());
+        this.writeExecutor = ThreadPoolUtil.newThreadPool("RocksDBSegmentLogStorage-write-pool", true, Utils.cpus(),
+            Utils.cpus() * 6, 60, new ArrayBlockingQueue<>(10000), new NamedThreadFactory(
+                "RocksDBSegmentLogStorageWriter"), new ThreadPoolExecutor.CallerRunsPolicy());
 
     }
 

--- a/jraft-core/src/main/java/com/alipay/sofa/jraft/storage/log/RocksDBSegmentLogStorage.java
+++ b/jraft-core/src/main/java/com/alipay/sofa/jraft/storage/log/RocksDBSegmentLogStorage.java
@@ -239,8 +239,8 @@ public class RocksDBSegmentLogStorage extends RocksDBLogStorage {
      * Creates a RocksDBSegmentLogStorage builder.
      * @return a builder instance.
      */
-    public static final Builder builder() {
-        return new Builder();
+    public static final Builder builder(final String uri, final RaftOptions raftOptions) {
+        return new Builder().setPath(uri).setRaftOptions(raftOptions);
     }
 
     public RocksDBSegmentLogStorage(final String path, final RaftOptions raftOptions) {

--- a/jraft-core/src/main/java/com/alipay/sofa/jraft/storage/log/RocksDBSegmentLogStorage.java
+++ b/jraft-core/src/main/java/com/alipay/sofa/jraft/storage/log/RocksDBSegmentLogStorage.java
@@ -142,7 +142,7 @@ public class RocksDBSegmentLogStorage extends RocksDBLogStorage {
             if (!this.segments.isEmpty()) {
                 // Sync current last file and correct it's lastLogIndex.
                 final SegmentFile currLastFile = this.segments.get(this.segments.size() - 1);
-                currLastFile.sync();
+                currLastFile.sync(isSync());
                 currLastFile.setLastLogIndex(logIndex - 1);
             }
             final SegmentFile segmentFile = new SegmentFile(logIndex, MAX_SEGMENT_FILE_SIZE, this.segmentsPath);
@@ -161,7 +161,7 @@ public class RocksDBSegmentLogStorage extends RocksDBLogStorage {
     protected void onSync() throws IOException {
         final SegmentFile lastSegmentFile = getLastSegmentFileForRead();
         if (lastSegmentFile != null) {
-            lastSegmentFile.sync();
+            lastSegmentFile.sync(isSync());
         }
     }
 

--- a/jraft-core/src/main/java/com/alipay/sofa/jraft/storage/log/RocksDBSegmentLogStorage.java
+++ b/jraft-core/src/main/java/com/alipay/sofa/jraft/storage/log/RocksDBSegmentLogStorage.java
@@ -382,7 +382,7 @@ public class RocksDBSegmentLogStorage extends RocksDBLogStorage {
         if (!segmentFile.init(opts)) {
             throw new IOException("Fail to create new segment file");
         }
-        segmentFile.mlock();
+        segmentFile.hintLoad();
         LOG.info("Create a new segment file {}.", segmentFile.getPath());
         return segmentFile;
     }
@@ -599,7 +599,7 @@ public class RocksDBSegmentLogStorage extends RocksDBLogStorage {
                 if (!segFile.isSwappedOut()) {
                     segmentsInMemeCount++;
                     if (segmentsInMemeCount >= this.keepInMemorySegmentCount && i != lastIndex) {
-                        segFile.munlock();
+                        segFile.hintUnload();
                         segFile.swapOut();
                         swappedOutCount++;
                     }
@@ -889,8 +889,9 @@ public class RocksDBSegmentLogStorage extends RocksDBLogStorage {
                                 prevIndex--;
                             }
                         } else {
-                            LOG.warn("Log entry not found at index={} when truncate suffix from {}.", prevIndex,
-                                lastIndexKept);
+                            LOG.warn(
+                                "Log entry not found at index={} when truncating logs suffix from lastIndexKept={}.",
+                                prevIndex, lastIndexKept);
                             prevIndex--;
                         }
                     }

--- a/jraft-core/src/main/java/com/alipay/sofa/jraft/storage/log/RocksDBSegmentLogStorage.java
+++ b/jraft-core/src/main/java/com/alipay/sofa/jraft/storage/log/RocksDBSegmentLogStorage.java
@@ -41,7 +41,6 @@ import org.rocksdb.RocksDBException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.alipay.sofa.jraft.error.LogEntryCorruptedException;
 import com.alipay.sofa.jraft.option.RaftOptions;
 import com.alipay.sofa.jraft.storage.impl.RocksDBLogStorage;
 import com.alipay.sofa.jraft.storage.log.CheckpointFile.Checkpoint;
@@ -890,8 +889,9 @@ public class RocksDBSegmentLogStorage extends RocksDBLogStorage {
                                 prevIndex--;
                             }
                         } else {
-                            // Data not found, should not happen.
-                            throw new LogEntryCorruptedException("Log entry data not found at index=" + prevIndex);
+                            LOG.warn("Log entry not found at index={} when truncate suffix from {}.", prevIndex,
+                                lastIndexKept);
+                            prevIndex--;
                         }
                     }
                 }

--- a/jraft-core/src/main/java/com/alipay/sofa/jraft/storage/log/RocksDBSegmentLogStorage.java
+++ b/jraft-core/src/main/java/com/alipay/sofa/jraft/storage/log/RocksDBSegmentLogStorage.java
@@ -335,7 +335,7 @@ public class RocksDBSegmentLogStorage extends RocksDBLogStorage {
                     try {
                         currLastFile.setReadOnly(true);
                         currLastFile.sync(isSync());
-                    } catch (IOException e) {
+                    } catch (final IOException e) {
                         events.setAttachment(e);
                     } finally {
                         events.countDown();
@@ -576,9 +576,9 @@ public class RocksDBSegmentLogStorage extends RocksDBLogStorage {
             }
             doAllocateSegment0();
             this.emptyCond.signal();
-        } catch (InterruptedException e) {
+        } catch (final InterruptedException e) {
             Thread.currentThread().interrupt();
-        } catch (IOException e) {
+        } catch (final IOException e) {
             this.blankSegments.add(new AllocatedResult(e));
             this.emptyCond.signal();
         } finally {
@@ -608,7 +608,7 @@ public class RocksDBSegmentLogStorage extends RocksDBLogStorage {
                 }
             }
             LOG.info("Swapped out {} segment files, cost {} ms.", swappedOutCount, Utils.monotonicMs() - beginTime);
-        } catch (Exception e) {
+        } catch (final Exception e) {
             LOG.error("Fail to swap out segments.", e);
         } finally {
             this.readLock.unlock();
@@ -680,7 +680,7 @@ public class RocksDBSegmentLogStorage extends RocksDBLogStorage {
         this.segmentAllocator.interrupt();
         try {
             this.segmentAllocator.join(500);
-        } catch (InterruptedException e) {
+        } catch (final InterruptedException e) {
             Thread.currentThread().interrupt();
         }
     }
@@ -742,7 +742,7 @@ public class RocksDBSegmentLogStorage extends RocksDBLogStorage {
                 this.checkpointFile.save(new Checkpoint(lastSegmentFile.getFilename(), lastSegmentFile
                     .getCommittedPos()));
             }
-        } catch (InterruptedException e) {
+        } catch (final InterruptedException e) {
             Thread.currentThread().interrupt();
         } catch (final IOException e) {
             LOG.error("Fatal error, fail to do checkpoint, last segment file is {}.",

--- a/jraft-core/src/main/java/com/alipay/sofa/jraft/storage/log/RocksDBSegmentLogStorage.java
+++ b/jraft-core/src/main/java/com/alipay/sofa/jraft/storage/log/RocksDBSegmentLogStorage.java
@@ -281,7 +281,7 @@ public class RocksDBSegmentLogStorage extends RocksDBLogStorage {
             final Checkpoint checkpoint = loadCheckpoint();
 
             final File[] segmentFiles = segmentsDir
-                .listFiles((final File dir, final String name) -> SEGMENT_FILE_NAME_PATTERN.matcher(name).matches());
+                    .listFiles((final File dir, final String name) -> SEGMENT_FILE_NAME_PATTERN.matcher(name).matches());
 
             final boolean normalExit = !this.abortFile.exists();
             if (!normalExit) {
@@ -344,11 +344,11 @@ public class RocksDBSegmentLogStorage extends RocksDBLogStorage {
                     }
 
                     final SegmentFileOptions opts = SegmentFileOptions.builder() //
-                        .setSync(isSync()) //
-                        .setRecover(needRecover && !normalExit) //
-                        .setLastFile(isLastFile) //
-                        .setNewFile(false) //
-                        .setPos(pos).build();
+                            .setSync(isSync()) //
+                            .setRecover(needRecover && !normalExit) //
+                            .setLastFile(isLastFile) //
+                            .setNewFile(false) //
+                            .setPos(pos).build();
 
                     if (!segmentFile.init(opts)) {
                         LOG.error("Fail to load segment file {}.", segmentFile.getPath());
@@ -415,6 +415,7 @@ public class RocksDBSegmentLogStorage extends RocksDBLogStorage {
 
         };
         this.segmentAllocator.setDaemon(true);
+        this.segmentAllocator.setName("SegmentAllocator");
         this.segmentAllocator.start();
     }
 
@@ -479,7 +480,7 @@ public class RocksDBSegmentLogStorage extends RocksDBLogStorage {
 
     private void startCheckpointTask() {
         this.checkpointExecutor = Executors
-            .newSingleThreadScheduledExecutor(new NamedThreadFactory(getServiceName() + "-Checkpoint-Thread-", true));
+                .newSingleThreadScheduledExecutor(new NamedThreadFactory(getServiceName() + "-Checkpoint-Thread-", true));
         this.checkpointExecutor.scheduleAtFixedRate(this::doCheckpoint, DEFAULT_CHECKPOINT_INTERVAL_MS,
             DEFAULT_CHECKPOINT_INTERVAL_MS, TimeUnit.MILLISECONDS);
         LOG.info("{} started checkpoint task.", getServiceName());

--- a/jraft-core/src/main/java/com/alipay/sofa/jraft/storage/log/SegmentFile.java
+++ b/jraft-core/src/main/java/com/alipay/sofa/jraft/storage/log/SegmentFile.java
@@ -77,7 +77,8 @@ public class SegmentFile implements Lifecycle<SegmentFileOptions> {
 
         @Override
         public String toString() {
-            return "SegmentFileOptions [recover=" + recover + ", pos=" + pos + ", isLastFile=" + isLastFile + "]";
+            return "SegmentFileOptions [recover=" + this.recover + ", pos=" + this.pos + ", isLastFile="
+                   + this.isLastFile + "]";
         }
     }
 
@@ -115,7 +116,7 @@ public class SegmentFile implements Lifecycle<SegmentFileOptions> {
         this.path = parentDir + File.separator + getSegmentFileName(this.firstLogIndex);
     }
 
-    static String getSegmentFileName(long logIndex) {
+    static String getSegmentFileName(final long logIndex) {
         return String.format("%019d", logIndex);
     }
 
@@ -426,7 +427,7 @@ public class SegmentFile implements Lifecycle<SegmentFileOptions> {
      * Forces any changes made to this segment file's content to be written to the
      * storage device containing the mapped file.
      */
-    public void sync() throws IOException {
+    public void sync(final boolean sync) throws IOException {
         if (this.committedPos >= this.wrotePos) {
             return;
         }
@@ -436,7 +437,9 @@ public class SegmentFile implements Lifecycle<SegmentFileOptions> {
             if (this.committedPos >= this.wrotePos) {
                 return;
             }
-            fsync();
+            if (sync) {
+                fsync();
+            }
             this.committedPos = this.wrotePos;
             LOG.debug("Commit segment file {} at pos {}.", this.path, this.committedPos);
         } finally {

--- a/jraft-core/src/main/java/com/alipay/sofa/jraft/storage/log/SegmentFile.java
+++ b/jraft-core/src/main/java/com/alipay/sofa/jraft/storage/log/SegmentFile.java
@@ -550,7 +550,7 @@ public class SegmentFile implements Lifecycle<SegmentFileOptions> {
         }
     }
 
-    private void saveHeader(final boolean sync) {
+    void saveHeader(final boolean sync) {
         int oldPos = this.buffer.position();
         try {
             this.buffer.position(0);

--- a/jraft-core/src/main/java/com/alipay/sofa/jraft/storage/log/SegmentFile.java
+++ b/jraft-core/src/main/java/com/alipay/sofa/jraft/storage/log/SegmentFile.java
@@ -68,12 +68,10 @@ import sun.nio.ch.DirectBuffer;
  */
 public class SegmentFile implements Lifecycle<SegmentFileOptions> {
 
-    private static final int    ONE_MINUTE      = 60 * 1000;
-    // TODO, detect system ?
-    private static final int    PAGE_SIZE       = 4096;
-    private static final byte[] PAGE_DATA       = new byte[PAGE_SIZE];
-    public static final int     HEADER_SIZE     = 18;
-    private static final long   BLANK_LOG_INDEX = -99;
+    private static final int  FSYNC_COST_MS_THRESHOLD = 1000;
+    private static final int  ONE_MINUTE              = 60 * 1000;
+    public static final int   HEADER_SIZE             = 18;
+    private static final long BLANK_LOG_INDEX         = -99;
 
     /**
      * Segment file header.
@@ -105,7 +103,7 @@ public class SegmentFile implements Lifecycle<SegmentFileOptions> {
 
         boolean decode(final ByteBuffer buffer) {
             if (buffer == null || buffer.remaining() < HEADER_SIZE) {
-                LOG.error("Fail to decode segment heade, invalid buffer length: {}",
+                LOG.error("Fail to decode segment header, invalid buffer length: {}",
                     buffer == null ? 0 : buffer.remaining());
                 return false;
             }
@@ -795,7 +793,7 @@ public class SegmentFile implements Lifecycle<SegmentFileOptions> {
             long startMs = Utils.monotonicMs();
             this.buffer.force();
             final long cost = Utils.monotonicMs() - startMs;
-            if (cost >= 1000) {
+            if (cost >= FSYNC_COST_MS_THRESHOLD) {
                 LOG.warn("Call fsync on file {}  cost {} ms.", this.path, cost);
             }
         }

--- a/jraft-core/src/main/java/com/alipay/sofa/jraft/storage/log/SegmentFile.java
+++ b/jraft-core/src/main/java/com/alipay/sofa/jraft/storage/log/SegmentFile.java
@@ -33,6 +33,7 @@ import java.util.concurrent.locks.ReadWriteLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 
 import org.apache.commons.io.FileUtils;
+import org.apache.commons.io.FilenameUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -219,6 +220,7 @@ public class SegmentFile implements Lifecycle<SegmentFileOptions> {
     private volatile boolean         swappedOut;
     private volatile boolean         readOnly;
     private long                     swappedOutTimestamp     = -1L;
+    private final String             filename;
 
     public SegmentFile(final int size, final String path, final ThreadPoolExecutor writeExecutor) {
         super();
@@ -226,6 +228,7 @@ public class SegmentFile implements Lifecycle<SegmentFileOptions> {
         this.size = size;
         this.writeExecutor = writeExecutor;
         this.path = path;
+        this.filename = FilenameUtils.getName(this.path);
         this.swappedOut = this.readOnly = false;
     }
 
@@ -247,6 +250,10 @@ public class SegmentFile implements Lifecycle<SegmentFileOptions> {
 
     int getCommittedPos() {
         return this.committedPos;
+    }
+
+    String getFilename() {
+        return this.filename;
     }
 
     long getFirstLogIndex() {

--- a/jraft-core/src/main/java/com/alipay/sofa/jraft/storage/log/SegmentFile.java
+++ b/jraft-core/src/main/java/com/alipay/sofa/jraft/storage/log/SegmentFile.java
@@ -38,10 +38,10 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.alipay.sofa.jraft.Lifecycle;
+import com.alipay.sofa.jraft.storage.impl.RocksDBLogStorage.WriteContext;
 import com.alipay.sofa.jraft.storage.log.SegmentFile.SegmentFileOptions;
 import com.alipay.sofa.jraft.util.Bits;
 import com.alipay.sofa.jraft.util.BytesUtil;
-import com.alipay.sofa.jraft.util.CountDownEvent;
 import com.alipay.sofa.jraft.util.Utils;
 import com.sun.jna.NativeLong;
 import com.sun.jna.Pointer;
@@ -678,7 +678,7 @@ public class SegmentFile implements Lifecycle<SegmentFileOptions> {
      * @return the wrote position
      */
     @SuppressWarnings("NonAtomicOperationOnVolatileField")
-    public int write(final long logIndex, final byte[] data, final CountDownEvent events) {
+    public int write(final long logIndex, final byte[] data, final WriteContext ctx) {
         int pos = -1;
         this.writeLock.lock();
         try {
@@ -703,9 +703,9 @@ public class SegmentFile implements Lifecycle<SegmentFileOptions> {
                     putInt(wroteIndex + RECORD_MAGIC_BYTES_SIZE, data.length);
                     put(wroteIndex + RECORD_MAGIC_BYTES_SIZE + RECORD_DATA_LENGTH_SIZE, data);
                 } catch (final Exception e) {
-                    events.setAttachment(e);
+                    ctx.setError(e);
                 } finally {
-                    events.countDown();
+                    ctx.finishJob();
                 }
             });
         }

--- a/jraft-core/src/main/java/com/alipay/sofa/jraft/util/AsciiStringUtil.java
+++ b/jraft-core/src/main/java/com/alipay/sofa/jraft/util/AsciiStringUtil.java
@@ -33,13 +33,16 @@ public final class AsciiStringUtil {
         return out;
     }
 
-    public static String unsafeDecode(final byte[] in) {
-        final int len = in.length;
+    public static String unsafeDecode(final byte[] in, final int offset, final int len) {
         final char[] out = new char[len];
         for (int i = 0; i < len; i++) {
-            out[i] = (char) (in[i] & 0xFF);
+            out[i] = (char) (in[i + offset] & 0xFF);
         }
         return UnsafeUtil.moveToString(out);
+    }
+
+    public static String unsafeDecode(final byte[] in) {
+        return unsafeDecode(in, 0, in.length);
     }
 
     public static String unsafeDecode(final ByteString in) {

--- a/jraft-core/src/main/java/com/alipay/sofa/jraft/util/CountDownEvent.java
+++ b/jraft-core/src/main/java/com/alipay/sofa/jraft/util/CountDownEvent.java
@@ -31,22 +31,31 @@ public class CountDownEvent {
 
     private int             state    = 0;
     private final Lock      lock     = new ReentrantLock();
-    private final Condition busyCond = lock.newCondition();
+    private final Condition busyCond = this.lock.newCondition();
+    private volatile Object attachment;
+
+    public Object getAttachment() {
+        return this.attachment;
+    }
+
+    public void setAttachment(final Object attachment) {
+        this.attachment = attachment;
+    }
 
     public int incrementAndGet() {
-        lock.lock();
+        this.lock.lock();
         try {
             return ++this.state;
         } finally {
-            lock.unlock();
+            this.lock.unlock();
         }
     }
 
     public void countDown() {
-        lock.lock();
+        this.lock.lock();
         try {
             if (--this.state == 0) {
-                busyCond.signalAll();
+                this.busyCond.signalAll();
             }
         } finally {
             this.lock.unlock();
@@ -54,13 +63,13 @@ public class CountDownEvent {
     }
 
     public void await() throws InterruptedException {
-        lock.lock();
+        this.lock.lock();
         try {
             while (this.state > 0) {
-                busyCond.await();
+                this.busyCond.await();
             }
         } finally {
-            lock.unlock();
+            this.lock.unlock();
         }
     }
 }

--- a/jraft-core/src/main/java/com/alipay/sofa/jraft/util/Platform.java
+++ b/jraft-core/src/main/java/com/alipay/sofa/jraft/util/Platform.java
@@ -52,7 +52,7 @@ public class Platform {
             .toLowerCase(Locale.US) //
             .contains("mac os x");
         if (mac) {
-            LOG.debug("Platform: Windows");
+            LOG.debug("Platform: Mac OS X");
         }
         return mac;
     }

--- a/jraft-core/src/main/java/com/alipay/sofa/jraft/util/Platform.java
+++ b/jraft-core/src/main/java/com/alipay/sofa/jraft/util/Platform.java
@@ -31,11 +31,30 @@ public class Platform {
 
     private static final boolean IS_WINDOWS = isWindows0();
 
+    private static final boolean IS_MAC     = isMac0();
+
     /**
      * Return {@code true} if the JVM is running on Windows
      */
     public static boolean isWindows() {
         return IS_WINDOWS;
+    }
+
+    /**
+     * Return {@code true} if the JVM is running on Mac OSX
+     */
+    public static boolean isMac() {
+        return IS_MAC;
+    }
+
+    private static boolean isMac0() {
+        final boolean mac = SystemPropertyUtil.get("os.name", "") //
+            .toLowerCase(Locale.US) //
+            .contains("mac os x");
+        if (mac) {
+            LOG.debug("Platform: Windows");
+        }
+        return mac;
     }
 
     private static boolean isWindows0() {

--- a/jraft-core/src/main/java/com/alipay/sofa/jraft/util/Utils.java
+++ b/jraft-core/src/main/java/com/alipay/sofa/jraft/util/Utils.java
@@ -367,4 +367,8 @@ public class Utils {
             }
         }
     }
+
+    public static String getString(final byte[] bs, final int off, final int len) {
+        return new String(bs, off, len, StandardCharsets.UTF_8);
+    }
 }

--- a/jraft-core/src/test/java/com/alipay/sofa/jraft/core/NodeTest.java
+++ b/jraft-core/src/test/java/com/alipay/sofa/jraft/core/NodeTest.java
@@ -3161,7 +3161,8 @@ public class NodeTest {
         final SynchronizedClosure done = new SynchronizedClosure();
         final Node leader = cluster.getLeader();
         leader.changePeers(new Configuration(peers), done);
-        assertTrue(done.await().isOk());
+        final Status st = done.await();
+        assertTrue(st.getErrorMsg(), st.isOk());
         cluster.ensureSame();
         assertEquals(10, cluster.getFsms().size());
         for (final MockStateMachine fsm : cluster.getFsms()) {

--- a/jraft-core/src/test/java/com/alipay/sofa/jraft/core/TestJRaftServiceFactory.java
+++ b/jraft-core/src/test/java/com/alipay/sofa/jraft/core/TestJRaftServiceFactory.java
@@ -24,7 +24,12 @@ public class TestJRaftServiceFactory extends DefaultJRaftServiceFactory {
 
     @Override
     public LogStorage createLogStorage(final String uri, final RaftOptions raftOptions) {
-        return new RocksDBSegmentLogStorage(uri, raftOptions, 0, 1024 * 1024);
+        return RocksDBSegmentLogStorage.builder(uri, raftOptions) //
+            .setPreAllocateSegmentCount(1) //
+            .setKeepInMemorySegmentCount(2) //
+            .setMaxSegmentFileSize(512 * 1024) //
+            .setValueSizeThreshold(0) //
+            .build();
     }
 
 }

--- a/jraft-core/src/test/java/com/alipay/sofa/jraft/core/TestJRaftServiceFactory.java
+++ b/jraft-core/src/test/java/com/alipay/sofa/jraft/core/TestJRaftServiceFactory.java
@@ -24,7 +24,7 @@ public class TestJRaftServiceFactory extends DefaultJRaftServiceFactory {
 
     @Override
     public LogStorage createLogStorage(final String uri, final RaftOptions raftOptions) {
-        return new RocksDBSegmentLogStorage(uri, raftOptions, 0);
+        return new RocksDBSegmentLogStorage(uri, raftOptions, 0, 64 * 1024 * 1024);
     }
 
 }

--- a/jraft-core/src/test/java/com/alipay/sofa/jraft/core/TestJRaftServiceFactory.java
+++ b/jraft-core/src/test/java/com/alipay/sofa/jraft/core/TestJRaftServiceFactory.java
@@ -24,7 +24,7 @@ public class TestJRaftServiceFactory extends DefaultJRaftServiceFactory {
 
     @Override
     public LogStorage createLogStorage(final String uri, final RaftOptions raftOptions) {
-        return new RocksDBSegmentLogStorage(uri, raftOptions);
+        return new RocksDBSegmentLogStorage(uri, raftOptions, 0);
     }
 
 }

--- a/jraft-core/src/test/java/com/alipay/sofa/jraft/core/TestJRaftServiceFactory.java
+++ b/jraft-core/src/test/java/com/alipay/sofa/jraft/core/TestJRaftServiceFactory.java
@@ -18,13 +18,13 @@ package com.alipay.sofa.jraft.core;
 
 import com.alipay.sofa.jraft.option.RaftOptions;
 import com.alipay.sofa.jraft.storage.LogStorage;
-import com.alipay.sofa.jraft.storage.impl.RocksDBLogStorage;
+import com.alipay.sofa.jraft.storage.log.RocksDBSegmentLogStorage;
 
 public class TestJRaftServiceFactory extends DefaultJRaftServiceFactory {
 
     @Override
     public LogStorage createLogStorage(final String uri, final RaftOptions raftOptions) {
-        return new RocksDBLogStorage(uri, raftOptions);
+        return new RocksDBSegmentLogStorage(uri, raftOptions);
     }
 
 }

--- a/jraft-core/src/test/java/com/alipay/sofa/jraft/core/TestJRaftServiceFactory.java
+++ b/jraft-core/src/test/java/com/alipay/sofa/jraft/core/TestJRaftServiceFactory.java
@@ -24,7 +24,7 @@ public class TestJRaftServiceFactory extends DefaultJRaftServiceFactory {
 
     @Override
     public LogStorage createLogStorage(final String uri, final RaftOptions raftOptions) {
-        return new RocksDBSegmentLogStorage(uri, raftOptions, 0, 64 * 1024 * 1024);
+        return new RocksDBSegmentLogStorage(uri, raftOptions, 0, 1024 * 1024);
     }
 
 }

--- a/jraft-core/src/test/java/com/alipay/sofa/jraft/storage/impl/LogManagerTest.java
+++ b/jraft-core/src/test/java/com/alipay/sofa/jraft/storage/impl/LogManagerTest.java
@@ -273,6 +273,21 @@ public class LogManagerTest extends BaseStorageTest {
         }
     }
 
+    @Test
+    public void testSetAppliedId2() throws Exception {
+        final List<LogEntry> mockEntries = mockAddEntries();
+
+        for (int i = 0; i < 10; i++) {
+            // it's in memory
+            Assert.assertEquals(mockEntries.get(i), this.logManager.getEntryFromMemory(i + 1));
+        }
+        this.logManager.setAppliedId(new LogId(10, 10));
+        for (int i = 0; i < 10; i++) {
+            assertNull(this.logManager.getEntryFromMemory(i + 1));
+            Assert.assertEquals(mockEntries.get(i), this.logManager.getEntry(i + 1));
+        }
+    }
+
     private List<LogEntry> mockAddEntries() throws InterruptedException {
         final CountDownLatch latch = new CountDownLatch(1);
         final List<LogEntry> mockEntries = TestUtils.mockEntries(10);

--- a/jraft-core/src/test/java/com/alipay/sofa/jraft/storage/impl/LogManagerTest.java
+++ b/jraft-core/src/test/java/com/alipay/sofa/jraft/storage/impl/LogManagerTest.java
@@ -16,6 +16,13 @@
  */
 package com.alipay.sofa.jraft.storage.impl;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.CountDownLatch;
@@ -46,13 +53,6 @@ import com.alipay.sofa.jraft.storage.LogManager;
 import com.alipay.sofa.jraft.storage.LogStorage;
 import com.alipay.sofa.jraft.test.TestUtils;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotSame;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertTrue;
-
 @RunWith(value = MockitoJUnitRunner.class)
 public class LogManagerTest extends BaseStorageTest {
     private LogManagerImpl       logManager;
@@ -68,7 +68,7 @@ public class LogManagerTest extends BaseStorageTest {
         super.setup();
         this.confManager = new ConfigurationManager();
         final RaftOptions raftOptions = new RaftOptions();
-        this.logStorage = new RocksDBLogStorage(this.path, raftOptions);
+        this.logStorage = newLogStorage(raftOptions);
         this.logManager = new LogManagerImpl();
         final LogManagerOptions opts = new LogManagerOptions();
         opts.setConfigurationManager(this.confManager);
@@ -78,6 +78,10 @@ public class LogManagerTest extends BaseStorageTest {
         opts.setLogStorage(this.logStorage);
         opts.setRaftOptions(raftOptions);
         assertTrue(this.logManager.init(opts));
+    }
+
+    protected RocksDBLogStorage newLogStorage(final RaftOptions raftOptions) {
+        return new RocksDBLogStorage(this.path, raftOptions);
     }
 
     @Override

--- a/jraft-core/src/test/java/com/alipay/sofa/jraft/storage/impl/LogManagerWithSegmentLogStorageTest.java
+++ b/jraft-core/src/test/java/com/alipay/sofa/jraft/storage/impl/LogManagerWithSegmentLogStorageTest.java
@@ -1,0 +1,29 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alipay.sofa.jraft.storage.impl;
+
+import com.alipay.sofa.jraft.option.RaftOptions;
+import com.alipay.sofa.jraft.storage.log.RocksDBSegmentLogStorage;
+
+public class LogManagerWithSegmentLogStorageTest extends LogManagerTest {
+
+    @Override
+    protected RocksDBLogStorage newLogStorage(final RaftOptions raftOptions) {
+        return new RocksDBSegmentLogStorage(this.path, raftOptions, 0);
+    }
+
+}

--- a/jraft-core/src/test/java/com/alipay/sofa/jraft/storage/impl/LogManagerWithSegmentLogStorageTest.java
+++ b/jraft-core/src/test/java/com/alipay/sofa/jraft/storage/impl/LogManagerWithSegmentLogStorageTest.java
@@ -23,7 +23,7 @@ public class LogManagerWithSegmentLogStorageTest extends LogManagerTest {
 
     @Override
     protected RocksDBLogStorage newLogStorage(final RaftOptions raftOptions) {
-        return new RocksDBSegmentLogStorage(this.path, raftOptions, 0);
+        return new RocksDBSegmentLogStorage(this.path, raftOptions, 0, 64 * 1024);
     }
 
 }

--- a/jraft-core/src/test/java/com/alipay/sofa/jraft/storage/impl/LogStorageBenchmark.java
+++ b/jraft-core/src/test/java/com/alipay/sofa/jraft/storage/impl/LogStorageBenchmark.java
@@ -124,6 +124,7 @@ public class LogStorageBenchmark {
 
     public static void main(final String[] args) {
         String testPath = Paths.get(SystemPropertyUtil.get("user.dir"), "log_storage").toString();
+        System.out.println("Test log storage path: " + testPath);
         int batchSize = 100;
         int logSize = 16 * 1024;
         int totalLogs = 1024 * 1024;

--- a/jraft-core/src/test/java/com/alipay/sofa/jraft/storage/log/CheckpointFileTest.java
+++ b/jraft-core/src/test/java/com/alipay/sofa/jraft/storage/log/CheckpointFileTest.java
@@ -44,7 +44,7 @@ public class CheckpointFileTest extends BaseStorageTest {
         this.checkpointFile.save(new CheckpointFile.Checkpoint("test1", 99));
         CheckpointFile.Checkpoint cp = this.checkpointFile.load();
         assertNotNull(cp);
-        assertEquals("test1", cp.segPath);
+        assertEquals("test1", cp.segFilename);
         assertEquals(99, cp.committedPos);
 
         this.checkpointFile.destroy();
@@ -53,7 +53,7 @@ public class CheckpointFileTest extends BaseStorageTest {
         this.checkpointFile.save(new CheckpointFile.Checkpoint("test2", 299));
         cp = this.checkpointFile.load();
         assertNotNull(cp);
-        assertEquals("test2", cp.segPath);
+        assertEquals("test2", cp.segFilename);
         assertEquals(299, cp.committedPos);
     }
 }

--- a/jraft-core/src/test/java/com/alipay/sofa/jraft/storage/log/CheckpointFileTest.java
+++ b/jraft-core/src/test/java/com/alipay/sofa/jraft/storage/log/CheckpointFileTest.java
@@ -41,19 +41,19 @@ public class CheckpointFileTest extends BaseStorageTest {
     public void testMisc() throws Exception {
         assertNull(this.checkpointFile.load());
 
-        this.checkpointFile.save(new CheckpointFile.Checkpoint(1, 99));
+        this.checkpointFile.save(new CheckpointFile.Checkpoint("test1", 99));
         CheckpointFile.Checkpoint cp = this.checkpointFile.load();
         assertNotNull(cp);
-        assertEquals(1, cp.firstLogIndex);
+        assertEquals("test1", cp.segPath);
         assertEquals(99, cp.committedPos);
 
         this.checkpointFile.destroy();
         assertNull(this.checkpointFile.load());
 
-        this.checkpointFile.save(new CheckpointFile.Checkpoint(100, 299));
+        this.checkpointFile.save(new CheckpointFile.Checkpoint("test2", 299));
         cp = this.checkpointFile.load();
         assertNotNull(cp);
-        assertEquals(100, cp.firstLogIndex);
+        assertEquals("test2", cp.segPath);
         assertEquals(299, cp.committedPos);
     }
 }

--- a/jraft-core/src/test/java/com/alipay/sofa/jraft/storage/log/SegmentFileTest.java
+++ b/jraft-core/src/test/java/com/alipay/sofa/jraft/storage/log/SegmentFileTest.java
@@ -77,7 +77,7 @@ public class SegmentFileTest extends BaseStorageTest {
         assertEquals(0, this.segmentFile.write(0, data));
         // Can't read before sync
         assertNull(this.segmentFile.read(0, 0));
-        this.segmentFile.sync();
+        this.segmentFile.sync(true);
         assertArrayEquals(data, this.segmentFile.read(0, 0));
 
         assertTrue(this.segmentFile.reachesFileEndBy(SegmentFile.getWriteBytes(data)));
@@ -89,7 +89,7 @@ public class SegmentFileTest extends BaseStorageTest {
         assertEquals(38, this.segmentFile.write(1, data2));
         // Can't read before sync
         assertNull(this.segmentFile.read(1, 38));
-        this.segmentFile.sync();
+        this.segmentFile.sync(true);
         assertArrayEquals(data2, this.segmentFile.read(1, 38));
         assertEquals(64, this.segmentFile.getWrotePos());
         assertEquals(64, this.segmentFile.getCommittedPos());

--- a/jraft-core/src/test/java/com/alipay/sofa/jraft/storage/log/SegmentFileTest.java
+++ b/jraft-core/src/test/java/com/alipay/sofa/jraft/storage/log/SegmentFileTest.java
@@ -62,6 +62,21 @@ public class SegmentFileTest extends BaseStorageTest {
     }
 
     @Test
+    public void testSwapInOut() throws Exception {
+        testWriteRead();
+        this.segmentFile.setReadOnly(true);
+        assertFalse(this.segmentFile.isSwappedOut());
+        this.segmentFile.swapOut();
+        assertTrue(this.segmentFile.isSwappedOut());
+
+        int firstWritePos = SegmentFile.HEADER_SIZE;
+
+        assertEquals(32, this.segmentFile.read(0, firstWritePos).length);
+        assertEquals(20, this.segmentFile.read(1, 38 + firstWritePos).length);
+        assertFalse(this.segmentFile.isSwappedOut());
+    }
+
+    @Test
     public void testInitAndLoad() {
         assertTrue(init());
     }

--- a/pom.xml
+++ b/pom.xml
@@ -61,6 +61,7 @@
         <java.target.version>1.8</java.target.version>
         <jctools.version>2.1.1</jctools.version>
         <jmh.version>1.20</jmh.version>
+        <jna.version>5.5.0</jna.version>
         <jsr305.version>3.0.2</jsr305.version>
         <junit.dep.version>4.8.2</junit.dep.version>
         <junit.version>4.12</junit.version>
@@ -206,6 +207,12 @@
                         <groupId>org.slf4j</groupId>
                     </exclusion>
                 </exclusions>
+            </dependency>
+            <!-- jna -->
+            <dependency>
+                <groupId>net.java.dev.jna</groupId>
+                <artifactId>jna</artifactId>
+                <version>${jna.version}</version>
             </dependency>
             <!-- jctools -->
             <dependency>


### PR DESCRIPTION
### Motivation:

RocksDBSegmentLogStorage improvements.  #316 

### Modification:

It's ready for review. @fengjiachun @zongtanghu  @masaimu @SteNicholas .

Main changes:

* Introduce a new data format for segment (See `SegmentFile` file comment), so it's not compilable with old versions.Because this log storage is experimental in old versions, i think it's acceptable.
* Pre-allocate segments to prevent  the slow mmap system call when creates a new segment file.
* Concurrent write buffers when appending log entires in batch and fsync once(group commit).
* Swap out segment file when it's idle, swap in if needed.
* Some performance tweak.
* Fixed some issues:
    * Can't read when RaftOptions's sync is false.
    * Forget to correct diskId in `LogManager` after snapshot is loaded.
    * `RocksDBSegmentLogStorage#truncateSuffix` throws exception when log not found.



### Result:

Fixes #316.


