### PR TITLE
(fix) revisiting segment log storage and fix some corner cases

### DIFF
--- a/jraft-core/src/main/java/com/alipay/sofa/jraft/core/NodeImpl.java
+++ b/jraft-core/src/main/java/com/alipay/sofa/jraft/core/NodeImpl.java
@@ -647,6 +647,8 @@ public class NodeImpl implements Node, RaftServerService {
 
         // Priority 0 is a special value so that a node will never participate in election.
         if (this.serverId.isPriorityNotElected()) {
+            LOG.warn("Node {} will never participate in election, because it's priority={}.", getNodeId(),
+                this.serverId.getPriority());
             return false;
         }
 
@@ -668,6 +670,8 @@ public class NodeImpl implements Node, RaftServerService {
             }
 
             if (this.electionTimeoutCounter == 1) {
+                LOG.debug("Node {} does not initiate leader election and waits for the next election timeout.",
+                    getNodeId());
                 return false;
             }
         }

--- a/jraft-core/src/main/java/com/alipay/sofa/jraft/storage/log/AbortFile.java
+++ b/jraft-core/src/main/java/com/alipay/sofa/jraft/storage/log/AbortFile.java
@@ -52,7 +52,7 @@ public class AbortFile {
     @SuppressWarnings("deprecation")
     private void writeDate() throws IOException {
         final File file = new File(this.path);
-        try (FileWriter writer = new FileWriter(file, false)) {
+        try (final FileWriter writer = new FileWriter(file, false)) {
             writer.write(new Date().toGMTString());
             writer.write(System.lineSeparator());
         }

--- a/jraft-core/src/main/java/com/alipay/sofa/jraft/storage/log/AbortFile.java
+++ b/jraft-core/src/main/java/com/alipay/sofa/jraft/storage/log/AbortFile.java
@@ -40,25 +40,26 @@ public class AbortFile {
     }
 
     public boolean create() throws IOException {
-        return writeDate();
-    }
-
-    @SuppressWarnings("deprecation")
-    private boolean writeDate() throws IOException {
         final File file = new File(this.path);
         if (file.createNewFile()) {
-            try (FileWriter writer = new FileWriter(file, false)) {
-                writer.write(new Date().toGMTString());
-                writer.write(System.lineSeparator());
-            }
+            writeDate();
             return true;
         } else {
             return false;
         }
     }
 
-    public boolean touch() throws IOException {
-        return writeDate();
+    @SuppressWarnings("deprecation")
+    private void writeDate() throws IOException {
+        final File file = new File(this.path);
+        try (FileWriter writer = new FileWriter(file, false)) {
+            writer.write(new Date().toGMTString());
+            writer.write(System.lineSeparator());
+        }
+    }
+
+    public void touch() throws IOException {
+        writeDate();
     }
 
     public boolean exists() {

--- a/jraft-core/src/main/java/com/alipay/sofa/jraft/storage/log/RocksDBSegmentLogStorage.java
+++ b/jraft-core/src/main/java/com/alipay/sofa/jraft/storage/log/RocksDBSegmentLogStorage.java
@@ -491,12 +491,11 @@ public class RocksDBSegmentLogStorage extends RocksDBLogStorage {
                     }
 
                     if (segmentFile.isBlank()) {
-                        this.blankSegments.add(new AllocatedResult(segmentFile));
-                    } else if(segmentFile.isHeaderCorrupted()) {
+                      this.blankSegments.add(new AllocatedResult(segmentFile));
+                    } else if (segmentFile.isHeaderCorrupted()) {
                       corruptedHeaderSegments.add(segFile);
-                    }
-                    else {
-                        this.segments.add(segmentFile);
+                    } else {
+                      this.segments.add(segmentFile);
                     }
                 }
 
@@ -622,14 +621,15 @@ public class RocksDBSegmentLogStorage extends RocksDBLogStorage {
                 LOG.error("Detected corrupted header segment file {}.", corruptedFile);
                 return false;
             } else {
-                // The file is the last file,it's the new blank segment but fail to save header, we can remove it safely.
+                // The file is the last file,it's the new blank segment but fail to save header, we can
+                // remove it safely.
                 LOG.warn("Truncate the last segment file {} which it's header is corrupted.",
                     corruptedFile.getAbsolutePath());
-                //We don't want to delete it, but rename it for safety.
+                // We don't want to delete it, but rename it for safety.
                 FileUtils.moveFile(corruptedFile, new File(corruptedFile.getAbsolutePath() + ".corrupted"));
             }
         } else if (corruptedHeaderSegments.size() > 1) {
-            //FATAL: it should not happen.
+            // FATAL: it should not happen.
             LOG.error("Detected corrupted header segment files: {}.", corruptedHeaderSegments);
             return false;
         }

--- a/jraft-core/src/main/java/com/alipay/sofa/jraft/storage/log/RocksDBSegmentLogStorage.java
+++ b/jraft-core/src/main/java/com/alipay/sofa/jraft/storage/log/RocksDBSegmentLogStorage.java
@@ -890,12 +890,16 @@ public class RocksDBSegmentLogStorage extends RocksDBLogStorage {
             if (keptFileIndex < 0) {
                 // When all the segments contain logs that index is greater than lastIndexKept,
                 // truncate all segments.
-                if (this.segments.size() > 0) {
-                    if (getFirstSegmentWithoutLock().getFirstLogIndex() > lastIndexKept) {
+                if (!this.segments.isEmpty()) {
+                    final long firstLogIndex = getFirstSegmentWithoutLock().getFirstLogIndex();
+                    if (firstLogIndex > lastIndexKept) {
                         final List<SegmentFile> removedFiles = this.segments.subList(0, this.segments.size());
                         destroyedFiles = new ArrayList<>(removedFiles);
                         removedFiles.clear();
                     }
+                    LOG.info(
+                        "Truncating all segments in {} because the first log index {} is greater than lastIndexKept={}",
+                        this.segmentsPath, firstLogIndex, lastIndexKept);
                 }
 
                 LOG.warn("Segment file not found by logIndex={} to be truncate_suffix, current segments:\n{}.",

--- a/jraft-core/src/main/java/com/alipay/sofa/jraft/storage/log/RocksDBSegmentLogStorage.java
+++ b/jraft-core/src/main/java/com/alipay/sofa/jraft/storage/log/RocksDBSegmentLogStorage.java
@@ -425,13 +425,18 @@ public class RocksDBSegmentLogStorage extends RocksDBLogStorage {
             .setNewFile(true) //
             .setPos(0).build();
 
-        if (!segmentFile.init(opts)) {
+        try {
+            if (!segmentFile.init(opts)) {
+                throw new IOException("Fail to create new segment file");
+            }
+            segmentFile.hintLoad();
+            LOG.info("Create a new segment file {}.", segmentFile.getPath());
+            return segmentFile;
+        } catch (IOException e) {
+            // Delete the file if fails
             FileUtils.deleteQuietly(new File(newSegPath));
-            throw new IOException("Fail to create new segment file");
+            throw e;
         }
-        segmentFile.hintLoad();
-        LOG.info("Create a new segment file {}.", segmentFile.getPath());
-        return segmentFile;
     }
 
     private String getNewSegmentFilePath() {

--- a/jraft-core/src/main/java/com/alipay/sofa/jraft/storage/log/RocksDBSegmentLogStorage.java
+++ b/jraft-core/src/main/java/com/alipay/sofa/jraft/storage/log/RocksDBSegmentLogStorage.java
@@ -486,8 +486,9 @@ public class RocksDBSegmentLogStorage extends RocksDBLogStorage {
                         this.writeExecutor);
 
                     if (!segmentFile.mmapFile(false)) {
-                        LOG.error("Fail to mmap segment file {}.", segFile.getAbsoluteFile());
-                        return false;
+                      assert (segmentFile.isHeaderCorrupted());
+                      corruptedHeaderSegments.add(segFile);
+                      continue;
                     }
 
                     if (segmentFile.isBlank()) {

--- a/jraft-core/src/main/java/com/alipay/sofa/jraft/storage/log/SegmentFile.java
+++ b/jraft-core/src/main/java/com/alipay/sofa/jraft/storage/log/SegmentFile.java
@@ -79,7 +79,7 @@ public class SegmentFile implements Lifecycle<SegmentFileOptions> {
      * @author boyan(boyan@antfin.com)
      *
      */
-    private static class SegmentHeader {
+    public static class SegmentHeader {
 
         private static final long RESERVED_FLAG = 0L;
         // The file first log index(inclusive)
@@ -282,6 +282,10 @@ public class SegmentFile implements Lifecycle<SegmentFileOptions> {
      */
     boolean isBlank() {
         return this.header.firstLogIndex == BLANK_LOG_INDEX;
+    }
+
+    boolean isHeaderCorrupted() {
+        return this.header == null;
     }
 
     String getPath() {

--- a/jraft-core/src/test/java/com/alipay/sofa/jraft/core/CliServiceTest.java
+++ b/jraft-core/src/test/java/com/alipay/sofa/jraft/core/CliServiceTest.java
@@ -163,11 +163,11 @@ public class CliServiceTest {
 
         // Add learner3
         this.cliService.addLearners(this.groupId, this.conf, Arrays.asList(learner3));
-        Thread.sleep(100);
+        Thread.sleep(1000);
         assertEquals(10, this.cluster.getFsmByPeer(learner3).getLogs().size());
 
         sendTestTaskAndWait(this.cluster.getLeader(), 0);
-        Thread.sleep(500);
+        Thread.sleep(1000);
         for (final MockStateMachine fsm : this.cluster.getFsms()) {
             assertEquals(20, fsm.getLogs().size());
 
@@ -180,7 +180,7 @@ public class CliServiceTest {
         // Remove  3
         this.cliService.removeLearners(this.groupId, this.conf, Arrays.asList(learner3));
         sendTestTaskAndWait(this.cluster.getLeader(), 0);
-        Thread.sleep(500);
+        Thread.sleep(1000);
         for (final MockStateMachine fsm : this.cluster.getFsms()) {
             if (!fsm.getAddress().equals(learner3.getEndpoint())) {
                 assertEquals(30, fsm.getLogs().size());
@@ -197,7 +197,7 @@ public class CliServiceTest {
         assertEquals(30, this.cluster.getFsmByPeer(learner3).getLogs().size());
 
         sendTestTaskAndWait(this.cluster.getLeader(), 0);
-        Thread.sleep(500);
+        Thread.sleep(1000);
         // Latest 10 logs are not replicated to learner1 and learner2, because they were removed by resetting learners set.
         for (final MockStateMachine fsm : this.cluster.getFsms()) {
             if (!oldLearners.contains(new PeerId(fsm.getAddress(), 0))) {

--- a/jraft-core/src/test/java/com/alipay/sofa/jraft/core/NodeTest.java
+++ b/jraft-core/src/test/java/com/alipay/sofa/jraft/core/NodeTest.java
@@ -1550,8 +1550,8 @@ public class NodeTest {
                     assertArrayEquals(requestContext, reqCtx);
                     success.set(true);
                 } else {
-                    assertTrue(status.getErrorMsg().contains("RPC exception:Check connection["));
-                    assertTrue(status.getErrorMsg().contains("] fail and try to create new one"));
+                    assertTrue(status.getErrorMsg(), status.getErrorMsg().contains("RPC exception:Check connection["));
+                    assertTrue(status.getErrorMsg(), status.getErrorMsg().contains("] fail and try to create new one"));
                 }
                 latch.countDown();
             }

--- a/jraft-core/src/test/java/com/alipay/sofa/jraft/storage/impl/BaseLogStorageTest.java
+++ b/jraft-core/src/test/java/com/alipay/sofa/jraft/storage/impl/BaseLogStorageTest.java
@@ -46,7 +46,7 @@ import com.alipay.sofa.jraft.test.TestUtils;
 import com.alipay.sofa.jraft.util.Utils;
 
 public abstract class BaseLogStorageTest extends BaseStorageTest {
-    private LogStorage           logStorage;
+    protected LogStorage         logStorage;
     private ConfigurationManager confManager;
     private LogEntryCodecFactory logEntryCodecFactory;
 
@@ -65,7 +65,7 @@ public abstract class BaseLogStorageTest extends BaseStorageTest {
 
     protected abstract LogStorage newLogStorage();
 
-    private LogStorageOptions newLogStorageOptions() {
+    protected LogStorageOptions newLogStorageOptions() {
         final LogStorageOptions opts = new LogStorageOptions();
         opts.setConfigurationManager(this.confManager);
         opts.setLogEntryCodecFactory(this.logEntryCodecFactory);
@@ -182,9 +182,6 @@ public abstract class BaseLogStorageTest extends BaseStorageTest {
 
     @Test
     public void testAppendMantyLargeEntries() {
-
-        appendLargeEntries(10000, 1024, 10);
-
         final long start = Utils.monotonicMs();
         final int totalLogs = 100000;
         final int logSize = 16 * 1024;

--- a/jraft-core/src/test/java/com/alipay/sofa/jraft/storage/impl/RocksDBSegmentLogStorageTest.java
+++ b/jraft-core/src/test/java/com/alipay/sofa/jraft/storage/impl/RocksDBSegmentLogStorageTest.java
@@ -16,15 +16,134 @@
  */
 package com.alipay.sofa.jraft.storage.impl;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import java.io.File;
+import java.util.Arrays;
+import java.util.concurrent.ThreadLocalRandom;
+import org.apache.commons.io.FileUtils;
+import org.junit.Test;
+import com.alipay.sofa.jraft.option.LogStorageOptions;
 import com.alipay.sofa.jraft.option.RaftOptions;
 import com.alipay.sofa.jraft.storage.LogStorage;
 import com.alipay.sofa.jraft.storage.log.RocksDBSegmentLogStorage;
+import com.alipay.sofa.jraft.test.TestUtils;
 
 public class RocksDBSegmentLogStorageTest extends BaseLogStorageTest {
 
     @Override
     protected LogStorage newLogStorage() {
-        return new RocksDBSegmentLogStorage(this.path, new RaftOptions());
+        return new RocksDBSegmentLogStorage(this.path, new RaftOptions(), 0, 1024 * 1024);
+    }
+
+    @Test
+    public void testTruncateChaos() throws Exception {
+        int times = 100;
+        int n = 100;
+
+        for (int i = 0; i < times; i++) {
+            this.logStorage.shutdown();
+            FileUtils.deleteDirectory(new File(this.path));
+            this.path = TestUtils.mkTempDir();
+            FileUtils.forceMkdir(new File(this.path));
+            this.logStorage = new RocksDBSegmentLogStorage(this.path, new RaftOptions(), 32, 256);
+            final LogStorageOptions opts = newLogStorageOptions();
+            this.logStorage.init(opts);
+
+            for (int j = 0; j < n; j++) {
+                this.logStorage.appendEntries(Arrays.asList(TestUtils.mockEntry(j, 1, ThreadLocalRandom.current()
+                    .nextInt(180))));
+            }
+
+            int index = ThreadLocalRandom.current().nextInt(n);
+            boolean truncatePrefix = ThreadLocalRandom.current().nextBoolean();
+            if (truncatePrefix) {
+                this.logStorage.truncatePrefix(index);
+
+                for (int j = 0; j < n; j++) {
+                    if (j < index) {
+                        assertNull(this.logStorage.getEntry(j));
+                    } else {
+                        assertNotNull(this.logStorage.getEntry(j));
+                    }
+                }
+            } else {
+                this.logStorage.truncateSuffix(index);
+
+                for (int j = 0; j < n; j++) {
+                    if (j <= index) {
+                        assertNotNull(this.logStorage.getEntry(j));
+                    } else {
+                        assertNull(this.logStorage.getEntry(j));
+                    }
+                }
+            }
+        }
+    }
+
+    @Test
+    public void testTruncateSuffixWithDifferentValueSize() throws Exception {
+        // shutdown the old one
+        this.logStorage.shutdown();
+        // Set value threshold to be 32 bytes.
+        this.logStorage = new RocksDBSegmentLogStorage(this.path, new RaftOptions(), 32, 64);
+        final LogStorageOptions opts = newLogStorageOptions();
+        this.logStorage.init(opts);
+        int term = 1;
+
+        for (int i = 0; i < 10; i++) {
+            this.logStorage.appendEntries(Arrays.asList(TestUtils.mockEntry(i, term, i)));
+        }
+
+        this.logStorage.appendEntries(Arrays.asList(TestUtils.mockEntry(10, term, 64)));
+
+        for (int i = 11; i < 20; i++) {
+            this.logStorage.appendEntries(Arrays.asList(TestUtils.mockEntry(i, term, i)));
+        }
+
+        for (int i = 0; i < 20; i++) {
+            assertNotNull(this.logStorage.getEntry(i));
+        }
+
+        assertEquals(((RocksDBSegmentLogStorage) this.logStorage).getLastSegmentFileForRead().getWrotePos(), 179);
+
+        this.logStorage.truncateSuffix(15);
+
+        for (int i = 0; i < 20; i++) {
+            if (i <= 15) {
+                assertNotNull(this.logStorage.getEntry(i));
+            } else {
+                assertNull(this.logStorage.getEntry(i));
+            }
+        }
+
+        assertEquals(((RocksDBSegmentLogStorage) this.logStorage).getLastSegmentFileForRead().getWrotePos(), 102);
+
+        this.logStorage.truncateSuffix(13);
+
+        for (int i = 0; i < 20; i++) {
+            if (i <= 13) {
+                assertNotNull(this.logStorage.getEntry(i));
+            } else {
+                assertNull(this.logStorage.getEntry(i));
+            }
+        }
+
+        assertEquals(((RocksDBSegmentLogStorage) this.logStorage).getLastSegmentFileForRead().getWrotePos(), 102);
+
+        this.logStorage.truncateSuffix(5);
+        for (int i = 0; i < 20; i++) {
+            if (i <= 5) {
+                assertNotNull(this.logStorage.getEntry(i));
+            } else {
+                assertNull(this.logStorage.getEntry(i));
+            }
+        }
+
+        assertNull(((RocksDBSegmentLogStorage) this.logStorage).getLastSegmentFileForRead());
+        this.logStorage.appendEntries(Arrays.asList(TestUtils.mockEntry(20, term, 64)));
+        assertNotNull(this.logStorage.getEntry(20));
     }
 
 }

--- a/jraft-core/src/test/java/com/alipay/sofa/jraft/storage/impl/RocksDBSegmentLogStorageTest.java
+++ b/jraft-core/src/test/java/com/alipay/sofa/jraft/storage/impl/RocksDBSegmentLogStorageTest.java
@@ -142,7 +142,7 @@ public class RocksDBSegmentLogStorageTest extends BaseLogStorageTest {
         }
 
         assertNull(((RocksDBSegmentLogStorage) this.logStorage).getLastSegmentFileForRead());
-        this.logStorage.appendEntries(Arrays.asList(TestUtils.mockEntry(20, term, 64)));
+        this.logStorage.appendEntries(Arrays.asList(TestUtils.mockEntry(20, term, 10)));
         assertNotNull(this.logStorage.getEntry(20));
     }
 

--- a/jraft-example/src/main/java/com/alipay/sofa/jraft/example/priorityelection/PriorityElectionNode.java
+++ b/jraft-example/src/main/java/com/alipay/sofa/jraft/example/priorityelection/PriorityElectionNode.java
@@ -21,11 +21,9 @@ import java.io.IOException;
 import java.nio.file.Paths;
 import java.util.List;
 import java.util.concurrent.CopyOnWriteArrayList;
-
 import org.apache.commons.io.FileUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
 import com.alipay.sofa.jraft.Lifecycle;
 import com.alipay.sofa.jraft.Node;
 import com.alipay.sofa.jraft.RaftGroupService;
@@ -89,7 +87,17 @@ public class PriorityElectionNode implements Lifecycle<PriorityElectionNodeOptio
         if (!serverId.parse(opts.getServerAddress())) {
             throw new IllegalArgumentException("Fail to parse serverId: " + opts.getServerAddress());
         }
-        // Set priority value, required
+
+        /**
+         * Set priority value, required for priority-based election, it must be a positive value when
+         * enable the feature, some special value meaning:
+         * <ul>
+         * <li>-1 : disable priority-based election.</li>
+         * <li>0: will never participate in election.</li>
+         * <li>1: minimum value</li>
+         * </ul>
+         * value.
+         */
         nodeOpts.setElectionPriority(serverId.getPriority());
 
         final RpcServer rpcServer = RaftRpcServerFactory.createRaftRpcServer(serverId.getEndpoint());
@@ -119,15 +127,15 @@ public class PriorityElectionNode implements Lifecycle<PriorityElectionNodeOptio
     }
 
     public Node getNode() {
-        return node;
+        return this.node;
     }
 
     public PriorityElectionOnlyStateMachine getFsm() {
-        return fsm;
+        return this.fsm;
     }
 
     public boolean isStarted() {
-        return started;
+        return this.started;
     }
 
     public boolean isLeader() {


### PR DESCRIPTION
修复 segment log storage 一些 bug 和 corner case 的处理，包括：

* `AbortFile#touch` 无效
* 在 recover 过程中，遇到历史日志数据损坏（可能磁盘数据损坏等意外情况）的情况，应当跳出 recover，终止节点启动。
* 针对 truncate prefix/suffix 处理的边缘情况，做了一些特殊处理，确保 segment 及时被删除。

