### PR TITLE
Memory optimize

### DIFF
--- a/jraft-rheakv/rheakv-core/src/main/java/com/alipay/sofa/jraft/rhea/storage/KVClosureAdapter.java
+++ b/jraft-rheakv/rheakv-core/src/main/java/com/alipay/sofa/jraft/rhea/storage/KVClosureAdapter.java
@@ -29,8 +29,8 @@ public class KVClosureAdapter implements KVStoreClosure {
 
     private static final Logger  LOG = LoggerFactory.getLogger(KVClosureAdapter.class);
 
-    private final KVStoreClosure done;
-    private final KVOperation    operation;
+    private KVStoreClosure done;
+    private KVOperation    operation;
 
     public KVClosureAdapter(final KVStoreClosure done, final KVOperation operation) {
         this.done = done;
@@ -71,6 +71,7 @@ public class KVClosureAdapter implements KVStoreClosure {
         if (done != null) {
             done.run(status);
         }
+        clear();
     }
 
     @Override
@@ -101,5 +102,10 @@ public class KVClosureAdapter implements KVStoreClosure {
         if (this.done != null) {
             this.done.setData(data);
         }
+    }
+
+    public void clear() {
+        done = null;
+        operation = null;
     }
 }

--- a/jraft-rheakv/rheakv-core/src/main/java/com/alipay/sofa/jraft/rhea/storage/KVClosureAdapter.java
+++ b/jraft-rheakv/rheakv-core/src/main/java/com/alipay/sofa/jraft/rhea/storage/KVClosureAdapter.java
@@ -27,10 +27,10 @@ import com.alipay.sofa.jraft.rhea.errors.Errors;
  */
 public class KVClosureAdapter implements KVStoreClosure {
 
-    private static final Logger  LOG = LoggerFactory.getLogger(KVClosureAdapter.class);
+    private static final Logger LOG = LoggerFactory.getLogger(KVClosureAdapter.class);
 
-    private KVStoreClosure done;
-    private KVOperation    operation;
+    private KVStoreClosure      done;
+    private KVOperation         operation;
 
     public KVClosureAdapter(final KVStoreClosure done, final KVOperation operation) {
         this.done = done;

--- a/jraft-rheakv/rheakv-core/src/main/java/com/alipay/sofa/jraft/rhea/storage/KVClosureAdapter.java
+++ b/jraft-rheakv/rheakv-core/src/main/java/com/alipay/sofa/jraft/rhea/storage/KVClosureAdapter.java
@@ -104,7 +104,7 @@ public class KVClosureAdapter implements KVStoreClosure {
         }
     }
 
-    public void clear() {
+    private void clear() {
         done = null;
         operation = null;
     }


### PR DESCRIPTION
RingBuffer will not clear automatically.

KVClosureAdapter's data will be hold at LogEntryAndClosure.
So after closuer callback be invoke, clear KVClosureAdapter's data.
