### PR TITLE
upgrade log4j version

### DIFF
--- a/jraft-core/pom.xml
+++ b/jraft-core/pom.xml
@@ -70,18 +70,22 @@
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-api</artifactId>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-core</artifactId>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-slf4j-impl</artifactId>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-jcl</artifactId>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>com.lmax</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -66,7 +66,7 @@
         <jsr305.version>3.0.2</jsr305.version>
         <junit.dep.version>4.8.2</junit.dep.version>
         <junit.version>4.12</junit.version>
-        <log4j.version>2.2</log4j.version>
+        <log4j.version>2.13.2</log4j.version>
         <main.user.dir>${user.dir}</main.user.dir>
         <metrics.version>4.0.2</metrics.version>
         <mockito.version>1.9.5</mockito.version>


### PR DESCRIPTION
### Motivation:

1. Upgrade log4j to 2.13.2 to fix vulnerabilities 
2. Modify log4j's scope to test in `jraft-core` #491 

### Modification:


### Result:

Fixes #491 
