### PR TITLE
(fix#411).TestLeaderStopAndReElectWithPriority unittest run failure.

### DIFF
--- a/jraft-core/src/test/java/com/alipay/sofa/jraft/core/NodeTest.java
+++ b/jraft-core/src/test/java/com/alipay/sofa/jraft/core/NodeTest.java
@@ -1060,7 +1060,7 @@ public class NodeTest {
         if (leaderPriority == 10) {
             // we just compare the two peers' log size value;
             assertTrue(peer2LogSize > peer1LogSize);
-        }else {
+        } else {
             assertEquals(60, leader.getNodeId().getPeerId().getPriority());
             assertEquals(100, leader.getNodeTargetPriority());
         }

--- a/jraft-core/src/test/java/com/alipay/sofa/jraft/core/NodeTest.java
+++ b/jraft-core/src/test/java/com/alipay/sofa/jraft/core/NodeTest.java
@@ -1048,8 +1048,22 @@ public class NodeTest {
         leader = cluster.getLeader();
 
         assertNotNull(leader);
-        assertEquals(60, leader.getNodeId().getPeerId().getPriority());
-        assertEquals(100, leader.getNodeTargetPriority());
+
+        // get current leader priority value
+        int leaderPriority = leader.getNodeId().getPeerId().getPriority();
+
+        // get current leader log size
+        int peer1LogSize = cluster.getFsmByPeer(peers.get(1)).getLogs().size();
+        int peer2LogSize = cluster.getFsmByPeer(peers.get(2)).getLogs().size();
+
+        // if the leader is lower priority value
+        if (leaderPriority == 10) {
+            // we just compare the two peers' log size value;
+            assertTrue(peer2LogSize > peer1LogSize);
+        }else {
+            assertEquals(60, leader.getNodeId().getPeerId().getPriority());
+            assertEquals(100, leader.getNodeTargetPriority());
+        }
 
         cluster.stopAll();
     }


### PR DESCRIPTION
### Motivation:

I look into the findTheNextCandidate method which is in the ReplicatorGroupImpl class.In this method, it will choose the node which logindex is much more enough become leader rather than the node which priority value is larger.

So, in this testLeaderStopAndReElectWithPriority method, if the node with priority 10 has more enough logindex file than node with priority 60, the node with priority 10 will be the leader.

### Modification:

So, I adjust the unit test codes, if the lower priority value node becomes the leader , then I compare the two peer's log size.

### Result:

Fixes #411 .

If there is no issue then describe the changes introduced by this PR.
