### PR TITLE
(feat) LogEntry's data should not be null, close #562

### DIFF
--- a/jraft-core/src/main/java/com/alipay/sofa/jraft/entity/LogEntry.java
+++ b/jraft-core/src/main/java/com/alipay/sofa/jraft/entity/LogEntry.java
@@ -36,24 +36,26 @@ import com.alipay.sofa.jraft.util.CrcUtil;
  */
 public class LogEntry implements Checksum {
 
+    public static final ByteBuffer EMPTY_DATA = ByteBuffer.wrap(new byte[0]);
+
     /** entry type */
-    private EnumOutter.EntryType type;
+    private EnumOutter.EntryType   type;
     /** log id with index/term */
-    private LogId                id = new LogId(0, 0);
+    private LogId                  id         = new LogId(0, 0);
     /** log entry current peers */
-    private List<PeerId>         peers;
+    private List<PeerId>           peers;
     /** log entry old peers */
-    private List<PeerId>         oldPeers;
+    private List<PeerId>           oldPeers;
     /** log entry current learners */
-    private List<PeerId>         learners;
+    private List<PeerId>           learners;
     /** log entry old learners */
-    private List<PeerId>         oldLearners;
+    private List<PeerId>           oldLearners;
     /** entry data */
-    private ByteBuffer           data;
+    private ByteBuffer             data       = EMPTY_DATA;
     /** checksum for log entry*/
-    private long                 checksum;
+    private long                   checksum;
     /** true when the log has checksum **/
-    private boolean              hasChecksum;
+    private boolean                hasChecksum;
 
     public List<PeerId> getLearners() {
         return this.learners;

--- a/jraft-core/src/main/java/com/alipay/sofa/jraft/entity/Task.java
+++ b/jraft-core/src/main/java/com/alipay/sofa/jraft/entity/Task.java
@@ -25,6 +25,7 @@ import java.util.concurrent.TimeoutException;
 
 import com.alipay.sofa.jraft.Closure;
 import com.alipay.sofa.jraft.closure.JoinableClosure;
+import com.alipay.sofa.jraft.util.Requires;
 
 /**
  * Basic message structure of jraft, contains:
@@ -42,7 +43,7 @@ public class Task implements Serializable {
     private static final long serialVersionUID = 2971309899898274575L;
 
     /** Associated  task data*/
-    private ByteBuffer        data;
+    private ByteBuffer        data             = LogEntry.EMPTY_DATA;
     /** task closure, called when the data is successfully committed to the raft group or failures happen.*/
     private Closure           done;
     /** Reject this task if expectedTerm doesn't match the current term of this Node if the value is not -1, default is -1.*/
@@ -55,7 +56,7 @@ public class Task implements Serializable {
     /**
      * Creates a task with data/done.
      */
-    public Task(ByteBuffer data, Closure done) {
+    public Task(final ByteBuffer data, final Closure done) {
         super();
         this.data = data;
         this.done = done;
@@ -64,7 +65,7 @@ public class Task implements Serializable {
     /**
      * Creates a task with data/done/expectedTerm.
      */
-    public Task(ByteBuffer data, Closure done, long expectedTerm) {
+    public Task(final ByteBuffer data, final Closure done, final long expectedTerm) {
         super();
         this.data = data;
         this.done = done;
@@ -75,7 +76,8 @@ public class Task implements Serializable {
         return this.data;
     }
 
-    public void setData(ByteBuffer data) {
+    public void setData(final ByteBuffer data) {
+        Requires.requireNonNull(data, "data should not be null, you can use LogEntry.EMPTY_DATA instead.");
         this.data = data;
     }
 
@@ -83,7 +85,7 @@ public class Task implements Serializable {
         return this.done;
     }
 
-    public void setDone(Closure done) {
+    public void setDone(final Closure done) {
         this.done = done;
     }
 
@@ -91,7 +93,7 @@ public class Task implements Serializable {
         return this.expectedTerm;
     }
 
-    public void setExpectedTerm(long expectedTerm) {
+    public void setExpectedTerm(final long expectedTerm) {
         this.expectedTerm = expectedTerm;
     }
 

--- a/jraft-core/src/test/java/com/alipay/sofa/jraft/entity/LogEntryTest.java
+++ b/jraft-core/src/test/java/com/alipay/sofa/jraft/entity/LogEntryTest.java
@@ -29,6 +29,7 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
 
 public class LogEntryTest {
@@ -39,7 +40,7 @@ public class LogEntryTest {
         LogEntry entry = new LogEntry(EnumOutter.EntryType.ENTRY_TYPE_NO_OP);
         entry.setId(new LogId(100, 3));
         entry.setPeers(Arrays.asList(new PeerId("localhost", 99, 1), new PeerId("localhost", 100, 2)));
-        assertNull(entry.getData());
+        assertSame(LogEntry.EMPTY_DATA, entry.getData());
         assertNull(entry.getOldPeers());
 
         byte[] content = entry.encode();
@@ -57,7 +58,7 @@ public class LogEntryTest {
         assertEquals(2, nentry.getPeers().size());
         assertEquals("localhost:99:1", nentry.getPeers().get(0).toString());
         assertEquals("localhost:100:2", nentry.getPeers().get(1).toString());
-        assertNull(nentry.getData());
+        assertSame(LogEntry.EMPTY_DATA, entry.getData());
         assertNull(nentry.getOldPeers());
     }
 

--- a/jraft-core/src/test/java/com/alipay/sofa/jraft/entity/codec/BaseLogEntryCodecFactoryTest.java
+++ b/jraft-core/src/test/java/com/alipay/sofa/jraft/entity/codec/BaseLogEntryCodecFactoryTest.java
@@ -31,6 +31,7 @@ import com.alipay.sofa.jraft.entity.PeerId;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
@@ -49,6 +50,24 @@ public abstract class BaseLogEntryCodecFactoryTest {
     protected abstract LogEntryCodecFactory newFactory();
 
     @Test
+    public void testEmptyData() {
+        LogEntry entry = new LogEntry(EnumOutter.EntryType.ENTRY_TYPE_NO_OP);
+        entry.setId(new LogId(100, 3));
+        entry.setPeers(Arrays.asList(new PeerId("localhost", 99, 1), new PeerId("localhost", 100, 2)));
+        entry.setData(ByteBuffer.allocate(0));
+
+        byte[] content = this.encoder.encode(entry);
+
+        assertNotNull(content);
+        assertTrue(content.length > 0);
+
+        LogEntry nentry = this.decoder.decode(content);
+        assertNotNull(nentry);
+        assertNotNull(nentry.getData());
+        assertEquals(0, nentry.getData().remaining());
+    }
+
+    @Test
     public void testEncodeDecodeEmpty() {
         try {
             assertNull(this.encoder.encode(null));
@@ -65,7 +84,7 @@ public abstract class BaseLogEntryCodecFactoryTest {
         LogEntry entry = new LogEntry(EnumOutter.EntryType.ENTRY_TYPE_NO_OP);
         entry.setId(new LogId(100, 3));
         entry.setPeers(Arrays.asList(new PeerId("localhost", 99, 1), new PeerId("localhost", 100, 2)));
-        assertNull(entry.getData());
+        assertSame(LogEntry.EMPTY_DATA, entry.getData());
         assertNull(entry.getOldPeers());
 
         byte[] content = this.encoder.encode(entry);
@@ -82,7 +101,7 @@ public abstract class BaseLogEntryCodecFactoryTest {
         assertEquals(2, nentry.getPeers().size());
         assertEquals("localhost:99:1", nentry.getPeers().get(0).toString());
         assertEquals("localhost:100:2", nentry.getPeers().get(1).toString());
-        assertNull(nentry.getData());
+        assertSame(LogEntry.EMPTY_DATA, nentry.getData());
         assertNull(nentry.getOldPeers());
     }
 

--- a/jraft-core/src/test/java/com/alipay/sofa/jraft/entity/codec/v2/LogEntryV2CodecFactoryTest.java
+++ b/jraft-core/src/test/java/com/alipay/sofa/jraft/entity/codec/v2/LogEntryV2CodecFactoryTest.java
@@ -35,6 +35,7 @@ import com.alipay.sofa.jraft.entity.codec.v1.V1Encoder;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
 
 public class LogEntryV2CodecFactoryTest extends BaseLogEntryCodecFactoryTest {
@@ -52,7 +53,7 @@ public class LogEntryV2CodecFactoryTest extends BaseLogEntryCodecFactoryTest {
         entry.setPeers(Arrays.asList(new PeerId("localhost", 99, 1), new PeerId("localhost", 100, 2)));
         List<PeerId> theLearners = createLearners("192.168.1.1:8081", "192.168.1.2:8081");
         entry.setLearners(theLearners);
-        assertNull(entry.getData());
+        assertSame(entry.getData(), LogEntry.EMPTY_DATA);
         assertNull(entry.getOldPeers());
 
         byte[] content = this.encoder.encode(entry);
@@ -88,7 +89,7 @@ public class LogEntryV2CodecFactoryTest extends BaseLogEntryCodecFactoryTest {
         assertEquals(2, nentry.getPeers().size());
         assertEquals("localhost:99:1", nentry.getPeers().get(0).toString());
         assertEquals("localhost:100:2", nentry.getPeers().get(1).toString());
-        assertNull(nentry.getData());
+        assertSame(nentry.getData(), LogEntry.EMPTY_DATA);
         assertNull(nentry.getOldPeers());
 
         assertTrue(nentry.hasLearners());


### PR DESCRIPTION
### Motivation:

The data in `LogEntry` should not be null(`required` in [protobuf](https://github.com/sofastack/sofa-jraft/blob/master/jraft-core/src/main/resources/log.proto#L16)), so we set a default empty data in `LogEntry` and require data is not null in `Task#setData(ByteBuffer)`, try to close #562 .

### Modification:

* `LogEntry` data field default value is ` LogEntry.EMPTY_DATA`.
* **Breaking change:** require data is not null in `Task#setData(ByteBuffer)`.
* Fixed some tests.

### Result:

Fixes #562 

