### PR TITLE
Some corner cases fixes

### DIFF
--- a/jraft-core/src/main/java/com/alipay/sofa/jraft/core/NodeImpl.java
+++ b/jraft-core/src/main/java/com/alipay/sofa/jraft/core/NodeImpl.java
@@ -2640,7 +2640,12 @@ public class NodeImpl implements Node, RaftServerService {
 
     @Override
     public boolean isLeader() {
-        return this.state == State.STATE_LEADER;
+        this.readLock.lock();
+        try {
+            return this.state == State.STATE_LEADER;
+        } finally {
+            this.readLock.unlock();
+        }
     }
 
     @Override

--- a/jraft-core/src/main/java/com/alipay/sofa/jraft/core/Replicator.java
+++ b/jraft-core/src/main/java/com/alipay/sofa/jraft/core/Replicator.java
@@ -905,12 +905,12 @@ public class Replicator implements ThreadId.OnError {
         }
         r.waitId = -1;
         if (errCode == RaftError.ETIMEDOUT.getNumber()) {
+            r.blockTimer = null;
             // Send empty entries after block timeout to check the correct
             // _next_index otherwise the replicator is likely waits in            executor.shutdown();
             // _wait_more_entries and no further logs would be replicated even if the
             // last_index of this followers is less than |next_index - 1|
             r.sendEmptyEntries(false);
-            r.blockTimer = null;
         } else if (errCode != RaftError.ESTOP.getNumber()) {
             // id is unlock in _send_entries
             r.sendEntries();
@@ -931,7 +931,7 @@ public class Replicator implements ThreadId.OnError {
         // each individual error (e.g. we don't need check every
         // heartbeat_timeout_ms whether a dead follower has come back), but it's just
         // fine now.
-        if(this.blockTimer!=null) {
+        if(this.blockTimer != null) {
           // already in blocking state,return immediately.
           this.id.unlock();
           return;

--- a/jraft-core/src/main/java/com/alipay/sofa/jraft/core/Replicator.java
+++ b/jraft-core/src/main/java/com/alipay/sofa/jraft/core/Replicator.java
@@ -1417,8 +1417,9 @@ public class Replicator implements ThreadId.OnError {
                 LOG.debug("Replicated logs in [{}, {}] to peer {}", r.nextIndex, r.nextIndex + entriesSize - 1,
                     r.options.getPeerId());
             }
-        } else {
-            // The request is probe request, change the state into Replicate.
+        }
+
+        if (r.state != State.Replicate) {
             r.state = State.Replicate;
         }
         r.nextIndex += entriesSize;

--- a/jraft-core/src/main/java/com/alipay/sofa/jraft/core/Replicator.java
+++ b/jraft-core/src/main/java/com/alipay/sofa/jraft/core/Replicator.java
@@ -944,7 +944,7 @@ public class Replicator implements ThreadId.OnError {
             this.statInfo.runningState = RunningState.BLOCKING;
             this.id.unlock();
         } catch (final Exception e) {
-          this.blockTimer = null;
+            this.blockTimer = null;
             LOG.error("Fail to add timer", e);
             // id unlock in sendEmptyEntries.
             sendEmptyEntries(false);

--- a/jraft-core/src/main/java/com/alipay/sofa/jraft/core/Replicator.java
+++ b/jraft-core/src/main/java/com/alipay/sofa/jraft/core/Replicator.java
@@ -1426,9 +1426,8 @@ public class Replicator implements ThreadId.OnError {
             }
         }
 
-        if (r.state != State.Replicate) {
-            r.state = State.Replicate;
-        }
+        r.state = State.Replicate;
+        r.blockTimer = null;
         r.nextIndex += entriesSize;
         r.hasSucceeded = true;
         r.notifyOnCaughtUp(RaftError.SUCCESS.getNumber(), false);

--- a/jraft-core/src/main/java/com/alipay/sofa/jraft/core/Replicator.java
+++ b/jraft-core/src/main/java/com/alipay/sofa/jraft/core/Replicator.java
@@ -266,10 +266,10 @@ public class Replicator implements ThreadId.OnError {
                             RpcUtils.runInThread(() -> listener.onCreated(peer));
                             break;
                         case ERROR:
-                          RpcUtils.runInThread(() -> listener.onError(peer, status));
+                            RpcUtils.runInThread(() -> listener.onError(peer, status));
                             break;
                         case DESTROYED:
-                          RpcUtils.runInThread(() -> listener.onDestroyed(peer));
+                            RpcUtils.runInThread(() -> listener.onDestroyed(peer));
                             break;
                         default:
                             break;
@@ -840,7 +840,7 @@ public class Replicator implements ThreadId.OnError {
         final Replicator r = (Replicator) id.lock();
 
         if (r == null) {
-          RpcUtils.runClosureInThread(done, new Status(RaftError.EINVAL, "No such replicator"));
+            RpcUtils.runClosureInThread(done, new Status(RaftError.EINVAL, "No such replicator"));
             return;
         }
         try {
@@ -923,7 +923,7 @@ public class Replicator implements ThreadId.OnError {
     }
 
     static void onBlockTimeout(final ThreadId arg) {
-      RpcUtils.runInThread(() -> onBlockTimeoutInNewThread(arg));
+        RpcUtils.runInThread(() -> onBlockTimeoutInNewThread(arg));
     }
 
     void block(final long startTimeMs, @SuppressWarnings("unused") final int errorCode) {
@@ -933,9 +933,9 @@ public class Replicator implements ThreadId.OnError {
         // heartbeat_timeout_ms whether a dead follower has come back), but it's just
         // fine now.
         if(this.blockTimer != null) {
-          // already in blocking state,return immediately.
-          this.id.unlock();
-          return;
+            // already in blocking state,return immediately.
+            this.id.unlock();
+            return;
         }
         final long dueTime = startTimeMs + this.options.getDynamicHeartBeatTimeoutMs();
         try {

--- a/jraft-core/src/main/java/com/alipay/sofa/jraft/rpc/RpcUtils.java
+++ b/jraft-core/src/main/java/com/alipay/sofa/jraft/rpc/RpcUtils.java
@@ -35,7 +35,8 @@ import com.alipay.sofa.jraft.util.Utils;
  *
  * @author boyan(boyan@antfin.com)
  */
-public class RpcUtils {
+public final class RpcUtils {
+
     private static final Logger       LOG                                = LoggerFactory.getLogger(RpcUtils.class);
 
     /**

--- a/jraft-core/src/main/java/com/alipay/sofa/jraft/rpc/RpcUtils.java
+++ b/jraft-core/src/main/java/com/alipay/sofa/jraft/rpc/RpcUtils.java
@@ -19,8 +19,10 @@ package com.alipay.sofa.jraft.rpc;
 import java.util.concurrent.Future;
 import java.util.concurrent.SynchronousQueue;
 import java.util.concurrent.ThreadPoolExecutor;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
 import com.alipay.sofa.jraft.Closure;
 import com.alipay.sofa.jraft.Status;
 import com.alipay.sofa.jraft.util.NamedThreadFactory;
@@ -32,13 +34,9 @@ import com.alipay.sofa.jraft.util.Utils;
  * RPC utilities
  *
  * @author boyan(boyan@antfin.com)
- *
  */
 public class RpcUtils {
-    private static final Logger LOG = LoggerFactory.getLogger(RpcUtils.class);
-
-    private RpcUtils() {
-    }
+    private static final Logger       LOG                                = LoggerFactory.getLogger(RpcUtils.class);
 
     /**
      * Default jraft closure executor pool minimum size, CPUs by default.
@@ -70,7 +68,8 @@ public class RpcUtils {
                                                                              .threadFactory(
                                                                                  new NamedThreadFactory(
                                                                                      "JRaft-Rpc-Closure-Executor-",
-                                                                                     true)).build();
+                                                                                     true)) //
+                                                                             .build();
 
     /**
      * Run closure with OK status in thread pool.
@@ -104,5 +103,8 @@ public class RpcUtils {
                 LOG.error("Fail to run done closure", t);
             }
         });
-  }
+    }
+
+    private RpcUtils() {
+    }
 }

--- a/jraft-core/src/main/java/com/alipay/sofa/jraft/rpc/RpcUtils.java
+++ b/jraft-core/src/main/java/com/alipay/sofa/jraft/rpc/RpcUtils.java
@@ -1,0 +1,107 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alipay.sofa.jraft.rpc;
+
+import java.util.concurrent.Future;
+import java.util.concurrent.SynchronousQueue;
+import java.util.concurrent.ThreadPoolExecutor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import com.alipay.sofa.jraft.Closure;
+import com.alipay.sofa.jraft.Status;
+import com.alipay.sofa.jraft.util.NamedThreadFactory;
+import com.alipay.sofa.jraft.util.SystemPropertyUtil;
+import com.alipay.sofa.jraft.util.ThreadPoolUtil;
+import com.alipay.sofa.jraft.util.Utils;
+
+/**
+ * RPC utilities
+ *
+ * @author boyan(boyan@antfin.com)
+ *
+ */
+public class RpcUtils {
+    private static final Logger LOG = LoggerFactory.getLogger(RpcUtils.class);
+
+    private RpcUtils() {
+    }
+
+    /**
+     * Default jraft closure executor pool minimum size, CPUs by default.
+     */
+    public static final int           MIN_RPC_CLOSURE_EXECUTOR_POOL_SIZE = SystemPropertyUtil.getInt(
+                                                                             "jraft.rpc.closure.threadpool.size.min",
+                                                                             Utils.cpus());
+
+    /**
+     * Default jraft closure executor pool maximum size.
+     */
+    public static final int           MAX_RPC_CLOSURE_EXECUTOR_POOL_SIZE = SystemPropertyUtil.getInt(
+                                                                             "jraft.rpc.closure.threadpool.size.max",
+                                                                             Math.max(100, Utils.cpus() * 5));
+
+    /**
+     * Global thread pool to run rpc closure.
+     */
+    private static ThreadPoolExecutor RPC_CLOSURE_EXECUTOR               = ThreadPoolUtil
+                                                                             .newBuilder()
+                                                                             .poolName("JRAFT_RPC_CLOSURE_EXECUTOR")
+                                                                             .enableMetric(true)
+                                                                             .coreThreads(
+                                                                                 MIN_RPC_CLOSURE_EXECUTOR_POOL_SIZE)
+                                                                             .maximumThreads(
+                                                                                 MAX_RPC_CLOSURE_EXECUTOR_POOL_SIZE)
+                                                                             .keepAliveSeconds(60L)
+                                                                             .workQueue(new SynchronousQueue<>())
+                                                                             .threadFactory(
+                                                                                 new NamedThreadFactory(
+                                                                                     "JRaft-Rpc-Closure-Executor-",
+                                                                                     true)).build();
+
+    /**
+     * Run closure with OK status in thread pool.
+     */
+    public static Future<?> runClosureInThread(final Closure done) {
+        if (done == null) {
+            return null;
+        }
+        return runClosureInThread(done, Status.OK());
+    }
+
+    /**
+     * Run a task in thread pool,returns the future object.
+     */
+    public static Future<?> runInThread(final Runnable runnable) {
+        return RPC_CLOSURE_EXECUTOR.submit(runnable);
+    }
+
+    /**
+     * Run closure with status in thread pool.
+     */
+    public static Future<?> runClosureInThread(final Closure done, final Status status) {
+    if (done == null) {
+      return null;
+    }
+    return runInThread(() -> {
+      try {
+        done.run(status);
+      } catch (final Throwable t) {
+        LOG.error("Fail to run done closure", t);
+      }
+    });
+  }
+}

--- a/jraft-core/src/main/java/com/alipay/sofa/jraft/rpc/RpcUtils.java
+++ b/jraft-core/src/main/java/com/alipay/sofa/jraft/rpc/RpcUtils.java
@@ -93,15 +93,16 @@ public class RpcUtils {
      * Run closure with status in thread pool.
      */
     public static Future<?> runClosureInThread(final Closure done, final Status status) {
-    if (done == null) {
-      return null;
-    }
-    return runInThread(() -> {
-      try {
-        done.run(status);
-      } catch (final Throwable t) {
-        LOG.error("Fail to run done closure", t);
-      }
-    });
+        if (done == null) {
+            return null;
+        }
+
+        return runInThread(() -> {
+            try {
+                done.run(status);
+            } catch (final Throwable t) {
+                LOG.error("Fail to run done closure", t);
+            }
+        });
   }
 }

--- a/jraft-core/src/main/java/com/alipay/sofa/jraft/rpc/impl/AbstractClientService.java
+++ b/jraft-core/src/main/java/com/alipay/sofa/jraft/rpc/impl/AbstractClientService.java
@@ -39,6 +39,7 @@ import com.alipay.sofa.jraft.rpc.RpcRequests.ErrorResponse;
 import com.alipay.sofa.jraft.rpc.RpcRequests.PingRequest;
 import com.alipay.sofa.jraft.rpc.RpcResponseClosure;
 import com.alipay.sofa.jraft.rpc.RpcResponseFactory;
+import com.alipay.sofa.jraft.rpc.RpcUtils;
 import com.alipay.sofa.jraft.util.Endpoint;
 import com.alipay.sofa.jraft.util.NamedThreadFactory;
 import com.alipay.sofa.jraft.util.RpcFactoryHelper;
@@ -188,7 +189,7 @@ public abstract class AbstractClientService implements ClientService {
             if (rc == null) {
                 future.failure(new IllegalStateException("Client service is uninitialized."));
                 // should be in another thread to avoid dead locking.
-                Utils.runClosureInThread(done, new Status(RaftError.EINTERNAL, "Client service is uninitialized."));
+                RpcUtils.runClosureInThread(done, new Status(RaftError.EINTERNAL, "Client service is uninitialized."));
                 return future;
             }
 

--- a/jraft-core/src/main/java/com/alipay/sofa/jraft/storage/impl/LogManagerImpl.java
+++ b/jraft-core/src/main/java/com/alipay/sofa/jraft/storage/impl/LogManagerImpl.java
@@ -297,8 +297,8 @@ public class LogManagerImpl implements LogManager {
         this.writeLock.lock();
         try {
             if (!entries.isEmpty() && !checkAndResolveConflict(entries, done)) {
+                // If checkAndResolveConflict returns false, the done will be called in it.
                 entries.clear();
-                Utils.runClosureInThread(done, new Status(RaftError.EINTERNAL, "Fail to checkAndResolveConflict."));
                 return;
             }
             for (int i = 0; i < entries.size(); i++) {
@@ -1008,6 +1008,7 @@ public class LogManagerImpl implements LogManager {
                 LOG.warn(
                     "Received entries of which the lastLog={} is not greater than appliedIndex={}, return immediately with nothing changed.",
                     lastLogEntry.getId().getIndex(), appliedIndex);
+                Utils.runClosureInThread(done);
                 return false;
             }
             if (firstLogEntry.getId().getIndex() == this.lastLogIndex + 1) {

--- a/jraft-core/src/main/java/com/alipay/sofa/jraft/storage/impl/LogManagerImpl.java
+++ b/jraft-core/src/main/java/com/alipay/sofa/jraft/storage/impl/LogManagerImpl.java
@@ -1008,6 +1008,7 @@ public class LogManagerImpl implements LogManager {
                 LOG.warn(
                     "Received entries of which the lastLog={} is not greater than appliedIndex={}, return immediately with nothing changed.",
                     lastLogEntry.getId().getIndex(), appliedIndex);
+                // Replicate old logs before appliedIndex should be considered successfully, response OK.
                 Utils.runClosureInThread(done);
                 return false;
             }

--- a/jraft-core/src/main/java/com/alipay/sofa/jraft/storage/snapshot/remote/CopySession.java
+++ b/jraft-core/src/main/java/com/alipay/sofa/jraft/storage/snapshot/remote/CopySession.java
@@ -41,6 +41,7 @@ import com.alipay.sofa.jraft.rpc.RpcRequests;
 import com.alipay.sofa.jraft.rpc.RpcRequests.GetFileRequest;
 import com.alipay.sofa.jraft.rpc.RpcRequests.GetFileResponse;
 import com.alipay.sofa.jraft.rpc.RpcResponseClosureAdapter;
+import com.alipay.sofa.jraft.rpc.RpcUtils;
 import com.alipay.sofa.jraft.storage.SnapshotThrottle;
 import com.alipay.sofa.jraft.util.ByteBufferCollector;
 import com.alipay.sofa.jraft.util.Endpoint;
@@ -203,7 +204,7 @@ public class CopySession implements Session {
     }
 
     private void onTimer() {
-        Utils.runInThread(this::sendNextRpc);
+      RpcUtils.runInThread(this::sendNextRpc);
     }
 
     void onRpcReturned(final Status status, final GetFileResponse response) {

--- a/jraft-core/src/main/java/com/alipay/sofa/jraft/storage/snapshot/remote/CopySession.java
+++ b/jraft-core/src/main/java/com/alipay/sofa/jraft/storage/snapshot/remote/CopySession.java
@@ -204,7 +204,7 @@ public class CopySession implements Session {
     }
 
     private void onTimer() {
-      RpcUtils.runInThread(this::sendNextRpc);
+        RpcUtils.runInThread(this::sendNextRpc);
     }
 
     void onRpcReturned(final Status status, final GetFileResponse response) {

--- a/jraft-core/src/main/java/com/alipay/sofa/jraft/util/Utils.java
+++ b/jraft-core/src/main/java/com/alipay/sofa/jraft/util/Utils.java
@@ -48,7 +48,7 @@ import com.codahale.metrics.MetricRegistry;
  *
  * 2018-Apr-07 10:12:35 AM
  */
-public class Utils {
+public final class Utils {
 
     private static final Logger       LOG                                 = LoggerFactory.getLogger(Utils.class);
 

--- a/jraft-core/src/test/java/com/alipay/sofa/jraft/core/NodeTest.java
+++ b/jraft-core/src/test/java/com/alipay/sofa/jraft/core/NodeTest.java
@@ -1741,6 +1741,7 @@ public class NodeTest {
         CountDownLatch latch = new CountDownLatch(1);
         leader.removePeer(oldLeader, new ExpectClosure(latch));
         waitLatch(latch);
+        Thread.sleep(100);
 
         // elect new leader
         cluster.waitLeader();

--- a/jraft-core/src/test/java/com/alipay/sofa/jraft/core/NodeTest.java
+++ b/jraft-core/src/test/java/com/alipay/sofa/jraft/core/NodeTest.java
@@ -1399,6 +1399,7 @@ public class NodeTest {
             assertEquals(1, leader.listLearners().size());
         }
 
+        Thread.sleep(100);
         // read from learner
         Node learner = cluster.getNodes().get(3);
         assertNotNull(leader);

--- a/jraft-core/src/test/java/com/alipay/sofa/jraft/core/NodeTest.java
+++ b/jraft-core/src/test/java/com/alipay/sofa/jraft/core/NodeTest.java
@@ -34,6 +34,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 import org.apache.commons.io.FileUtils;
 import org.junit.After;
+import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.BeforeClass;
@@ -104,10 +105,42 @@ public class NodeTest {
 
     private long                testStartMs;
 
+    private static DumpThread   dumpThread;
+
+    static class DumpThread extends Thread {
+        private static long      DUMP_TIMEOUT_MS = 5 * 60 * 1000;
+        private volatile boolean stopped         = false;
+
+        @Override
+        public void run() {
+            while (!this.stopped) {
+                try {
+                    Thread.sleep(DUMP_TIMEOUT_MS);
+                    System.out.println("Test hang too long, dump threads");
+                    TestUtils.dumpThreads();
+                } catch (InterruptedException e) {
+                    // reset request, continue
+                    continue;
+                }
+            }
+        }
+    }
+
     @BeforeClass
-    public static void setupRocksdbOptions() {
+    public static void setupNodeTest() {
         StorageOptionsFactory.registerRocksDBTableFormatConfig(RocksDBLogStorage.class, StorageOptionsFactory
             .getDefaultRocksDBTableConfig().setBlockCacheSize(256 * SizeUnit.MB));
+        dumpThread = new DumpThread();
+        dumpThread.setName("NodeTest-DumpThread");
+        dumpThread.setDaemon(true);
+        dumpThread.start();
+    }
+
+    @AfterClass
+    public static void tearNodeTest() throws Exception {
+        dumpThread.stopped = true;
+        dumpThread.interrupt();
+        dumpThread.join(100);
     }
 
     @Before
@@ -117,6 +150,7 @@ public class NodeTest {
         FileUtils.forceMkdir(new File(this.dataPath));
         assertEquals(NodeImpl.GLOBAL_NUM_NODES.get(), 0);
         this.testStartMs = Utils.monotonicMs();
+        dumpThread.interrupt(); // reset dump timeout
     }
 
     @After

--- a/jraft-core/src/test/java/com/alipay/sofa/jraft/test/TestUtils.java
+++ b/jraft-core/src/test/java/com/alipay/sofa/jraft/test/TestUtils.java
@@ -16,6 +16,9 @@
  */
 package com.alipay.sofa.jraft.test;
 
+import java.lang.management.ManagementFactory;
+import java.lang.management.ThreadInfo;
+import java.lang.management.ThreadMXBean;
 import java.net.Inet4Address;
 import java.net.InetAddress;
 import java.net.NetworkInterface;
@@ -26,7 +29,6 @@ import java.util.ArrayList;
 import java.util.Enumeration;
 import java.util.List;
 import java.util.concurrent.ThreadLocalRandom;
-
 import com.alipay.sofa.jraft.JRaftUtils;
 import com.alipay.sofa.jraft.conf.ConfigurationEntry;
 import com.alipay.sofa.jraft.entity.EnumOutter;
@@ -38,9 +40,10 @@ import com.alipay.sofa.jraft.util.Endpoint;
 
 /**
  * Test helper
+ *
  * @author boyan (boyan@alibaba-inc.com)
  *
- * 2018-Apr-11 10:16:07 AM
+ *         2018-Apr-11 10:16:07 AM
  */
 public class TestUtils {
 
@@ -49,6 +52,18 @@ public class TestUtils {
         entry.setConf(JRaftUtils.getConfiguration(confStr));
         entry.setOldConf(JRaftUtils.getConfiguration(oldConfStr));
         return entry;
+    }
+
+    public static void dumpThreads() {
+        try {
+            ThreadMXBean bean = ManagementFactory.getThreadMXBean();
+            ThreadInfo[] infos = bean.dumpAllThreads(true, true);
+            for (ThreadInfo info : infos) {
+                System.out.println(info);
+            }
+        } catch (Throwable t) {
+            t.printStackTrace(); // NOPMD
+        }
     }
 
     public static String mkTempDir() {
@@ -128,7 +143,7 @@ public class TestUtils {
         return ret;
     }
 
-    public static List<PeerId> generatePriorityPeers(final int n, List<Integer> priorities) {
+    public static List<PeerId> generatePriorityPeers(final int n, final List<Integer> priorities) {
         List<PeerId> ret = new ArrayList<>();
         for (int i = 0; i < n; i++) {
             Endpoint endpoint = new Endpoint(getMyIp(), INIT_PORT + i);


### PR DESCRIPTION
Main changes:

* Replicate logs before appliedIndex(in follower) to followers should be considered successfully.
* Provide an isolate thread pool to run replciator and rpc closures to prevent problems such as #426 
* Prevent creating too many block timers when RPC fails( status is not ok).
* Fixed replicate state field may be wrong in some situations.

