### PR TITLE
Add ARM64 support

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -75,7 +75,7 @@
         <project.encoding>UTF-8</project.encoding>
         <protobuf.version>3.5.1</protobuf.version>
         <protostuff.version>1.6.0</protostuff.version>
-        <rocksdb.version>5.18.3</rocksdb.version>
+        <rocksdb.version>5.18.4</rocksdb.version>
         <slf4j.version>1.7.21</slf4j.version>
     </properties>
 


### PR DESCRIPTION
Upgraded 'rocksdb' version to 5.18.4 for AArch64 support.

Signed-off-by: odidev <odidev@puresoftware.com>

