### PR TITLE
Feature/2020.09.22 changes

### DIFF
--- a/jraft-core/src/main/java/com/alipay/sofa/jraft/core/NodeImpl.java
+++ b/jraft-core/src/main/java/com/alipay/sofa/jraft/core/NodeImpl.java
@@ -232,7 +232,7 @@ public class NodeImpl implements Node, RaftServerService {
 
         private final Node node;
 
-        public NodeReadWriteLock(Node node) {
+        public NodeReadWriteLock(final Node node) {
             super(MAX_BLOCKING_MS_TO_REPORT, TimeUnit.MILLISECONDS);
             this.node = node;
         }
@@ -1943,7 +1943,7 @@ public class NodeImpl implements Node, RaftServerService {
             }
 
             if (entriesCount == 0) {
-                // heartbeat
+                // heartbeat or probe request
                 final AppendEntriesResponse.Builder respBuilder = AppendEntriesResponse.newBuilder() //
                     .setSuccess(true) //
                     .setTerm(this.currTerm) //

--- a/jraft-core/src/main/java/com/alipay/sofa/jraft/storage/impl/LogManagerImpl.java
+++ b/jraft-core/src/main/java/com/alipay/sofa/jraft/storage/impl/LogManagerImpl.java
@@ -619,9 +619,14 @@ public class LogManagerImpl implements LogManager {
             if (this.lastSnapshotId.compareTo(this.appliedId) > 0) {
                 this.appliedId = this.lastSnapshotId.copy();
             }
-            if (this.lastSnapshotId.compareTo(this.diskId) > 0) {
-                this.diskId = this.lastSnapshotId.copy();
-            }
+            // NOTICE: not to update disk_id here as we are not sure if this node really
+            // has these logs on disk storage. Just leave disk_id as it was, which can keep
+            // these logs in memory all the time until they are flushed to disk. By this
+            // way we can avoid some corner cases which failed to get logs.
+            // See https://github.com/baidu/braft/pull/224/commits/8ef6fdbf70d23f5a4ee147356a889e2c0fa22aac
+            //            if (this.lastSnapshotId.compareTo(this.diskId) > 0) {
+            //                this.diskId = this.lastSnapshotId.copy();
+            //            }
 
             if (term == 0) {
                 // last_included_index is larger than last_index

--- a/jraft-core/src/test/java/com/alipay/sofa/jraft/core/NodeTest.java
+++ b/jraft-core/src/test/java/com/alipay/sofa/jraft/core/NodeTest.java
@@ -321,7 +321,7 @@ public class NodeTest {
                         if (status.isOk()) {
                             readIndexSuccesses.incrementAndGet();
                         } else {
-                            assertTrue("Unexpect status: " + status,
+                            assertTrue("Unexpected status: " + status,
                                 status.getErrorMsg().contains(errorMsg) || status.getRaftError() == RaftError.ETIMEDOUT
                                         || status.getErrorMsg().contains("Invalid state for readIndex: STATE_ERROR"));
                         }

--- a/jraft-core/src/test/java/com/alipay/sofa/jraft/core/NodeTest.java
+++ b/jraft-core/src/test/java/com/alipay/sofa/jraft/core/NodeTest.java
@@ -321,9 +321,8 @@ public class NodeTest {
                         if (status.isOk()) {
                             readIndexSuccesses.incrementAndGet();
                         } else {
-                            assertTrue(
-                                "Unexpect status: " + status,
-                                status.getErrorMsg().contains(errorMsg)
+                            assertTrue("Unexpect status: " + status,
+                                status.getErrorMsg().contains(errorMsg) || status.getRaftError() == RaftError.ETIMEDOUT
                                         || status.getErrorMsg().contains("Invalid state for readIndex: STATE_ERROR"));
                         }
                     } finally {

--- a/jraft-core/src/test/java/com/alipay/sofa/jraft/core/ReplicatorGroupTest.java
+++ b/jraft-core/src/test/java/com/alipay/sofa/jraft/core/ReplicatorGroupTest.java
@@ -42,7 +42,7 @@ import com.alipay.sofa.jraft.rpc.RpcRequests;
 import com.alipay.sofa.jraft.rpc.impl.FutureImpl;
 import com.alipay.sofa.jraft.storage.LogManager;
 import com.alipay.sofa.jraft.storage.SnapshotStorage;
-
+import com.google.protobuf.ByteString;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
@@ -279,6 +279,7 @@ public class ReplicatorGroupTest {
             .setPrevLogIndex(10) //
             .setPrevLogTerm(1) //
             .setCommittedIndex(0) //
+            .setData(ByteString.EMPTY) //
             .build();
     }
 }

--- a/jraft-core/src/test/java/com/alipay/sofa/jraft/storage/impl/LogManagerTest.java
+++ b/jraft-core/src/test/java/com/alipay/sofa/jraft/storage/impl/LogManagerTest.java
@@ -168,6 +168,7 @@ public class LogManagerTest extends BaseStorageTest {
 
         assertEquals(1, this.logManager.getFirstLogIndex());
         assertEquals(10, this.logManager.getLastLogIndex());
+        Thread.sleep(200); // waiting for setDiskId()
         this.logManager.setAppliedId(new LogId(9, 1));
 
         for (int i = 0; i < 10; i++) {


### PR DESCRIPTION
Some changes:

* Don't update `diskId` when `setSnapshot`  in LogManagerImpl for some corner cases.
* Send heartbeat response directly.Do not put it into pipeline response queue.It's a little trick here,  we consider an empty appendEntries request( no entries and no data) as a true heartbeat request, and set empty data for probe request(also has no entries), we may refactor it later by adding a new flag field.
