### PR TITLE
[improve] ignore PreVoteRequest when not in conf

### DIFF
--- a/jraft-core/src/main/java/com/alipay/sofa/jraft/core/NodeImpl.java
+++ b/jraft-core/src/main/java/com/alipay/sofa/jraft/core/NodeImpl.java
@@ -1650,6 +1650,11 @@ public class NodeImpl implements Node, RaftServerService {
             boolean granted = false;
             // noinspection ConstantConditions
             do {
+                if (!this.conf.contains(candidateId)) {
+                    LOG.warn("Node {} ignore PreVoteRequest from {} as it is not in conf <{}>.", getNodeId(),
+                        request.getServerId(), this.conf);
+                    break;
+                }
                 if (this.leaderId != null && !this.leaderId.isEmpty() && isCurrentLeaderValid()) {
                     LOG.info(
                         "Node {} ignore PreVoteRequest from {}, term={}, currTerm={}, because the leader {}'s lease is still valid.",

--- a/jraft-core/src/main/java/com/alipay/sofa/jraft/core/NodeImpl.java
+++ b/jraft-core/src/main/java/com/alipay/sofa/jraft/core/NodeImpl.java
@@ -1667,11 +1667,11 @@ public class NodeImpl implements Node, RaftServerService {
                     // A follower replicator may not be started when this node become leader, so we must check it.
                     checkReplicator(candidateId);
                     break;
-                } else if (request.getTerm() == this.currTerm + 1) {
-                    // A follower replicator may not be started when this node become leader, so we must check it.
-                    // check replicator state
-                    checkReplicator(candidateId);
                 }
+                // A follower replicator may not be started when this node become leader, so we must check it.
+                // check replicator state
+                checkReplicator(candidateId);
+
                 doUnlock = false;
                 this.writeLock.unlock();
 

--- a/jraft-rheakv/rheakv-core/src/test/java/com/alipay/sofa/jraft/rhea/chaos/ChaosTestCluster.java
+++ b/jraft-rheakv/rheakv-core/src/test/java/com/alipay/sofa/jraft/rhea/chaos/ChaosTestCluster.java
@@ -92,8 +92,8 @@ public class ChaosTestCluster {
                 .withInitialServerList(initialServerList).withOnlyLeaderRead(this.onlyLeaderRead) //
                 .withStoreEngineOptions(storeOpts) //
                 .withPlacementDriverOptions(pdOpts) //
-                .withFailoverRetries(10) //
-                .withFutureTimeoutMillis(TimeUnit.SECONDS.toMillis(30)) //
+                .withFailoverRetries(30) //
+                .withFutureTimeoutMillis(TimeUnit.SECONDS.toMillis(60)) //
                 .config();
             BatchingOptions batchingOptions = opts.getBatchingOptions();
             if (batchingOptions == null) {


### PR DESCRIPTION
### Motivation:

When users add a new peer to the raft group, it may cause the added peer to pre_vote quickly. Although the state of raft cluster will not be affected,  but some irrelevant logs will be printed.

### Modification:

Ignore the pre_vote_request when the peer not in conf.

### Result:
#509 

