### PR TITLE
feat: rheakv support scan in reverse

### DIFF
--- a/jraft-example/src/main/java/com/alipay/sofa/jraft/example/rheakv/ReverseScanExample.java
+++ b/jraft-example/src/main/java/com/alipay/sofa/jraft/example/rheakv/ReverseScanExample.java
@@ -16,26 +16,25 @@
  */
 package com.alipay.sofa.jraft.example.rheakv;
 
-import java.util.List;
-import java.util.concurrent.CompletableFuture;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import com.alipay.sofa.jraft.rhea.client.RheaKVStore;
 import com.alipay.sofa.jraft.rhea.storage.KVEntry;
 import com.alipay.sofa.jraft.rhea.util.Lists;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
 
 import static com.alipay.sofa.jraft.util.BytesUtil.readUtf8;
 import static com.alipay.sofa.jraft.util.BytesUtil.writeUtf8;
 
 /**
  *
- * @author jiachun.fjc
+ * @author baozi
  */
-public class ScanExample {
+public class ReverseScanExample {
 
-    private static final Logger LOG = LoggerFactory.getLogger(ScanExample.class);
+    private static final Logger LOG = LoggerFactory.getLogger(ReverseScanExample.class);
 
     public static void main(final String[] args) throws Exception {
         final Client client = new Client();
@@ -53,31 +52,31 @@ public class ScanExample {
             rheaKVStore.bPut(bytes, bytes);
         }
 
-        final byte[] firstKey = keys.get(0);
-        final byte[] lastKey = keys.get(keys.size() - 1);
+        final byte[] firstKey = keys.get(keys.size() - 1);
+        final byte[] lastKey = keys.get(0);
         final String firstKeyString = readUtf8(firstKey);
         final String lastKeyString = readUtf8(lastKey);
 
         // async scan
-        final CompletableFuture<List<KVEntry>> f1 = rheaKVStore.scan(firstKey, lastKey);
-        final CompletableFuture<List<KVEntry>> f2 = rheaKVStore.scan(firstKey, lastKey, false);
-        final CompletableFuture<List<KVEntry>> f3 = rheaKVStore.scan(firstKeyString, lastKeyString);
-        final CompletableFuture<List<KVEntry>> f4 = rheaKVStore.scan(firstKeyString, lastKeyString, false);
+        final CompletableFuture<List<KVEntry>> f1 = rheaKVStore.reverseScan(firstKey, lastKey);
+        final CompletableFuture<List<KVEntry>> f2 = rheaKVStore.reverseScan(firstKey, lastKey, false);
+        final CompletableFuture<List<KVEntry>> f3 = rheaKVStore.reverseScan(firstKeyString, lastKeyString);
+        final CompletableFuture<List<KVEntry>> f4 = rheaKVStore.reverseScan(firstKeyString, lastKeyString, false);
         CompletableFuture.allOf(f1, f2, f3, f4).join();
         for (final CompletableFuture<List<KVEntry>> f : new CompletableFuture[] { f1, f2, f3, f4 }) {
             for (final KVEntry kv : f.join()) {
-                LOG.info("Async scan: key={}, value={}", readUtf8(kv.getKey()), readUtf8(kv.getValue()));
+                LOG.info("Async reverseScan: key={}, value={}", readUtf8(kv.getKey()), readUtf8(kv.getValue()));
             }
         }
 
         // sync scan
-        final List<KVEntry> l1 = rheaKVStore.bScan(firstKey, lastKey);
-        final List<KVEntry> l2 = rheaKVStore.bScan(firstKey, lastKey, false);
-        final List<KVEntry> l3 = rheaKVStore.bScan(firstKeyString, lastKeyString);
-        final List<KVEntry> l4 = rheaKVStore.bScan(firstKeyString, lastKeyString, false);
+        final List<KVEntry> l1 = rheaKVStore.bReverseScan(firstKey, lastKey);
+        final List<KVEntry> l2 = rheaKVStore.bReverseScan(firstKey, lastKey, false);
+        final List<KVEntry> l3 = rheaKVStore.bReverseScan(firstKeyString, lastKeyString);
+        final List<KVEntry> l4 = rheaKVStore.bReverseScan(firstKeyString, lastKeyString, false);
         for (final List<KVEntry> l : new List[] { l1, l2, l3, l4 }) {
             for (final KVEntry kv : l) {
-                LOG.info("sync scan: key={}, value={}", readUtf8(kv.getKey()), readUtf8(kv.getValue()));
+                LOG.info("sync reverseScan: key={}, value={}", readUtf8(kv.getKey()), readUtf8(kv.getValue()));
             }
         }
     }

--- a/jraft-rheakv/rheakv-core/src/main/java/com/alipay/sofa/jraft/rhea/client/DefaultRheaKVStore.java
+++ b/jraft-rheakv/rheakv-core/src/main/java/com/alipay/sofa/jraft/rhea/client/DefaultRheaKVStore.java
@@ -16,6 +16,7 @@
  */
 package com.alipay.sofa.jraft.rhea.client;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
@@ -610,8 +611,7 @@ public class DefaultRheaKVStore implements RheaKVStore {
                                                     final boolean readOnlySafe, final boolean returnValue,
                                                     final int retriesLeft, final Throwable lastCause) {
         Requires.requireNonNull(startKey, "startKey");
-        final List<Region> regionList = this.pdClient
-                .findRegionsByKeyRange(startKey, endKey, ApiExceptionHelper.isInvalidEpoch(lastCause));
+        final List<Region> regionList = this.pdClient.findRegionsByKeyRange(startKey, endKey, ApiExceptionHelper.isInvalidEpoch(lastCause));
         final List<CompletableFuture<List<KVEntry>>> futures = Lists.newArrayListWithCapacity(regionList.size());
         final Errors lastError = lastCause == null ? null : Errors.forException(lastCause);
         for (final Region region : regionList) {
@@ -623,7 +623,7 @@ public class DefaultRheaKVStore implements RheaKVStore {
             final ListRetryCallable<KVEntry> retryCallable = retryCause -> internalScan(subStartKey, subEndKey,
                     readOnlySafe, returnValue, retriesLeft - 1, retryCause);
             final ListFailoverFuture<KVEntry> future = new ListFailoverFuture<>(retriesLeft, retryCallable);
-            internalRegionScan(region, subStartKey, subEndKey, readOnlySafe, returnValue, future, retriesLeft, lastError,
+            internalRegionScan(region, subStartKey, subEndKey, false, readOnlySafe, returnValue, future, retriesLeft, lastError,
                     this.onlyLeaderRead);
             futures.add(future);
         }
@@ -631,23 +631,32 @@ public class DefaultRheaKVStore implements RheaKVStore {
     }
 
     private void internalRegionScan(final Region region, final byte[] subStartKey, final byte[] subEndKey,
-                                    final boolean readOnlySafe, final boolean returnValue,
+                                    final boolean reverse, final boolean readOnlySafe, final boolean returnValue,
                                     final CompletableFuture<List<KVEntry>> future, final int retriesLeft,
                                     final Errors lastCause, final boolean requireLeader) {
         final RegionEngine regionEngine = getRegionEngine(region.getId(), requireLeader);
         // require leader on retry
-        final RetryRunner retryRunner = retryCause -> internalRegionScan(region, subStartKey, subEndKey, readOnlySafe,
+        final RetryRunner retryRunner = retryCause -> internalRegionScan(region, subStartKey, subEndKey, reverse, readOnlySafe,
                 returnValue, future, retriesLeft - 1, retryCause, true);
         final FailoverClosure<List<KVEntry>> closure = new FailoverClosureImpl<>(future, false,
                 retriesLeft, retryRunner);
         if (regionEngine != null) {
             if (ensureOnValidEpoch(region, regionEngine, closure)) {
                 final RawKVStore rawKVStore = getRawKVStore(regionEngine);
-                if (this.kvDispatcher == null) {
-                    rawKVStore.scan(subStartKey, subEndKey, readOnlySafe, returnValue, closure);
+                if (reverse) {
+                    if (this.kvDispatcher == null) {
+                        rawKVStore.reverseScan(subStartKey, subEndKey, readOnlySafe, returnValue, closure);
+                    } else {
+                        this.kvDispatcher.execute(
+                                () -> rawKVStore.reverseScan(subStartKey, subEndKey, readOnlySafe, returnValue, closure));
+                    }
                 } else {
-                    this.kvDispatcher.execute(
-                            () -> rawKVStore.scan(subStartKey, subEndKey, readOnlySafe, returnValue, closure));
+                    if (this.kvDispatcher == null) {
+                        rawKVStore.scan(subStartKey, subEndKey, readOnlySafe, returnValue, closure);
+                    } else {
+                        this.kvDispatcher.execute(
+                                () -> rawKVStore.scan(subStartKey, subEndKey, readOnlySafe, returnValue, closure));
+                    }
                 }
             }
         } else {
@@ -658,8 +667,105 @@ public class DefaultRheaKVStore implements RheaKVStore {
             request.setReturnValue(returnValue);
             request.setRegionId(region.getId());
             request.setRegionEpoch(region.getRegionEpoch());
+            request.setReverse(reverse);
             this.rheaKVRpcService.callAsyncWithRpc(request, closure, lastCause, requireLeader);
         }
+    }
+
+    @Override
+    public CompletableFuture<List<KVEntry>> reverseScan(final byte[] startKey, final byte[] endKey) {
+        return reverseScan(startKey, endKey, true);
+    }
+
+    @Override
+    public CompletableFuture<List<KVEntry>> reverseScan(final String startKey, final String endKey) {
+        return reverseScan(BytesUtil.writeUtf8(startKey), BytesUtil.writeUtf8(endKey));
+    }
+
+    @Override
+    public CompletableFuture<List<KVEntry>> reverseScan(final byte[] startKey, final byte[] endKey,
+                                                        final boolean readOnlySafe) {
+        return reverseScan(startKey, endKey, readOnlySafe, true);
+    }
+
+    @Override
+    public CompletableFuture<List<KVEntry>> reverseScan(final String startKey, final String endKey,
+                                                        final boolean readOnlySafe) {
+        return reverseScan(BytesUtil.writeUtf8(startKey), BytesUtil.writeUtf8(endKey), readOnlySafe);
+    }
+
+    @Override
+    public CompletableFuture<List<KVEntry>> reverseScan(final byte[] startKey, final byte[] endKey,
+                                                        final boolean readOnlySafe, final boolean returnValue) {
+        checkState();
+        final byte[] realEndKey = BytesUtil.nullToEmpty(endKey);
+        if (startKey != null) {
+            Requires.requireTrue(BytesUtil.compare(startKey, realEndKey) > 0, "startKey must > endKey");
+        }
+        final FutureGroup<List<KVEntry>> futureGroup = internalReverseScan(startKey, realEndKey, readOnlySafe,
+            returnValue, this.failoverRetries, null);
+        return FutureHelper.joinList(futureGroup);
+    }
+
+    @Override
+    public CompletableFuture<List<KVEntry>> reverseScan(final String startKey, final String endKey,
+                                                        final boolean readOnlySafe, final boolean returnValue) {
+        return reverseScan(BytesUtil.writeUtf8(startKey), BytesUtil.writeUtf8(endKey), readOnlySafe, returnValue);
+    }
+
+    @Override
+    public List<KVEntry> bReverseScan(final byte[] startKey, final byte[] endKey) {
+        return FutureHelper.get(reverseScan(startKey, endKey), this.futureTimeoutMillis);
+    }
+
+    @Override
+    public List<KVEntry> bReverseScan(final String startKey, final String endKey) {
+        return FutureHelper.get(reverseScan(startKey, endKey), this.futureTimeoutMillis);
+    }
+
+    @Override
+    public List<KVEntry> bReverseScan(final byte[] startKey, final byte[] endKey, final boolean readOnlySafe) {
+        return FutureHelper.get(reverseScan(startKey, endKey, readOnlySafe), this.futureTimeoutMillis);
+    }
+
+    @Override
+    public List<KVEntry> bReverseScan(final String startKey, final String endKey, final boolean readOnlySafe) {
+        return FutureHelper.get(reverseScan(startKey, endKey, readOnlySafe), this.futureTimeoutMillis);
+    }
+
+    @Override
+    public List<KVEntry> bReverseScan(final byte[] startKey, final byte[] endKey, final boolean readOnlySafe,
+                                      final boolean returnValue) {
+        return FutureHelper.get(reverseScan(startKey, endKey, readOnlySafe, returnValue), this.futureTimeoutMillis);
+    }
+
+    @Override
+    public List<KVEntry> bReverseScan(final String startKey, final String endKey, final boolean readOnlySafe,
+                                      final boolean returnValue) {
+        return FutureHelper.get(reverseScan(startKey, endKey, readOnlySafe, returnValue), this.futureTimeoutMillis);
+    }
+
+    private FutureGroup<List<KVEntry>> internalReverseScan(final byte[] startKey, final byte[] endKey,
+                                                           final boolean readOnlySafe, final boolean returnValue,
+                                                           final int retriesLeft, final Throwable lastCause) {
+        Requires.requireNonNull(endKey, "endKey");
+        final List<Region> regionList = this.pdClient.findRegionsByKeyRange(endKey, startKey, ApiExceptionHelper.isInvalidEpoch(lastCause));
+        Collections.reverse(regionList);
+        final List<CompletableFuture<List<KVEntry>>> futures = Lists.newArrayListWithCapacity(regionList.size());
+        final Errors lastError = lastCause == null ? null : Errors.forException(lastCause);
+        for (final Region region : regionList) {
+            final byte[] regionEndKey = region.getEndKey();
+            final byte[] regionStartKey = region.getStartKey();
+            final byte[] subStartKey = regionEndKey == null ? startKey : (startKey == null ? regionEndKey : BytesUtil.min(regionEndKey, startKey));
+            final byte[] subEndKey = regionStartKey == null ? endKey : BytesUtil.max(regionStartKey, endKey);
+            final ListRetryCallable<KVEntry> retryCallable = retryCause -> internalReverseScan(subStartKey, subEndKey,
+                    readOnlySafe, returnValue, retriesLeft - 1, retryCause);
+            final ListFailoverFuture<KVEntry> future = new ListFailoverFuture<>(retriesLeft, retryCallable);
+            internalRegionScan(region, subStartKey, subEndKey, true, readOnlySafe, returnValue, future, retriesLeft, lastError,
+                    this.onlyLeaderRead );
+            futures.add(future);
+        }
+        return new FutureGroup<>(futures);
     }
 
     public List<KVEntry> singleRegionScan(final byte[] startKey, final byte[] endKey, final int limit,

--- a/jraft-rheakv/rheakv-core/src/main/java/com/alipay/sofa/jraft/rhea/client/RheaKVStore.java
+++ b/jraft-rheakv/rheakv-core/src/main/java/com/alipay/sofa/jraft/rhea/client/RheaKVStore.java
@@ -255,6 +255,86 @@ public interface RheaKVStore extends Lifecycle<RheaKVStoreOptions> {
                         final boolean returnValue);
 
     /**
+     * Equivalent to {@code reverseScan(startKey, endKey, true)}.
+     */
+    CompletableFuture<List<KVEntry>> reverseScan(final byte[] startKey, final byte[] endKey);
+
+    /**
+     * @see #reverseScan(byte[], byte[])
+     */
+    CompletableFuture<List<KVEntry>> reverseScan(final String startKey, final String endKey);
+
+    /**
+     * Equivalent to {@code reverseScan(startKey, endKey, readOnlySafe, true)}.
+     */
+    CompletableFuture<List<KVEntry>> reverseScan(final byte[] startKey, final byte[] endKey, final boolean readOnlySafe);
+
+    /**
+     * @see #reverseScan(byte[], byte[], boolean)
+     */
+    CompletableFuture<List<KVEntry>> reverseScan(final String startKey, final String endKey, final boolean readOnlySafe);
+
+    /**
+     * Reverse query all data in the key of range [startKey, endKey).
+     * <p>
+     * Provide consistent reading if {@code readOnlySafe} is true.
+     *
+     * Reverse scanning is usually much worse than forward scanning.
+     *
+     * Reverse scanning across multi regions maybe slower and devastating.
+     *
+     * @param startKey     first key to reverse scan within database (included),
+     *                     null means 'max-key' in the database.
+     * @param endKey       last key to reverse scan within database (excluded).
+     *                     null means 'min-key' in the database.
+     * @param readOnlySafe provide consistent reading if {@code readOnlySafe}
+     *                     is true.
+     * @param returnValue  whether to return value.
+     * @return a list where the key of range [startKey, endKey) passed by user
+     * and value for {@code KVEntry}
+     */
+    CompletableFuture<List<KVEntry>> reverseScan(final byte[] startKey, final byte[] endKey,
+                                                 final boolean readOnlySafe, final boolean returnValue);
+
+    /**
+     * @see #reverseScan(byte[], byte[], boolean, boolean)
+     */
+    CompletableFuture<List<KVEntry>> reverseScan(final String startKey, final String endKey,
+                                                 final boolean readOnlySafe, final boolean returnValue);
+
+    /**
+     * @see #reverseScan(byte[], byte[])
+     */
+    List<KVEntry> bReverseScan(final byte[] startKey, final byte[] endKey);
+
+    /**
+     * @see #scan(String, String)
+     */
+    List<KVEntry> bReverseScan(final String startKey, final String endKey);
+
+    /**
+     * @see #scan(String, String, boolean)
+     */
+    List<KVEntry> bReverseScan(final byte[] startKey, final byte[] endKey, final boolean readOnlySafe);
+
+    /**
+     * @see #scan(String, String, boolean)
+     */
+    List<KVEntry> bReverseScan(final String startKey, final String endKey, final boolean readOnlySafe);
+
+    /**
+     * @see #reverseScan(String, String, boolean, boolean)
+     */
+    List<KVEntry> bReverseScan(final byte[] startKey, final byte[] endKey, final boolean readOnlySafe,
+                               final boolean returnValue);
+
+    /**
+     * @see #reverseScan(String, String, boolean, boolean)
+     */
+    List<KVEntry> bReverseScan(final String startKey, final String endKey, final boolean readOnlySafe,
+                               final boolean returnValue);
+
+    /**
      * Equivalent to {@code iterator(startKey, endKey, bufSize, true)}.
      */
     RheaIterator<KVEntry> iterator(final byte[] startKey, final byte[] endKey, final int bufSize);

--- a/jraft-rheakv/rheakv-core/src/main/java/com/alipay/sofa/jraft/rhea/cmd/store/ScanRequest.java
+++ b/jraft-rheakv/rheakv-core/src/main/java/com/alipay/sofa/jraft/rhea/cmd/store/ScanRequest.java
@@ -36,6 +36,15 @@ public class ScanRequest extends BaseRequest {
     private int               limit;
     private boolean           readOnlySafe     = true;
     private boolean           returnValue      = true;
+    private boolean           reverse          = false;
+
+    public boolean isReverse() {
+        return reverse;
+    }
+
+    public void setReverse(boolean reverse) {
+        this.reverse = reverse;
+    }
 
     public byte[] getStartKey() {
         return startKey;
@@ -85,7 +94,7 @@ public class ScanRequest extends BaseRequest {
     @Override
     public String toString() {
         return "ScanRequest{" + "startKey=" + BytesUtil.toHex(startKey) + ", endKey=" + BytesUtil.toHex(endKey)
-               + ", limit=" + limit + ", readOnlySafe=" + readOnlySafe + ", returnValue=" + returnValue + "} "
-               + super.toString();
+               + ", limit=" + limit + ", reverse=" + reverse + ", readOnlySafe=" + readOnlySafe + ", returnValue="
+               + returnValue + "} " + super.toString();
     }
 }

--- a/jraft-rheakv/rheakv-core/src/main/java/com/alipay/sofa/jraft/rhea/storage/BaseRawKVStore.java
+++ b/jraft-rheakv/rheakv-core/src/main/java/com/alipay/sofa/jraft/rhea/storage/BaseRawKVStore.java
@@ -76,6 +76,34 @@ public abstract class BaseRawKVStore<T> implements RawKVStore, Lifecycle<T> {
     }
 
     @Override
+    public void reverseScan(final byte[] startKey, final byte[] endKey, final KVStoreClosure closure) {
+        reverseScan(startKey, endKey, Integer.MAX_VALUE, closure);
+    }
+
+    @Override
+    public void reverseScan(final byte[] startKey, final byte[] endKey, final boolean readOnlySafe,
+                            final KVStoreClosure closure) {
+        reverseScan(startKey, endKey, Integer.MAX_VALUE, readOnlySafe, closure);
+    }
+
+    @Override
+    public void reverseScan(final byte[] startKey, final byte[] endKey, final boolean readOnlySafe,
+                            final boolean returnValue, final KVStoreClosure closure) {
+        reverseScan(startKey, endKey, Integer.MAX_VALUE, readOnlySafe, returnValue, closure);
+    }
+
+    @Override
+    public void reverseScan(final byte[] startKey, final byte[] endKey, final int limit, final KVStoreClosure closure) {
+        reverseScan(startKey, endKey, limit, true, closure);
+    }
+
+    @Override
+    public void reverseScan(final byte[] startKey, final byte[] endKey, final int limit, final boolean readOnlySafe,
+                            final KVStoreClosure closure) {
+        reverseScan(startKey, endKey, limit, readOnlySafe, true, closure);
+    }
+
+    @Override
     public void execute(final NodeExecutor nodeExecutor, final boolean isLeader, final KVStoreClosure closure) {
         final Timer.Context timeCtx = getTimeContext("EXECUTE");
         try {
@@ -97,6 +125,19 @@ public abstract class BaseRawKVStore<T> implements RawKVStore, Lifecycle<T> {
 
     public long getSafeEndValueForSequence(final long startVal, final int step) {
         return Math.max(startVal, Long.MAX_VALUE - step < startVal ? Long.MAX_VALUE : startVal + step);
+    }
+
+    /**
+     *  If limit == 0, it will be modified to Integer.MAX_VALUE on the server
+     *  and then queried.  So 'limit == 0' means that the number of queries is
+     *  not limited. This is because serialization uses varint to compress
+     *  numbers.  In the case of 0, only 1 byte is occupied, and Integer.MAX_VALUE
+     *  takes 5 bytes.
+     * @param limit
+     * @return
+     */
+    protected int normalizeLimit(final int limit) {
+        return limit > 0 ? limit : Integer.MAX_VALUE;
     }
 
     /**

--- a/jraft-rheakv/rheakv-core/src/main/java/com/alipay/sofa/jraft/rhea/storage/BatchRawKVStore.java
+++ b/jraft-rheakv/rheakv-core/src/main/java/com/alipay/sofa/jraft/rhea/storage/BatchRawKVStore.java
@@ -134,6 +134,14 @@ public abstract class BatchRawKVStore<T> extends BaseRawKVStore<T> {
         }
     }
 
+    public void batchReverseScan(final KVStateOutputList kvStates) {
+        for (int i = 0, l = kvStates.size(); i < l; i++) {
+            final KVState kvState = kvStates.get(i);
+            final KVOperation op = kvState.getOp();
+            reverseScan(op.getStartKey(), op.getEndKey(), op.getLimit(), true, op.isReturnValue(), kvState.getDone());
+        }
+    }
+
     public void batchGetAndPut(final KVStateOutputList kvStates) {
         for (int i = 0, l = kvStates.size(); i < l; i++) {
             final KVState kvState = kvStates.get(i);

--- a/jraft-rheakv/rheakv-core/src/main/java/com/alipay/sofa/jraft/rhea/storage/KVOperation.java
+++ b/jraft-rheakv/rheakv-core/src/main/java/com/alipay/sofa/jraft/rhea/storage/KVOperation.java
@@ -77,12 +77,15 @@ public class KVOperation implements Serializable {
     /** Contains key operation */
     public static final byte    CONTAINS_KEY     = 0x13;
 
-    public static final byte    EOF              = 0x14;
+    /** Reverse Scan operation */
+    public static final byte    REVERSE_SCAN     = 0x14;
+
+    public static final byte    EOF              = 0x15;
 
     private static final byte[] VALID_OPS;
 
     static {
-        VALID_OPS = new byte[19];
+        VALID_OPS = new byte[EOF - 1];
         VALID_OPS[0] = PUT;
         VALID_OPS[1] = PUT_IF_ABSENT;
         VALID_OPS[2] = DELETE;
@@ -102,6 +105,7 @@ public class KVOperation implements Serializable {
         VALID_OPS[16] = COMPARE_PUT;
         VALID_OPS[17] = DELETE_LIST;
         VALID_OPS[18] = CONTAINS_KEY;
+        VALID_OPS[19] = REVERSE_SCAN;
     }
 
     private byte[]              key;                                    // also startKey for DELETE_RANGE
@@ -199,6 +203,11 @@ public class KVOperation implements Serializable {
     public static KVOperation createScan(final byte[] startKey, final byte[] endKey, final int limit,
                                          final boolean returnValue) {
         return new KVOperation(startKey, endKey, Pair.of(limit, returnValue), SCAN);
+    }
+
+    public static KVOperation createReverseScan(final byte[] startKey, final byte[] endKey, final int limit,
+                                                final boolean returnValue) {
+        return new KVOperation(startKey, endKey, Pair.of(limit, returnValue), REVERSE_SCAN);
     }
 
     public static KVOperation createGetAndPut(final byte[] key, final byte[] value) {
@@ -374,6 +383,8 @@ public class KVOperation implements Serializable {
                 return "RESET_SEQUENCE";
             case RANGE_SPLIT:
                 return "RANGE_SPLIT";
+            case REVERSE_SCAN:
+                return "REVERSE_SCAN";
             default:
                 return "UNKNOWN" + op;
         }

--- a/jraft-rheakv/rheakv-core/src/main/java/com/alipay/sofa/jraft/rhea/storage/KVStoreStateMachine.java
+++ b/jraft-rheakv/rheakv-core/src/main/java/com/alipay/sofa/jraft/rhea/storage/KVStoreStateMachine.java
@@ -197,6 +197,9 @@ public class KVStoreStateMachine extends StateMachineAdapter {
             case KVOperation.SCAN:
                 this.rawKVStore.batchScan(kvStates);
                 break;
+            case KVOperation.REVERSE_SCAN:
+                this.rawKVStore.batchReverseScan(kvStates);
+                break;
             case KVOperation.GET_PUT:
                 this.rawKVStore.batchGetAndPut(kvStates);
                 break;

--- a/jraft-rheakv/rheakv-core/src/main/java/com/alipay/sofa/jraft/rhea/storage/MetricsRawKVStore.java
+++ b/jraft-rheakv/rheakv-core/src/main/java/com/alipay/sofa/jraft/rhea/storage/MetricsRawKVStore.java
@@ -40,6 +40,7 @@ import static com.alipay.sofa.jraft.rhea.storage.KVOperation.PUT;
 import static com.alipay.sofa.jraft.rhea.storage.KVOperation.PUT_IF_ABSENT;
 import static com.alipay.sofa.jraft.rhea.storage.KVOperation.PUT_LIST;
 import static com.alipay.sofa.jraft.rhea.storage.KVOperation.RESET_SEQUENCE;
+import static com.alipay.sofa.jraft.rhea.storage.KVOperation.REVERSE_SCAN;
 import static com.alipay.sofa.jraft.rhea.storage.KVOperation.SCAN;
 
 /**
@@ -124,6 +125,41 @@ public class MetricsRawKVStore implements RawKVStore {
                      final boolean returnValue, final KVStoreClosure closure) {
         final KVStoreClosure c = metricsAdapter(closure, SCAN, 0, 0);
         this.rawKVStore.scan(startKey, endKey, limit, readOnlySafe, returnValue, c);
+    }
+
+    @Override
+    public void reverseScan(final byte[] startKey, final byte[] endKey, final KVStoreClosure closure) {
+        reverseScan(startKey, endKey, Integer.MAX_VALUE, closure);
+    }
+
+    @Override
+    public void reverseScan(final byte[] startKey, final byte[] endKey, final boolean readOnlySafe,
+                            final KVStoreClosure closure) {
+        reverseScan(startKey, endKey, Integer.MAX_VALUE, readOnlySafe, closure);
+    }
+
+    @Override
+    public void reverseScan(final byte[] startKey, final byte[] endKey, final boolean readOnlySafe,
+                            final boolean returnValue, final KVStoreClosure closure) {
+        reverseScan(startKey, endKey, Integer.MAX_VALUE, readOnlySafe, returnValue, closure);
+    }
+
+    @Override
+    public void reverseScan(final byte[] startKey, final byte[] endKey, final int limit, final KVStoreClosure closure) {
+        reverseScan(startKey, endKey, limit, true, closure);
+    }
+
+    @Override
+    public void reverseScan(final byte[] startKey, final byte[] endKey, final int limit, final boolean readOnlySafe,
+                            final KVStoreClosure closure) {
+        reverseScan(startKey, endKey, limit, readOnlySafe, true, closure);
+    }
+
+    @Override
+    public void reverseScan(final byte[] startKey, final byte[] endKey, final int limit, final boolean readOnlySafe,
+                            final boolean returnValue, final KVStoreClosure closure) {
+        final KVStoreClosure c = metricsAdapter(closure, REVERSE_SCAN, 0, 0);
+        this.rawKVStore.reverseScan(startKey, endKey, limit, readOnlySafe, returnValue, c);
     }
 
     @Override

--- a/jraft-rheakv/rheakv-core/src/main/java/com/alipay/sofa/jraft/rhea/storage/RawKVStore.java
+++ b/jraft-rheakv/rheakv-core/src/main/java/com/alipay/sofa/jraft/rhea/storage/RawKVStore.java
@@ -119,6 +119,45 @@ public interface RawKVStore {
               final boolean returnValue, final KVStoreClosure closure);
 
     /**
+     * Equivalent to {@code reverseScan(startKey, endKey, Integer.MAX_VALUE, closure)}.
+     */
+    void reverseScan(final byte[] startKey, final byte[] endKey, final KVStoreClosure closure);
+
+    /**
+     * Equivalent to {@code reverseScan(startKey, endKey, Integer.MAX_VALUE, readOnlySafe, closure)}.
+     */
+    void reverseScan(final byte[] startKey, final byte[] endKey, final boolean readOnlySafe,
+                     final KVStoreClosure closure);
+
+    /**
+     * Equivalent to {@code reverseScan(startKey, endKey, Integer.MAX_VALUE, readOnlySafe, returnValue, closure)}.
+     */
+    void reverseScan(final byte[] startKey, final byte[] endKey, final boolean readOnlySafe, final boolean returnValue,
+                     final KVStoreClosure closure);
+
+    /**
+     * Equivalent to {@code reverseScan(startKey, endKey, limit, true, closure)}.
+     */
+    void reverseScan(final byte[] startKey, final byte[] endKey, final int limit, final KVStoreClosure closure);
+
+    /**
+     * Equivalent to {@code reverseScan(startKey, endKey, limit, readOnlySafe, true, closure)}.
+     */
+    void reverseScan(final byte[] startKey, final byte[] endKey, final int limit, final boolean readOnlySafe,
+                     final KVStoreClosure closure);
+
+    /**
+     * Reverse query all data in the key range of [startKey, endKey),
+     * {@code limit} is the max number of keys.
+     *
+     * Provide consistent reading if {@code readOnlySafe} is true.
+     *
+     * Only return keys(ignore values) if {@code returnValue} is false.
+     */
+    void reverseScan(final byte[] startKey, final byte[] endKey, final int limit, final boolean readOnlySafe,
+                     final boolean returnValue, final KVStoreClosure closure);
+
+    /**
      * Get a globally unique auto-increment sequence.
      *
      * Be careful do not to try to get or update the value of {@code seqKey}

--- a/jraft-rheakv/rheakv-core/src/main/java/com/alipay/sofa/jraft/rhea/storage/RocksRawKVStore.java
+++ b/jraft-rheakv/rheakv-core/src/main/java/com/alipay/sofa/jraft/rhea/storage/RocksRawKVStore.java
@@ -308,12 +308,7 @@ public class RocksRawKVStore extends BatchRawKVStore<RocksDBOptions> implements 
                      final KVStoreClosure closure) {
         final Timer.Context timeCtx = getTimeContext("SCAN");
         final List<KVEntry> entries = Lists.newArrayList();
-        // If limit == 0, it will be modified to Integer.MAX_VALUE on the server
-        // and then queried.  So 'limit == 0' means that the number of queries is
-        // not limited. This is because serialization uses varint to compress
-        // numbers.  In the case of 0, only 1 byte is occupied, and Integer.MAX_VALUE
-        // takes 5 bytes.
-        final int maxCount = limit > 0 ? limit : Integer.MAX_VALUE;
+        int maxCount = normalizeLimit(limit);
         final Lock readLock = this.readWriteLock.readLock();
         readLock.lock();
         try (final RocksIterator it = this.db.newIterator()) {
@@ -336,6 +331,41 @@ public class RocksRawKVStore extends BatchRawKVStore<RocksDBOptions> implements 
             LOG.error("Fail to [SCAN], range: ['[{}, {})'], {}.", BytesUtil.toHex(startKey), BytesUtil.toHex(endKey),
                 StackTraceUtil.stackTrace(e));
             setFailure(closure, "Fail to [SCAN]");
+        } finally {
+            readLock.unlock();
+            timeCtx.stop();
+        }
+    }
+
+    @Override
+    public void reverseScan(final byte[] startKey, final byte[] endKey, final int limit,
+                            @SuppressWarnings("unused") final boolean readOnlySafe, final boolean returnValue,
+                            final KVStoreClosure closure) {
+        final Timer.Context timeCtx = getTimeContext("REVERSE_SCAN");
+        final List<KVEntry> entries = Lists.newArrayList();
+        int maxCount = normalizeLimit(limit);
+        final Lock readLock = this.readWriteLock.readLock();
+        readLock.lock();
+        try (final RocksIterator it = this.db.newIterator()) {
+            if (startKey == null) {
+                it.seekToLast();
+            } else {
+                it.seekForPrev(startKey);
+            }
+            int count = 0;
+            while (it.isValid() && count++ < maxCount) {
+                final byte[] key = it.key();
+                if (endKey != null && BytesUtil.compare(key, endKey) <= 0) {
+                    break;
+                }
+                entries.add(new KVEntry(key, returnValue ? it.value() : null));
+                it.prev();
+            }
+            setSuccess(closure, entries);
+        } catch (final Exception e) {
+            LOG.error("Fail to [REVERSE_SCAN], range: ['[{}, {})'], {}.", BytesUtil.toHex(startKey),
+                BytesUtil.toHex(endKey), StackTraceUtil.stackTrace(e));
+            setFailure(closure, "Fail to [REVERSE_SCAN]");
         } finally {
             readLock.unlock();
             timeCtx.stop();

--- a/jraft-rheakv/rheakv-core/src/test/java/com/alipay/sofa/jraft/rhea/storage/memorydb/MemoryKVStoreTest.java
+++ b/jraft-rheakv/rheakv-core/src/test/java/com/alipay/sofa/jraft/rhea/storage/memorydb/MemoryKVStoreTest.java
@@ -307,6 +307,56 @@ public class MemoryKVStoreTest extends BaseKVStoreTest {
     }
 
     /**
+     * Test method: {@link MemoryRawKVStore#reverseScan(byte[], byte[], KVStoreClosure)}
+     */
+    @Test
+    public void reverseScanTest() {
+        final List<byte[]> keyList = Lists.newArrayList();
+        final List<byte[]> valueList = Lists.newArrayList();
+        for (int i = 0; i < 10; i++) {
+            byte[] key = makeKey("scan_test_key_" + i);
+            byte[] value = makeValue("scan_test_key_" + i);
+            keyList.add(key);
+            valueList.add(value);
+            this.kvStore.put(key, value, null);
+        }
+        for (int i = 0; i < 10; i++) {
+            byte[] key = makeKey("no_scan_test_key_" + i);
+            byte[] value = makeValue("no_scan_test_key_" + i);
+            this.kvStore.put(key, value, null);
+        }
+
+        List<KVEntry> entries = new SyncKVStore<List<KVEntry>>() {
+            @Override
+            public void execute(RawKVStore kvStore, KVStoreClosure closure) {
+                kvStore.reverseScan(makeKey("scan_test_key_" + 99), makeKey("scan_test_key_"), closure);
+            }
+        }.apply(this.kvStore);
+        assertEquals(entries.size(), keyList.size());
+        for (int i = keyList.size() - 1; i >= 0; i--) {
+            assertArrayEquals(keyList.get(i), entries.get(keyList.size() - 1 - i).getKey());
+            assertArrayEquals(valueList.get(i), entries.get(keyList.size() - 1 - i).getValue());
+        }
+
+        entries = new SyncKVStore<List<KVEntry>>() {
+            @Override
+            public void execute(RawKVStore kvStore, KVStoreClosure closure) {
+                kvStore.reverseScan(makeKey("scan_test_key_" + 99), null, closure);
+            }
+        }.apply(this.kvStore);
+        assertEquals(entries.size(), 20);
+
+        entries = new SyncKVStore<List<KVEntry>>() {
+            @Override
+            public void execute(RawKVStore kvStore, KVStoreClosure closure) {
+                kvStore.reverseScan(null, null, closure);
+            }
+        }.apply(this.kvStore);
+        assertEquals(entries.size(), 20);
+
+    }
+
+    /**
      * Test method: {@link MemoryRawKVStore#getSequence(byte[], int, KVStoreClosure)}
      */
     @Test


### PR DESCRIPTION
### Motivation: 
> It looks that rheakv doesn't support scan in reverse order, we should support it.

#340 

### Modification:

整个代码改动按照scan接口的相关点，新增reverseScan接口，按照reverse scan的含义实现。


### Result:

1. `RheaKVStore`接口新增`reverseScan`方法并实现`DefaultRheaKVStore`。相关测试也补充完毕。
2. `RawKVStore`接口新增`reverseScan`方法，并实现了内存版本`MemoryRawKVStore`和`RocksRawKVStore`相关测试也补充完毕。
3. 新增`ReverseScanRequest`并在状态机和方法内实现了相关修改,批量操作也按原本实现做了实现。
