### PR TITLE
fix MetadataRpcClient#getClusterInfo returns null

### DIFF
--- a/jraft-rheakv/rheakv-core/src/main/java/com/alipay/sofa/jraft/rhea/cmd/pd/GetClusterInfoResponse.java
+++ b/jraft-rheakv/rheakv-core/src/main/java/com/alipay/sofa/jraft/rhea/cmd/pd/GetClusterInfoResponse.java
@@ -21,22 +21,12 @@ import com.alipay.sofa.jraft.rhea.metadata.Cluster;
 /**
  * @author jiachun.fjc
  */
-public class GetClusterInfoResponse extends BaseResponse {
+public class GetClusterInfoResponse extends BaseResponse<Cluster> {
 
     private static final long serialVersionUID = 8811355826978037463L;
 
-    private Cluster           cluster;
-
-    public Cluster getCluster() {
-        return cluster;
-    }
-
-    public void setCluster(Cluster cluster) {
-        this.cluster = cluster;
-    }
-
     @Override
     public String toString() {
-        return "GetClusterInfoResponse{" + "cluster=" + cluster + "} " + super.toString();
+        return "GetClusterInfoResponse{" + "cluster=" + getValue() + "} " + super.toString();
     }
 }

--- a/jraft-rheakv/rheakv-core/src/main/java/com/alipay/sofa/jraft/rhea/cmd/pd/GetClusterInfoResponse.java
+++ b/jraft-rheakv/rheakv-core/src/main/java/com/alipay/sofa/jraft/rhea/cmd/pd/GetClusterInfoResponse.java
@@ -24,9 +24,4 @@ import com.alipay.sofa.jraft.rhea.metadata.Cluster;
 public class GetClusterInfoResponse extends BaseResponse<Cluster> {
 
     private static final long serialVersionUID = 8811355826978037463L;
-
-    @Override
-    public String toString() {
-        return "GetClusterInfoResponse{" + "cluster=" + getValue() + "} " + super.toString();
-    }
 }

--- a/jraft-rheakv/rheakv-pd/src/main/java/com/alipay/sofa/jraft/rhea/DefaultPlacementDriverService.java
+++ b/jraft-rheakv/rheakv-pd/src/main/java/com/alipay/sofa/jraft/rhea/DefaultPlacementDriverService.java
@@ -190,7 +190,7 @@ public class DefaultPlacementDriverService implements PlacementDriverService, Le
         }
         try {
             final Cluster cluster = this.metadataStore.getClusterInfo(clusterId);
-            response.setCluster(cluster);
+            response.setValue(cluster);
         } catch (final Throwable t) {
             LOG.error("Failed to handle: {}, {}.", request, StackTraceUtil.stackTrace(t));
             response.setError(Errors.forException(t));


### PR DESCRIPTION
### Motivation:

When calling MetadataRpcClient#getClusterInfo to get cluster information from remote Pd, it always returns a null.

### Modification:

Modify GetClusterInfoReponse and DefaultPlacementDriverService to rightly return the cluster information

### Result:
 
Fixes #537 

