### PR TITLE
feat/never discard the callback task

### DIFF
--- a/jraft-core/src/main/java/com/alipay/sofa/jraft/rpc/impl/BoltRpcClient.java
+++ b/jraft-core/src/main/java/com/alipay/sofa/jraft/rpc/impl/BoltRpcClient.java
@@ -20,6 +20,7 @@ import java.util.Map;
 import java.util.concurrent.Executor;
 
 import com.alipay.remoting.ConnectionEventType;
+import com.alipay.remoting.RejectedExecutionPolicy;
 import com.alipay.remoting.Url;
 import com.alipay.remoting.config.switches.GlobalSwitch;
 import com.alipay.remoting.rpc.RpcAddressParser;
@@ -165,7 +166,7 @@ public class BoltRpcClient implements RpcClient {
         return new BoltCallback(callback);
     }
 
-    private static class BoltCallback implements com.alipay.remoting.InvokeCallback {
+    private static class BoltCallback implements com.alipay.remoting.RejectionProcessableInvokeCallback {
 
         private final InvokeCallback callback;
 
@@ -186,6 +187,11 @@ public class BoltRpcClient implements RpcClient {
         @Override
         public Executor getExecutor() {
             return this.callback.executor();
+        }
+
+        @Override
+        public RejectedExecutionPolicy rejectedExecutionPolicy() {
+            return RejectedExecutionPolicy.CALLER_RUNS;
         }
     }
 }


### PR DESCRIPTION
### Motivation:

The bolt default callback task rejection policy is discard policy, we should ensure that never discard the callback task.

```
    /**
     * @see com.alipay.remoting.InvokeCallbackListener#onResponse(com.alipay.remoting.InvokeFuture)
     */
    @Override
    public void onResponse(InvokeFuture future) {
        InvokeCallback callback = future.getInvokeCallback();
        if (callback != null) {
            CallbackTask task = new CallbackTask(this.getRemoteAddress(), future);
            if (callback.getExecutor() != null) {
                // There is no need to switch classloader, because executor is provided by user.
                try {
                    callback.getExecutor().execute(task);
                } catch (RejectedExecutionException e) {
                    if (callback instanceof RejectionProcessableInvokeCallback) {
                        switch (((RejectionProcessableInvokeCallback) callback)
                            .rejectedExecutionPolicy()) {
                            case CALLER_RUNS:
                                task.run();
                                break;
                            case CALLER_HANDLE_EXCEPTION:
                                callback.onException(e);
                                break;
                            case DISCARD:
                            default:
                                logger.warn("Callback thread pool busy. discard the callback");
                                break;
                        }
                    } else {
                        logger.warn("Callback thread pool busy.");
                    }
                }
            } else {
                task.run();
            }
        }
    }
```

### Modification:

Impl RejectionProcessableInvokeCallback

### Result:


If there is no issue then describe the changes introduced by this PR.
