### PR TITLE
(fix) peer context should not be shared between connections, see #461

### DIFF
--- a/jraft-core/src/main/java/com/alipay/sofa/jraft/rpc/Connection.java
+++ b/jraft-core/src/main/java/com/alipay/sofa/jraft/rpc/Connection.java
@@ -40,7 +40,7 @@ public interface Connection {
     void setAttribute(final String key, final Object value);
 
     /**
-     * Set the attribute to the connection if the key's item is not exists, otherwise returns the present item.
+     * Set the attribute to the connection if the key's item doesn't exist, otherwise returns the present item.
      *
      * @param key   the attribute key
      * @param value the attribute value

--- a/jraft-core/src/main/java/com/alipay/sofa/jraft/rpc/Connection.java
+++ b/jraft-core/src/main/java/com/alipay/sofa/jraft/rpc/Connection.java
@@ -17,6 +17,8 @@
 package com.alipay.sofa.jraft.rpc;
 
 /**
+ *
+ * RPC connection
  * @author jiachun.fjc
  */
 public interface Connection {
@@ -36,6 +38,16 @@ public interface Connection {
      * @param value the attribute value
      */
     void setAttribute(final String key, final Object value);
+
+    /**
+     * Set the attribute to the connection if the key's item is not exists, otherwise returns the present item.
+     *
+     * @param key   the attribute key
+     * @param value the attribute value
+     * @return the previous value associated with the specified key, or
+     *         <tt>null</tt> if there was no mapping for the key.
+     */
+    Object setAttributeIfAbsent(final String key, final Object value);
 
     /**
      * Close the connection.

--- a/jraft-core/src/main/java/com/alipay/sofa/jraft/rpc/impl/BoltRpcServer.java
+++ b/jraft-core/src/main/java/com/alipay/sofa/jraft/rpc/impl/BoltRpcServer.java
@@ -38,7 +38,7 @@ public class BoltRpcServer implements RpcServer {
 
     private final com.alipay.remoting.rpc.RpcServer rpcServer;
 
-    public BoltRpcServer(com.alipay.remoting.rpc.RpcServer rpcServer) {
+    public BoltRpcServer(final com.alipay.remoting.rpc.RpcServer rpcServer) {
         this.rpcServer = Requires.requireNonNull(rpcServer, "rpcServer");
     }
 
@@ -64,6 +64,11 @@ public class BoltRpcServer implements RpcServer {
                 @Override
                 public Object getAttribute(final String key) {
                     return conn.getAttribute(key);
+                }
+
+                @Override
+                public Object setAttributeIfAbsent(final String key, final Object value) {
+                    return conn.setAttributeIfAbsent(key, value);
                 }
 
                 @Override
@@ -140,20 +145,25 @@ public class BoltRpcServer implements RpcServer {
     }
 
     public com.alipay.remoting.rpc.RpcServer getServer() {
-        return rpcServer;
+        return this.rpcServer;
     }
 
     private static class BoltConnection implements Connection {
 
         private final com.alipay.remoting.Connection conn;
 
-        private BoltConnection(com.alipay.remoting.Connection conn) {
+        private BoltConnection(final com.alipay.remoting.Connection conn) {
             this.conn = Requires.requireNonNull(conn, "conn");
         }
 
         @Override
         public Object getAttribute(final String key) {
             return this.conn.getAttribute(key);
+        }
+
+        @Override
+        public Object setAttributeIfAbsent(final String key, final Object value) {
+            return this.conn.setAttributeIfAbsent(key, value);
         }
 
         @Override

--- a/jraft-core/src/main/java/com/alipay/sofa/jraft/rpc/impl/core/AppendEntriesRequestProcessor.java
+++ b/jraft-core/src/main/java/com/alipay/sofa/jraft/rpc/impl/core/AppendEntriesRequestProcessor.java
@@ -164,18 +164,9 @@ public class AppendEntriesRequestProcessor extends NodeRequestProcessor<AppendEn
 
     PeerPair pairOf(final String peerId, final String serverId) {
         synchronized (this.pairConstants) {
-            Map<String, PeerPair> pairs = this.pairConstants.get(peerId);
-            if (pairs == null) {
-                pairs = new HashMap<>();
-                this.pairConstants.put(peerId, pairs);
-            }
+            Map<String, PeerPair> pairs = this.pairConstants.computeIfAbsent(peerId, k -> new HashMap<>());
 
-            PeerPair pair = pairs.get(serverId);
-            if (pair == null) {
-                pair = new PeerPair(peerId, serverId);
-                pairs.put(serverId, pair);
-            }
-
+            PeerPair pair = pairs.computeIfAbsent(serverId, k -> new PeerPair(peerId, serverId));
             return pair;
         }
     }
@@ -389,7 +380,7 @@ public class AppendEntriesRequestProcessor extends NodeRequestProcessor<AppendEn
 
         // Add the pair to connection attribute metadata.
         if (conn != null) {
-            Set<PeerPair> pairs = null;
+            Set<PeerPair> pairs;
             if ((pairs = (Set<AppendEntriesRequestProcessor.PeerPair>) conn.getAttribute(PAIR_ATTR)) == null) {
                 pairs = new ConcurrentHashSet<>();
                 Set<PeerPair> existsPairs = (Set<PeerPair>) conn.setAttributeIfAbsent(PAIR_ATTR, pairs);

--- a/jraft-extension/rpc-grpc-impl/src/main/java/io/grpc/netty/shaded/io/grpc/netty/NettyConnectionHelper.java
+++ b/jraft-extension/rpc-grpc-impl/src/main/java/io/grpc/netty/shaded/io/grpc/netty/NettyConnectionHelper.java
@@ -17,16 +17,14 @@
 package io.grpc.netty.shaded.io.grpc.netty;
 
 import java.util.List;
-
-import io.grpc.internal.ServerStream;
-import io.grpc.netty.shaded.io.netty.channel.Channel;
-import io.grpc.netty.shaded.io.netty.util.Attribute;
-import io.grpc.netty.shaded.io.netty.util.AttributeKey;
-
 import com.alipay.sofa.jraft.rpc.Connection;
 import com.alipay.sofa.jraft.rpc.impl.ConnectionClosedEventListener;
 import com.alipay.sofa.jraft.util.internal.ReferenceFieldUpdater;
 import com.alipay.sofa.jraft.util.internal.Updaters;
+import io.grpc.internal.ServerStream;
+import io.grpc.netty.shaded.io.netty.channel.Channel;
+import io.grpc.netty.shaded.io.netty.util.Attribute;
+import io.grpc.netty.shaded.io.netty.util.AttributeKey;
 
 /**
  * Get netty channel.
@@ -77,8 +75,13 @@ class NettyConnection implements Connection {
 
     private final Channel ch;
 
-    NettyConnection(Channel ch) {
+    NettyConnection(final Channel ch) {
         this.ch = ch;
+    }
+
+    @Override
+    public Object setAttributeIfAbsent(final String key, final Object value) {
+        return this.ch.attr(AttributeKey.valueOf(key)).setIfAbsent(value);
     }
 
     @Override
@@ -97,7 +100,8 @@ class NettyConnection implements Connection {
     }
 
     void addClosedEventListener(final ConnectionClosedEventListener listener) {
-        this.ch.closeFuture() //
-            .addListener(future -> listener.onClosed(this.ch.remoteAddress().toString(), NettyConnection.this));
+      this.ch.closeFuture() //
+      .addListener(
+          future -> listener.onClosed(this.ch.remoteAddress().toString(), NettyConnection.this));
     }
 }

--- a/jraft-extension/rpc-grpc-impl/src/test/java/com/alipay/sofa/jraft/rpc/impl/core/AppendEntriesRequestProcessorTest.java
+++ b/jraft-extension/rpc-grpc-impl/src/test/java/com/alipay/sofa/jraft/rpc/impl/core/AppendEntriesRequestProcessorTest.java
@@ -16,9 +16,9 @@
  */
 package com.alipay.sofa.jraft.rpc.impl.core;
 
+import java.util.Set;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
-
 import org.junit.Test;
 import org.mockito.Mock;
 import org.mockito.Mockito;
@@ -30,14 +30,16 @@ import com.alipay.sofa.jraft.rpc.RaftServerService;
 import com.alipay.sofa.jraft.rpc.RpcContext;
 import com.alipay.sofa.jraft.rpc.RpcRequests.AppendEntriesRequest;
 import com.alipay.sofa.jraft.rpc.RpcRequests.PingRequest;
+import com.alipay.sofa.jraft.rpc.impl.core.AppendEntriesRequestProcessor.PeerPair;
 import com.alipay.sofa.jraft.rpc.impl.core.AppendEntriesRequestProcessor.PeerRequestContext;
 import com.alipay.sofa.jraft.test.MockAsyncContext;
 import com.alipay.sofa.jraft.test.TestUtils;
-
+import com.alipay.sofa.jraft.util.concurrent.ConcurrentHashSet;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertSame;
 import static org.mockito.Matchers.eq;
 
@@ -45,16 +47,18 @@ public class AppendEntriesRequestProcessorTest extends BaseNodeRequestProcessorT
 
     private AppendEntriesRequest request;
 
+    private final String         serverId = "localhost:8082";
+
     @Override
-    public AppendEntriesRequest createRequest(String groupId, PeerId peerId) {
-        request = AppendEntriesRequest.newBuilder().setCommittedIndex(0). //
+    public AppendEntriesRequest createRequest(final String groupId, final PeerId peerId) {
+        this.request = AppendEntriesRequest.newBuilder().setCommittedIndex(0). //
             setGroupId(groupId). //
             setPeerId(peerId.toString()).//
-            setServerId("localhost:8082"). //
+            setServerId(this.serverId). //
             setPrevLogIndex(0). //
             setTerm(0). //
             setPrevLogTerm(0).build();
-        return request;
+        return this.request;
     }
 
     @Mock
@@ -66,34 +70,67 @@ public class AppendEntriesRequestProcessorTest extends BaseNodeRequestProcessorT
         this.asyncContext = new MockAsyncContext() {
             @Override
             public Connection getConnection() {
-                return conn;
+                return AppendEntriesRequestProcessorTest.this.conn;
             }
         };
-        Mockito.when(this.conn.getAttribute(AppendEntriesRequestProcessor.PEER_ATTR)).thenReturn(this.peerIdStr);
+        Set<PeerPair> pairs = new ConcurrentHashSet<>();
+        pairs.add(new PeerPair(this.peerIdStr, this.serverId));
+        Mockito.when(this.conn.getAttribute(AppendEntriesRequestProcessor.PAIR_ATTR)).thenReturn(pairs);
     }
 
     private ExecutorService executor;
 
     @Override
     public NodeRequestProcessor<AppendEntriesRequest> newProcessor() {
-        executor = Executors.newSingleThreadExecutor();
-        return new AppendEntriesRequestProcessor(executor);
+        this.executor = Executors.newSingleThreadExecutor();
+        return new AppendEntriesRequestProcessor(this.executor);
     }
 
     @Override
     public void teardown() {
         super.teardown();
-        if (executor != null) {
-            executor.shutdownNow();
+        if (this.executor != null) {
+            this.executor.shutdownNow();
         }
     }
 
+    @Test
+    public void testPairOf() {
+        final AppendEntriesRequestProcessor processor = (AppendEntriesRequestProcessor) newProcessor();
+
+        PeerPair pair = processor.pairOf(this.peerIdStr, this.serverId);
+        assertEquals(pair.remote, this.serverId);
+        assertEquals(pair.local, this.peerIdStr);
+
+        // test constant pool
+        assertSame(pair, processor.pairOf(this.peerIdStr, this.serverId));
+        assertSame(pair, processor.pairOf(this.peerIdStr, this.serverId));
+    }
+
+    @Test
+    public void testOnClosed() {
+        mockNode();
+        final AppendEntriesRequestProcessor processor = (AppendEntriesRequestProcessor) newProcessor();
+
+        PeerPair pair = processor.pairOf(this.peerIdStr, this.serverId);
+        final PeerRequestContext ctx = processor.getOrCreatePeerRequestContext(this.groupId, pair, this.conn);
+        assertNotNull(ctx);
+        assertSame(ctx, processor.getPeerRequestContext(this.groupId, pair));
+        assertSame(ctx, processor.getOrCreatePeerRequestContext(this.groupId, pair, this.conn));
+
+        processor.onClosed(null, this.conn);
+        assertNull(processor.getPeerRequestContext(this.groupId, pair));
+        assertNotSame(ctx, processor.getOrCreatePeerRequestContext(this.groupId, pair, this.conn));
+    }
+
     @Override
-    public void verify(String interest, RaftServerService service, NodeRequestProcessor<AppendEntriesRequest> processor) {
+    public void verify(final String interest, final RaftServerService service,
+                       final NodeRequestProcessor<AppendEntriesRequest> processor) {
         assertEquals(interest, AppendEntriesRequest.class.getName());
-        Mockito.verify(service).handleAppendEntriesRequest(eq(request), Mockito.any());
-        final PeerRequestContext ctx = ((AppendEntriesRequestProcessor) processor).getPeerRequestContext(groupId,
-            peerIdStr, conn);
+        Mockito.verify(service).handleAppendEntriesRequest(eq(this.request), Mockito.any());
+        final PeerPair pair = ((AppendEntriesRequestProcessor) processor).pairOf(this.peerIdStr, this.serverId);
+        final PeerRequestContext ctx = ((AppendEntriesRequestProcessor) processor).getOrCreatePeerRequestContext(
+            this.groupId, pair, this.conn);
         assertNotNull(ctx);
     }
 
@@ -102,9 +139,10 @@ public class AppendEntriesRequestProcessorTest extends BaseNodeRequestProcessorT
         mockNode();
 
         final AppendEntriesRequestProcessor processor = (AppendEntriesRequestProcessor) newProcessor();
-        final PeerRequestContext ctx = processor.getPeerRequestContext(groupId, peerIdStr, conn);
+        final PeerPair pair = processor.pairOf(this.peerIdStr, this.serverId);
+        final PeerRequestContext ctx = processor.getOrCreatePeerRequestContext(this.groupId, pair, this.conn);
         assertNotNull(ctx);
-        assertSame(ctx, processor.getPeerRequestContext(groupId, peerIdStr, conn));
+        assertSame(ctx, processor.getOrCreatePeerRequestContext(this.groupId, pair, this.conn));
         assertEquals(0, ctx.getNextRequiredSequence());
         assertEquals(0, ctx.getAndIncrementSequence());
         assertEquals(1, ctx.getAndIncrementSequence());
@@ -112,8 +150,8 @@ public class AppendEntriesRequestProcessorTest extends BaseNodeRequestProcessorT
         assertEquals(1, ctx.getAndIncrementNextRequiredSequence());
         assertFalse(ctx.hasTooManyPendingResponses());
 
-        processor.removePeerRequestContext(groupId, peerIdStr);
-        final PeerRequestContext newCtx = processor.getPeerRequestContext(groupId, peerIdStr, conn);
+        processor.removePeerRequestContext(this.groupId, pair);
+        final PeerRequestContext newCtx = processor.getOrCreatePeerRequestContext(this.groupId, pair, this.conn);
         assertNotNull(newCtx);
         assertNotSame(ctx, newCtx);
 
@@ -128,36 +166,38 @@ public class AppendEntriesRequestProcessorTest extends BaseNodeRequestProcessorT
     @Test
     public void testSendSequenceResponse() {
         mockNode();
-
-        final RpcContext asyncContext = Mockito.mock(RpcContext.class);
         final AppendEntriesRequestProcessor processor = (AppendEntriesRequestProcessor) newProcessor();
+        final PeerPair pair = processor.pairOf(this.peerIdStr, this.serverId);
+        processor.getOrCreatePeerRequestContext(this.groupId, pair, this.conn);
         final PingRequest msg = TestUtils.createPingRequest();
-        processor.sendSequenceResponse(groupId, peerIdStr, 1, asyncContext, msg);
+        final RpcContext asyncContext = Mockito.mock(RpcContext.class);
+        processor.sendSequenceResponse(this.groupId, pair, 1, asyncContext, msg);
         Mockito.verify(asyncContext, Mockito.never()).sendResponse(msg);
 
-        processor.sendSequenceResponse(groupId, peerIdStr, 0, asyncContext, msg);
+        processor.sendSequenceResponse(this.groupId, pair, 0, asyncContext, msg);
         Mockito.verify(asyncContext, Mockito.times(2)).sendResponse(msg);
     }
 
     @Test
     public void testTooManyPendingResponses() {
-        final PeerId peer = this.mockNode();
-        NodeManager.getInstance().get(groupId, peer).getRaftOptions().setMaxReplicatorInflightMsgs(2);
+        final PeerId peer = mockNode();
+        NodeManager.getInstance().get(this.groupId, peer).getRaftOptions().setMaxReplicatorInflightMsgs(2);
 
         final RpcContext asyncContext = Mockito.mock(RpcContext.class);
         final AppendEntriesRequestProcessor processor = (AppendEntriesRequestProcessor) newProcessor();
+        final PeerPair pair = processor.pairOf(this.peerIdStr, this.serverId);
         final PingRequest msg = TestUtils.createPingRequest();
         final Connection conn = Mockito.mock(Connection.class);
         Mockito.when(asyncContext.getConnection()).thenReturn(conn);
-        final PeerRequestContext ctx = processor.getPeerRequestContext(groupId, peerIdStr, conn);
+        final PeerRequestContext ctx = processor.getOrCreatePeerRequestContext(this.groupId, pair, conn);
         assertNotNull(ctx);
-        processor.sendSequenceResponse(groupId, peerIdStr, 1, asyncContext, msg);
-        processor.sendSequenceResponse(groupId, peerIdStr, 2, asyncContext, msg);
-        processor.sendSequenceResponse(groupId, peerIdStr, 3, asyncContext, msg);
+        processor.sendSequenceResponse(this.groupId, pair, 1, asyncContext, msg);
+        processor.sendSequenceResponse(this.groupId, pair, 2, asyncContext, msg);
+        processor.sendSequenceResponse(this.groupId, pair, 3, asyncContext, msg);
         Mockito.verify(asyncContext, Mockito.never()).sendResponse(msg);
         Mockito.verify(conn).close();
 
-        final PeerRequestContext newCtx = processor.getPeerRequestContext(groupId, peerIdStr, conn);
+        final PeerRequestContext newCtx = processor.getOrCreatePeerRequestContext(this.groupId, pair, conn);
         assertNotNull(newCtx);
         assertNotSame(ctx, newCtx);
     }


### PR DESCRIPTION
### Motivation:

Don't share peer contexts between connections. The peer context may be destroyed which is not expected, see #461 .

### Modification:

Change the peerRequestContexts type in `AppendEntriesRequestProcessor`  from `Map<groupId, <peerId, context>>` 
to `Map<groupId, <PeerPair, context>>`. The `PeerPair` is the pair of local peerId and remote serverId.

### Result:

Fixes #461 

