### PR TITLE
do not allow write snapshot file outside of parent dir

### DIFF
--- a/jraft-core/src/main/java/com/alipay/sofa/jraft/storage/snapshot/local/LocalSnapshotCopier.java
+++ b/jraft-core/src/main/java/com/alipay/sofa/jraft/storage/snapshot/local/LocalSnapshotCopier.java
@@ -199,7 +199,7 @@ public class LocalSnapshotCopier extends SnapshotCopier {
                 return false;
             }
         } catch (final IOException e) {
-            LOG.error("Failed to check file: {}, writer path: {}.", fileName, this.writer.getPath());
+            LOG.error("Failed to check file: {}, writer path: {}.", fileName, this.writer.getPath(), e);
             setError(RaftError.EIO, "Failed to check file: {}, writer path: {}.", fileName, this.writer.getPath());
             return false;
         }

--- a/jraft-core/src/main/java/com/alipay/sofa/jraft/storage/snapshot/local/LocalSnapshotCopier.java
+++ b/jraft-core/src/main/java/com/alipay/sofa/jraft/storage/snapshot/local/LocalSnapshotCopier.java
@@ -123,20 +123,13 @@ public class LocalSnapshotCopier extends SnapshotCopier {
             LOG.info("Skipped downloading {}", fileName);
             return;
         }
-        final String parentCanonicalPath = Paths.get(this.writer.getPath()).toFile().getCanonicalPath();
-        final Path filePath = Paths.get(parentCanonicalPath, fileName);
-        final File file = filePath.toFile();
-        final String fileAbsolutePath = file.getAbsolutePath();
-        final String fileCanonicalPath = file.getCanonicalPath();
-        if (!fileAbsolutePath.equals(fileCanonicalPath)) {
-            LOG.error("File[{}] are not allowed to be created outside of directory[{}].", fileAbsolutePath,
-                fileCanonicalPath);
-            setError(RaftError.EIO, "File[%s] are not allowed to be created outside of directory", fileAbsolutePath,
-                fileCanonicalPath);
+        if (!checkFile(fileName)) {
             return;
         }
-        if (!filePath.equals(filePath.getParent()) && !filePath.getParent().getFileName().toString().equals(".")) {
-            final File parentDir = filePath.getParent().toFile();
+        final String filePath = this.writer.getPath() + File.separator + fileName;
+        final Path subPath = Paths.get(filePath);
+        if (!subPath.equals(subPath.getParent()) && !subPath.getParent().getFileName().toString().equals(".")) {
+            final File parentDir = subPath.getParent().toFile();
             if (!parentDir.exists() && !parentDir.mkdirs()) {
                 LOG.error("Fail to create directory for {}", filePath);
                 setError(RaftError.EIO, "Fail to create directory");
@@ -155,7 +148,7 @@ public class LocalSnapshotCopier extends SnapshotCopier {
                     }
                     return;
                 }
-                session = this.copier.startCopyToFile(fileName, filePath.toString(), null);
+                session = this.copier.startCopyToFile(fileName, filePath, null);
                 if (session == null) {
                     LOG.error("Fail to copy {}", fileName);
                     setError(-1, "Fail to copy %s", fileName);
@@ -189,6 +182,28 @@ public class LocalSnapshotCopier extends SnapshotCopier {
                 Utils.closeQuietly(session);
             }
         }
+    }
+
+    private boolean checkFile(final String fileName) {
+        try {
+            final String parentCanonicalPath = Paths.get(this.writer.getPath()).toFile().getCanonicalPath();
+            final Path filePath = Paths.get(parentCanonicalPath, fileName);
+            final File file = filePath.toFile();
+            final String fileAbsolutePath = file.getAbsolutePath();
+            final String fileCanonicalPath = file.getCanonicalPath();
+            if (!fileAbsolutePath.equals(fileCanonicalPath)) {
+                LOG.error("File[{}] are not allowed to be created outside of directory[{}].", fileAbsolutePath,
+                    fileCanonicalPath);
+                setError(RaftError.EIO, "File[%s] are not allowed to be created outside of directory.",
+                    fileAbsolutePath, fileCanonicalPath);
+                return false;
+            }
+        } catch (final IOException e) {
+            LOG.error("Failed to check file: {}, writer path: {}.", fileName, this.writer.getPath());
+            setError(RaftError.EIO, "Failed to check file: {}, writer path: {}.", fileName, this.writer.getPath());
+            return false;
+        }
+        return true;
     }
 
     private void loadMetaTable() throws InterruptedException {


### PR DESCRIPTION
### Motivation:

do not allow write snapshot file outside of parent dir

### Modification:

1. use canonical  path
2. check the file path with `canonical  path`

### Result:

Fixes #<GitHub issue number>.

If there is no issue then describe the changes introduced by this PR.
