### PR TITLE
(feat) Adds new method stateChanged(peerId, newState) for ReplicatorS…

### DIFF
--- a/jraft-core/src/test/java/com/alipay/sofa/jraft/core/NodeTest.java
+++ b/jraft-core/src/test/java/com/alipay/sofa/jraft/core/NodeTest.java
@@ -58,6 +58,7 @@ import com.alipay.sofa.jraft.closure.ReadIndexClosure;
 import com.alipay.sofa.jraft.closure.SynchronizedClosure;
 import com.alipay.sofa.jraft.closure.TaskClosure;
 import com.alipay.sofa.jraft.conf.Configuration;
+import com.alipay.sofa.jraft.core.Replicator.ReplicatorState;
 import com.alipay.sofa.jraft.entity.EnumOutter;
 import com.alipay.sofa.jraft.entity.PeerId;
 import com.alipay.sofa.jraft.entity.Task;
@@ -522,6 +523,11 @@ public class NodeTest {
         public void onCreated(final PeerId peer) {
             LOG.info("Replicator has created");
             NodeTest.this.startedCounter.incrementAndGet();
+        }
+
+        @Override
+        public void stateChanged(final PeerId peer, final ReplicatorState newState) {
+            LOG.info("Replicator {} state is changed into {}.", peer, newState);
         }
 
         @Override

--- a/jraft-core/src/test/java/com/alipay/sofa/jraft/core/NodeTest.java
+++ b/jraft-core/src/test/java/com/alipay/sofa/jraft/core/NodeTest.java
@@ -58,7 +58,6 @@ import com.alipay.sofa.jraft.closure.ReadIndexClosure;
 import com.alipay.sofa.jraft.closure.SynchronizedClosure;
 import com.alipay.sofa.jraft.closure.TaskClosure;
 import com.alipay.sofa.jraft.conf.Configuration;
-import com.alipay.sofa.jraft.core.Replicator.ReplicatorState;
 import com.alipay.sofa.jraft.entity.EnumOutter;
 import com.alipay.sofa.jraft.entity.PeerId;
 import com.alipay.sofa.jraft.entity.Task;


### PR DESCRIPTION
### Motivation:

Track replicator state #521 

### Modification:

Adds a new method to `ReplicatorStateListener`

```java
   /**
         * Called when the replicator state is changed. See {@link ReplicatorState}
         * @param peer the replicator's peer id.
         * @param newState the new replicator state.
         * @since 1.3.6
         */
        default void stateChanged(final PeerId peer, final ReplicatorState newState) {}
```

And a new enum type `ReplicatorState`:

```java
     /**
       * Represents state changes in the replicator.
       * @author boyan(boyan@antfin.com)
       *
       */
      enum ReplicatorState{
        /**
         * The replicator is created.
         */
        CREATED,
        /**
         * The replicator is destroyed.
         */
        DESTROYED,
        /**
         * The replicator begins to doing it's job(replicating logs or installing snapshot).
         */
        ONLINE,
        /**
         * The replicaotr is suspended by raft error or lost connection.
         */
        OFFLINE
      }
```

Users can use this API to track the replicator state for some purposes.

### Result:

Fixes #521 

