### PR TITLE
Fix/error response on future

### DIFF
--- a/jraft-core/src/main/java/com/alipay/sofa/jraft/rpc/impl/AbstractClientService.java
+++ b/jraft-core/src/main/java/com/alipay/sofa/jraft/rpc/impl/AbstractClientService.java
@@ -235,7 +235,9 @@ public abstract class AbstractClientService implements ClientService {
                         }
                         if (done != null) {
                             try {
-                                done.setResponse((T) msg);
+                                if (status.isOk()) {
+                                    done.setResponse((T) msg);
+                                }
                                 done.run(status);
                             } catch (final Throwable t) {
                                 LOG.error("Fail to run RpcResponseClosure, the request is {}.", request, t);

--- a/jraft-core/src/main/java/com/alipay/sofa/jraft/rpc/impl/AbstractClientService.java
+++ b/jraft-core/src/main/java/com/alipay/sofa/jraft/rpc/impl/AbstractClientService.java
@@ -216,33 +216,33 @@ public abstract class AbstractClientService implements ClientService {
 
                     if (err == null) {
                         Status status = Status.OK();
+                        Message msg;
                         if (result instanceof ErrorResponse) {
                             status = handleErrorResponse((ErrorResponse) result);
+                            msg = (Message) result;
                         } else if (result instanceof Message) {
                             final Descriptors.FieldDescriptor fd = ((Message) result).getDescriptorForType() //
                                 .findFieldByNumber(RpcResponseFactory.ERROR_RESPONSE_NUM);
                             if (fd != null && ((Message) result).hasField(fd)) {
                                 final ErrorResponse eResp = (ErrorResponse) ((Message) result).getField(fd);
                                 status = handleErrorResponse(eResp);
+                                msg = eResp;
                             } else {
-                                if (done != null) {
-                                    done.setResponse((T) result);
-                                }
+                                msg = (T) result;
                             }
                         } else {
-                            if (done != null) {
-                                done.setResponse((T) result);
-                            }
+                            msg = (T) result;
                         }
                         if (done != null) {
                             try {
+                                done.setResponse((T) msg);
                                 done.run(status);
                             } catch (final Throwable t) {
                                 LOG.error("Fail to run RpcResponseClosure, the request is {}.", request, t);
                             }
                         }
                         if (!future.isDone()) {
-                            future.setResult((Message) result);
+                            future.setResult(msg);
                         }
                     } else {
                         if (done != null) {

--- a/jraft-core/src/test/java/com/alipay/sofa/jraft/rpc/AbstractClientServiceTest.java
+++ b/jraft-core/src/test/java/com/alipay/sofa/jraft/rpc/AbstractClientServiceTest.java
@@ -257,7 +257,7 @@ public class AbstractClientServiceTest {
         MockRpcResponseClosure<ErrorResponse> done = new MockRpcResponseClosure<>();
         Future<Message> future = this.clientService.invokeWithDone(this.endpoint, request, invokeCtx, done, -1);
         Mockito.verify(this.rpcClient).invokeAsync(eq(this.endpoint), eq(request), eq(invokeCtx),
-                callbackArg.capture(), eq((long) this.rpcOptions.getRpcDefaultTimeout()));
+            callbackArg.capture(), eq((long) this.rpcOptions.getRpcDefaultTimeout()));
         InvokeCallback cb = callbackArg.getValue();
         assertNotNull(cb);
         assertNotNull(future);
@@ -266,7 +266,8 @@ public class AbstractClientServiceTest {
         assertNull(done.status);
         assertFalse(future.isDone());
 
-        final Message resp = this.rpcResponseFactory.newResponse(CliRequests.GetPeersResponse.getDefaultInstance(), new Status(-1, "failed"));
+        final Message resp = this.rpcResponseFactory.newResponse(CliRequests.GetPeersResponse.getDefaultInstance(),
+            new Status(-1, "failed"));
         cb.complete(resp, null);
 
         final Message msg = future.get();

--- a/jraft-extension/rpc-grpc-impl/src/test/java/com/alipay/sofa/jraft/rpc/AbstractClientServiceTest.java
+++ b/jraft-extension/rpc-grpc-impl/src/test/java/com/alipay/sofa/jraft/rpc/AbstractClientServiceTest.java
@@ -243,4 +243,40 @@ public class AbstractClientServiceTest {
         assertNotNull(done.status);
         assertEquals(RaftError.ETIMEDOUT.getNumber(), done.status.getCode());
     }
+
+    @Test
+    public void testInvokeWithDOneOnErrorResponse() throws Exception {
+        final InvokeContext invokeCtx = new InvokeContext();
+        invokeCtx.put(InvokeContext.CRC_SWITCH, false);
+        final ArgumentCaptor<InvokeCallback> callbackArg = ArgumentCaptor.forClass(InvokeCallback.class);
+        final CliRequests.GetPeersRequest request = CliRequests.GetPeersRequest.newBuilder() //
+                .setGroupId("id") //
+                .setLeaderId("127.0.0.1:8001") //
+                .build();
+
+        MockRpcResponseClosure<ErrorResponse> done = new MockRpcResponseClosure<>();
+        Future<Message> future = this.clientService.invokeWithDone(this.endpoint, request, invokeCtx, done, -1);
+        Mockito.verify(this.rpcClient).invokeAsync(eq(this.endpoint), eq(request), eq(invokeCtx),
+                callbackArg.capture(), eq((long) this.rpcOptions.getRpcDefaultTimeout()));
+        InvokeCallback cb = callbackArg.getValue();
+        assertNotNull(cb);
+        assertNotNull(future);
+
+        assertNull(done.getResponse());
+        assertNull(done.status);
+        assertFalse(future.isDone());
+
+        final Message resp = this.rpcResponseFactory.newResponse(CliRequests.GetPeersResponse.getDefaultInstance(), new Status(-1, "failed"));
+        cb.complete(resp, null);
+
+        final Message msg = future.get();
+
+        assertTrue(msg instanceof ErrorResponse);
+        assertEquals(((ErrorResponse) msg).getErrorMsg(), "failed");
+
+        done.latch.await();
+        assertNotNull(done.status);
+        assertTrue(!done.status.isOk());
+        assertEquals(done.status.getErrorMsg(), "failed");
+    }
 }

--- a/jraft-extension/rpc-grpc-impl/src/test/java/com/alipay/sofa/jraft/rpc/AbstractClientServiceTest.java
+++ b/jraft-extension/rpc-grpc-impl/src/test/java/com/alipay/sofa/jraft/rpc/AbstractClientServiceTest.java
@@ -250,14 +250,14 @@ public class AbstractClientServiceTest {
         invokeCtx.put(InvokeContext.CRC_SWITCH, false);
         final ArgumentCaptor<InvokeCallback> callbackArg = ArgumentCaptor.forClass(InvokeCallback.class);
         final CliRequests.GetPeersRequest request = CliRequests.GetPeersRequest.newBuilder() //
-                .setGroupId("id") //
-                .setLeaderId("127.0.0.1:8001") //
-                .build();
+            .setGroupId("id") //
+            .setLeaderId("127.0.0.1:8001") //
+            .build();
 
         MockRpcResponseClosure<ErrorResponse> done = new MockRpcResponseClosure<>();
         Future<Message> future = this.clientService.invokeWithDone(this.endpoint, request, invokeCtx, done, -1);
         Mockito.verify(this.rpcClient).invokeAsync(eq(this.endpoint), eq(request), eq(invokeCtx),
-                callbackArg.capture(), eq((long) this.rpcOptions.getRpcDefaultTimeout()));
+            callbackArg.capture(), eq((long) this.rpcOptions.getRpcDefaultTimeout()));
         InvokeCallback cb = callbackArg.getValue();
         assertNotNull(cb);
         assertNotNull(future);
@@ -266,7 +266,8 @@ public class AbstractClientServiceTest {
         assertNull(done.status);
         assertFalse(future.isDone());
 
-        final Message resp = this.rpcResponseFactory.newResponse(CliRequests.GetPeersResponse.getDefaultInstance(), new Status(-1, "failed"));
+        final Message resp = this.rpcResponseFactory.newResponse(CliRequests.GetPeersResponse.getDefaultInstance(),
+            new Status(-1, "failed"));
         cb.complete(resp, null);
 
         final Message msg = future.get();


### PR DESCRIPTION
### Motivation:

forget to parse error_response and set to future when use grpc

### Modification:


### Result:

