### PR TITLE
fail-fast on connection fail

### DIFF
--- a/jraft-core/src/main/java/com/alipay/sofa/jraft/rpc/impl/core/DefaultRaftClientService.java
+++ b/jraft-core/src/main/java/com/alipay/sofa/jraft/rpc/impl/core/DefaultRaftClientService.java
@@ -154,16 +154,16 @@ public class DefaultRaftClientService extends AbstractClientService implements R
     private Future<Message> onConnectionFail(final Endpoint endpoint, final Message request, Closure done, final Executor executor) {
         final FutureImpl<Message> future = new FutureImpl<>();
         executor.execute(() -> {
+            final String fmt = "Check connection[%s] fail and try to create new one";
             if (done != null) {
                 try {
-                    done.run(new Status(RaftError.EINTERNAL, "Check connection[%s] fail and try to create new one", endpoint));
+                    done.run(new Status(RaftError.EINTERNAL, fmt, endpoint));
                 } catch (final Throwable t) {
                     LOG.error("Fail to run RpcResponseClosure, the request is {}.", request, t);
                 }
             }
             if (!future.isDone()) {
-                future.failure(new RemotingException("Check connection[" +
-                        endpoint.toString()  + "] fail and try to create new one"));
+                future.failure(new RemotingException(String.format(fmt, endpoint)));
             }
         });
         return future;

--- a/jraft-core/src/main/java/com/alipay/sofa/jraft/rpc/impl/core/DefaultRaftClientService.java
+++ b/jraft-core/src/main/java/com/alipay/sofa/jraft/rpc/impl/core/DefaultRaftClientService.java
@@ -21,6 +21,7 @@ import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.Executor;
 import java.util.concurrent.Future;
 
+import com.alipay.sofa.jraft.Closure;
 import com.alipay.sofa.jraft.ReplicatorGroup;
 import com.alipay.sofa.jraft.Status;
 import com.alipay.sofa.jraft.error.RaftError;
@@ -93,12 +94,20 @@ public class DefaultRaftClientService extends AbstractClientService implements R
     @Override
     public Future<Message> preVote(final Endpoint endpoint, final RequestVoteRequest request,
                                    final RpcResponseClosure<RequestVoteResponse> done) {
+        if (!checkConnection(endpoint, true)) {
+            return onConnectionFail(endpoint, request, done, this.rpcExecutor);
+        }
+
         return invokeWithDone(endpoint, request, done, this.nodeOptions.getElectionTimeoutMs());
     }
 
     @Override
     public Future<Message> requestVote(final Endpoint endpoint, final RequestVoteRequest request,
                                        final RpcResponseClosure<RequestVoteResponse> done) {
+        if (!checkConnection(endpoint, true)) {
+            return onConnectionFail(endpoint, request, done, this.rpcExecutor);
+        }
+
         return invokeWithDone(endpoint, request, done, this.nodeOptions.getElectionTimeoutMs());
     }
 
@@ -107,26 +116,11 @@ public class DefaultRaftClientService extends AbstractClientService implements R
                                          final int timeoutMs, final RpcResponseClosure<AppendEntriesResponse> done) {
         final Executor executor = this.appendEntriesExecutorMap.computeIfAbsent(endpoint, k -> APPEND_ENTRIES_EXECUTORS.next());
 
-        if (checkConnection(endpoint, true)) {
-            return invokeWithDone(endpoint, request, done, timeoutMs, executor);
+        if (!checkConnection(endpoint, true)) {
+            return onConnectionFail(endpoint, request, done, executor);
         }
 
-        // fail-fast when no connection
-        final FutureImpl<Message> future = new FutureImpl<>();
-        executor.execute(() -> {
-            if (done != null) {
-                try {
-                    done.run(new Status(RaftError.EINTERNAL, "Check connection[%s] fail and try to create new one", endpoint));
-                } catch (final Throwable t) {
-                    LOG.error("Fail to run RpcResponseClosure, the request is {}.", request, t);
-                }
-            }
-            if (!future.isDone()) {
-                future.failure(new RemotingException("Check connection[" +
-                        endpoint.toString()  + "] fail and try to create new one"));
-            }
-        });
-        return future;
+        return invokeWithDone(endpoint, request, done, timeoutMs, executor);
     }
 
     @Override
@@ -154,5 +148,24 @@ public class DefaultRaftClientService extends AbstractClientService implements R
     public Future<Message> readIndex(final Endpoint endpoint, final ReadIndexRequest request, final int timeoutMs,
                                      final RpcResponseClosure<ReadIndexResponse> done) {
         return invokeWithDone(endpoint, request, done, timeoutMs);
+    }
+
+    // fail-fast when no connection
+    private Future<Message> onConnectionFail(final Endpoint endpoint, final Message request, Closure done, final Executor executor) {
+        final FutureImpl<Message> future = new FutureImpl<>();
+        executor.execute(() -> {
+            if (done != null) {
+                try {
+                    done.run(new Status(RaftError.EINTERNAL, "Check connection[%s] fail and try to create new one", endpoint));
+                } catch (final Throwable t) {
+                    LOG.error("Fail to run RpcResponseClosure, the request is {}.", request, t);
+                }
+            }
+            if (!future.isDone()) {
+                future.failure(new RemotingException("Check connection[" +
+                        endpoint.toString()  + "] fail and try to create new one"));
+            }
+        });
+        return future;
     }
 }


### PR DESCRIPTION
### Motivation:

check the connection first and fail-fast (asynchronously to create the connection) on pre-vote and vote

### Modification:


### Result:

Fixes #583 .

If there is no issue then describe the changes introduced by this PR.
