### PR TITLE
(feat) Node#isLeader doesn't need read locking

### DIFF
--- a/jraft-core/src/main/java/com/alipay/sofa/jraft/core/NodeImpl.java
+++ b/jraft-core/src/main/java/com/alipay/sofa/jraft/core/NodeImpl.java
@@ -2624,12 +2624,7 @@ public class NodeImpl implements Node, RaftServerService {
 
     @Override
     public boolean isLeader() {
-        this.readLock.lock();
-        try {
-            return this.state == State.STATE_LEADER;
-        } finally {
-            this.readLock.unlock();
-        }
+        return this.state == State.STATE_LEADER;
     }
 
     @Override


### PR DESCRIPTION
`state` field is already declared `volatile`, the read locking is unnecessary in `Node#isLeader` method.

