### PR TITLE
(feat) Set segment file to be read-only after write and sync

### DIFF
--- a/jraft-core/src/main/java/com/alipay/sofa/jraft/storage/impl/RocksDBLogStorage.java
+++ b/jraft-core/src/main/java/com/alipay/sofa/jraft/storage/impl/RocksDBLogStorage.java
@@ -106,6 +106,13 @@ public class RocksDBLogStorage implements LogStorage, Describer {
         }
 
         /**
+         * Adds a callback that will be invoked after all sub jobs finish.
+         */
+        default void addFinishHook(final Runnable r) {
+
+        }
+
+        /**
          * Set an exception to context.
          * @param e
          */

--- a/jraft-core/src/main/java/com/alipay/sofa/jraft/storage/log/RocksDBSegmentLogStorage.java
+++ b/jraft-core/src/main/java/com/alipay/sofa/jraft/storage/log/RocksDBSegmentLogStorage.java
@@ -24,6 +24,7 @@ import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
 import java.util.concurrent.ArrayBlockingQueue;
+import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ThreadPoolExecutor;
@@ -95,8 +96,7 @@ public class RocksDBSegmentLogStorage extends RocksDBLogStorage {
         @Override
         public synchronized void addFinishHook(final Runnable r) {
             if (this.hooks == null) {
-                this.hooks = new ArrayList<>(3);
-
+                this.hooks = new CopyOnWriteArrayList<>();
             }
             this.hooks.add(r);
         }


### PR DESCRIPTION
### Motivation:

Segment file may be swapped out(unmap) when writing, then the JVM may crash.The segment file is swapped out only when it's readonly. So we must make sure the segment file to be set readonly after all writing/fsync requests are finished.

So this PR adds finish hooks to `WriteContext`, all these hooks will be invoked after writing and fsync. It move `currLastFile.setReadOnly(true)` from write-executor to a finish hook, so we make sure that the segment file is set readonly only after all writing/fsync requests are finished. 


