### PR TITLE
add parallel compress and deCompresss feature

### DIFF
--- a/jraft-example/src/main/java/com/alipay/sofa/jraft/example/rheakv/Server1.java
+++ b/jraft-example/src/main/java/com/alipay/sofa/jraft/example/rheakv/Server1.java
@@ -44,6 +44,7 @@ public class Server1 {
                 .config();
         final RheaKVStoreOptions opts = RheaKVStoreOptionsConfigured.newConfigured() //
                 .withClusterName(Configs.CLUSTER_NAME) //
+                .withUseParallelCompress(true)
                 .withInitialServerList(Configs.ALL_NODE_ADDRESSES)
                 .withStoreEngineOptions(storeOpts) //
                 .withPlacementDriverOptions(pdOpts) //

--- a/jraft-example/src/main/java/com/alipay/sofa/jraft/example/rheakv/Server1.java
+++ b/jraft-example/src/main/java/com/alipay/sofa/jraft/example/rheakv/Server1.java
@@ -32,7 +32,7 @@ import com.alipay.sofa.jraft.util.Endpoint;
  */
 public class Server1 {
 
-    public static void main(final String[] args) throws Exception {
+    public static void main(final String[] args) {
         final PlacementDriverOptions pdOpts = PlacementDriverOptionsConfigured.newConfigured()
                 .withFake(true) // use a fake pd
                 .config();
@@ -44,7 +44,7 @@ public class Server1 {
                 .config();
         final RheaKVStoreOptions opts = RheaKVStoreOptionsConfigured.newConfigured() //
                 .withClusterName(Configs.CLUSTER_NAME) //
-                .withUseParallelCompress(true)
+                .withUseParallelCompress(true) //
                 .withInitialServerList(Configs.ALL_NODE_ADDRESSES)
                 .withStoreEngineOptions(storeOpts) //
                 .withPlacementDriverOptions(pdOpts) //

--- a/jraft-example/src/main/java/com/alipay/sofa/jraft/example/rheakv/Server2.java
+++ b/jraft-example/src/main/java/com/alipay/sofa/jraft/example/rheakv/Server2.java
@@ -44,6 +44,7 @@ public class Server2 {
                 .config();
         final RheaKVStoreOptions opts = RheaKVStoreOptionsConfigured.newConfigured() //
                 .withClusterName(Configs.CLUSTER_NAME) //
+                .withUseParallelCompress(true) //
                 .withInitialServerList(Configs.ALL_NODE_ADDRESSES)
                 .withStoreEngineOptions(storeOpts) //
                 .withPlacementDriverOptions(pdOpts) //

--- a/jraft-example/src/main/java/com/alipay/sofa/jraft/example/rheakv/Server3.java
+++ b/jraft-example/src/main/java/com/alipay/sofa/jraft/example/rheakv/Server3.java
@@ -44,6 +44,7 @@ public class Server3 {
                 .config();
         final RheaKVStoreOptions opts = RheaKVStoreOptionsConfigured.newConfigured() //
                 .withClusterName(Configs.CLUSTER_NAME) //
+                .withUseParallelCompress(true) //
                 .withInitialServerList(Configs.ALL_NODE_ADDRESSES)
                 .withStoreEngineOptions(storeOpts) //
                 .withPlacementDriverOptions(pdOpts) //

--- a/jraft-rheakv/rheakv-core/pom.xml
+++ b/jraft-rheakv/rheakv-core/pom.xml
@@ -37,6 +37,10 @@
             <artifactId>commons-io</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-compress</artifactId>
+        </dependency>
+        <dependency>
             <groupId>com.alipay.sofa</groupId>
             <artifactId>bolt</artifactId>
         </dependency>

--- a/jraft-rheakv/rheakv-core/src/main/java/com/alipay/sofa/jraft/rhea/client/DefaultRheaKVStore.java
+++ b/jraft-rheakv/rheakv-core/src/main/java/com/alipay/sofa/jraft/rhea/client/DefaultRheaKVStore.java
@@ -323,7 +323,6 @@ public class DefaultRheaKVStore implements RheaKVStore {
         if (this.putBatching != null) {
             this.putBatching.shutdown();
         }
-        ZipStrategyManager.shutdown();
         this.stateListenerContainer.clear();
         LOG.info("[DefaultRheaKVStore] shutdown successfully.");
     }

--- a/jraft-rheakv/rheakv-core/src/main/java/com/alipay/sofa/jraft/rhea/client/DefaultRheaKVStore.java
+++ b/jraft-rheakv/rheakv-core/src/main/java/com/alipay/sofa/jraft/rhea/client/DefaultRheaKVStore.java
@@ -24,6 +24,8 @@ import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.TimeUnit;
 
+import com.alipay.sofa.jraft.rhea.storage.zip.ParallelZipStrategy;
+import com.alipay.sofa.jraft.rhea.storage.zip.ZipStrategyManager;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -240,6 +242,10 @@ public class DefaultRheaKVStore implements RheaKVStore {
         if (!this.pdClient.init(pdOpts)) {
             LOG.error("Fail to init [PlacementDriverClient].");
             return false;
+        }
+        if (opts.isUseParallelCompress()) {
+            ZipStrategyManager.addZipStrategy(ZipStrategyManager.PARALLEL_STRATEGY,
+                    new ParallelZipStrategy(opts.getCompressCoreThreads(), opts.getDeCompressCoreThreads()));
         }
         // init store engine
         final StoreEngineOptions stOpts = opts.getStoreEngineOptions();

--- a/jraft-rheakv/rheakv-core/src/main/java/com/alipay/sofa/jraft/rhea/client/DefaultRheaKVStore.java
+++ b/jraft-rheakv/rheakv-core/src/main/java/com/alipay/sofa/jraft/rhea/client/DefaultRheaKVStore.java
@@ -24,7 +24,6 @@ import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.TimeUnit;
 
-import com.alipay.sofa.jraft.rhea.storage.zip.ParallelZipStrategy;
 import com.alipay.sofa.jraft.rhea.storage.zip.ZipStrategyManager;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -243,10 +242,8 @@ public class DefaultRheaKVStore implements RheaKVStore {
             LOG.error("Fail to init [PlacementDriverClient].");
             return false;
         }
-        if (opts.isUseParallelCompress()) {
-            ZipStrategyManager.addZipStrategy(ZipStrategyManager.PARALLEL_STRATEGY,
-                    new ParallelZipStrategy(opts.getCompressCoreThreads(), opts.getDeCompressCoreThreads()));
-        }
+        // init compress strategies
+        ZipStrategyManager.init(opts);
         // init store engine
         final StoreEngineOptions stOpts = opts.getStoreEngineOptions();
         if (stOpts != null) {
@@ -326,6 +323,7 @@ public class DefaultRheaKVStore implements RheaKVStore {
         if (this.putBatching != null) {
             this.putBatching.shutdown();
         }
+        ZipStrategyManager.shutdown();
         this.stateListenerContainer.clear();
         LOG.info("[DefaultRheaKVStore] shutdown successfully.");
     }

--- a/jraft-rheakv/rheakv-core/src/main/java/com/alipay/sofa/jraft/rhea/options/RheaKVStoreOptions.java
+++ b/jraft-rheakv/rheakv-core/src/main/java/com/alipay/sofa/jraft/rhea/options/RheaKVStoreOptions.java
@@ -186,8 +186,8 @@ public class RheaKVStoreOptions {
                + ", initialServerList='" + initialServerList + '\'' + ", onlyLeaderRead=" + onlyLeaderRead
                + ", rpcOptions=" + rpcOptions + ", failoverRetries=" + failoverRetries + ", futureTimeoutMillis="
                + futureTimeoutMillis + ", useParallelKVExecutor=" + useParallelKVExecutor + ", batchingOptions="
-               + batchingOptions + ", useParallelCompress=" + useParallelCompress + ", compressCoreThreads="
-               + compressThreads + ", deCompressCoreThreads=" + deCompressThreads + '}';
+               + batchingOptions + ", useParallelCompress=" + useParallelCompress + ", compressThreads="
+               + compressThreads + ", deCompressThreads=" + deCompressThreads + '}';
     }
 
 }

--- a/jraft-rheakv/rheakv-core/src/main/java/com/alipay/sofa/jraft/rhea/options/RheaKVStoreOptions.java
+++ b/jraft-rheakv/rheakv-core/src/main/java/com/alipay/sofa/jraft/rhea/options/RheaKVStoreOptions.java
@@ -49,7 +49,7 @@ public class RheaKVStoreOptions {
     private boolean                useParallelKVExecutor = true;
     private BatchingOptions        batchingOptions       = BatchingOptionsConfigured.newDefaultConfig();
     // If 'useParallelCompress' is true , We will compress and decompress Snapshot concurrently
-    private boolean                useParallelCompress   = true;
+    private boolean                useParallelCompress   = false;
     private int                    compressThreads       = Utils.cpus();
     private int                    deCompressThreads     = Utils.cpus() + 1;
 

--- a/jraft-rheakv/rheakv-core/src/main/java/com/alipay/sofa/jraft/rhea/options/RheaKVStoreOptions.java
+++ b/jraft-rheakv/rheakv-core/src/main/java/com/alipay/sofa/jraft/rhea/options/RheaKVStoreOptions.java
@@ -50,7 +50,7 @@ public class RheaKVStoreOptions {
     // If 'useParallelCompress' is true , We will compress and decompress Snapshot concurrently
     private boolean                useParallelCompress   = true;
     private int                    compressCoreThreads   = (int) (Runtime.getRuntime().availableProcessors() * 0.75);
-    private int                    deCompressCoreThreads = Runtime.getRuntime().availableProcessors();
+    private int                    deCompressCoreThreads = Runtime.getRuntime().availableProcessors() + 1;
 
     public long getClusterId() {
         return clusterId;

--- a/jraft-rheakv/rheakv-core/src/main/java/com/alipay/sofa/jraft/rhea/options/RheaKVStoreOptions.java
+++ b/jraft-rheakv/rheakv-core/src/main/java/com/alipay/sofa/jraft/rhea/options/RheaKVStoreOptions.java
@@ -47,6 +47,10 @@ public class RheaKVStoreOptions {
     private long                   futureTimeoutMillis   = 5000;
     private boolean                useParallelKVExecutor = true;
     private BatchingOptions        batchingOptions       = BatchingOptionsConfigured.newDefaultConfig();
+    // If 'useParallelCompress' is true , We will compress and decompress Snapshot concurrently
+    private boolean                useParallelCompress   = true;
+    private int                    compressCoreThreads   = (int) (Runtime.getRuntime().availableProcessors() * 0.75);
+    private int                    deCompressCoreThreads = Runtime.getRuntime().availableProcessors();
 
     public long getClusterId() {
         return clusterId;
@@ -150,6 +154,30 @@ public class RheaKVStoreOptions {
         this.batchingOptions = batchingOptions;
     }
 
+    public boolean isUseParallelCompress() {
+        return useParallelCompress;
+    }
+
+    public void setUseParallelCompress(boolean useParallelCompress) {
+        this.useParallelCompress = useParallelCompress;
+    }
+
+    public int getCompressCoreThreads() {
+        return compressCoreThreads;
+    }
+
+    public void setCompressCoreThreads(int compressCoreThreads) {
+        this.compressCoreThreads = compressCoreThreads;
+    }
+
+    public int getDeCompressCoreThreads() {
+        return deCompressCoreThreads;
+    }
+
+    public void setDeCompressCoreThreads(int deCompressCoreThreads) {
+        this.deCompressCoreThreads = deCompressCoreThreads;
+    }
+
     @Override
     public String toString() {
         return "RheaKVStoreOptions{" + "clusterId=" + clusterId + ", clusterName='" + clusterName + '\''
@@ -157,6 +185,8 @@ public class RheaKVStoreOptions {
                + ", initialServerList='" + initialServerList + '\'' + ", onlyLeaderRead=" + onlyLeaderRead
                + ", rpcOptions=" + rpcOptions + ", failoverRetries=" + failoverRetries + ", futureTimeoutMillis="
                + futureTimeoutMillis + ", useParallelKVExecutor=" + useParallelKVExecutor + ", batchingOptions="
-               + batchingOptions + '}';
+               + batchingOptions + ", useParallelCompress=" + useParallelCompress + ", compressCoreThreads="
+               + compressCoreThreads + ", deCompressCoreThreads=" + deCompressCoreThreads + '}';
     }
+
 }

--- a/jraft-rheakv/rheakv-core/src/main/java/com/alipay/sofa/jraft/rhea/options/RheaKVStoreOptions.java
+++ b/jraft-rheakv/rheakv-core/src/main/java/com/alipay/sofa/jraft/rhea/options/RheaKVStoreOptions.java
@@ -18,6 +18,7 @@ package com.alipay.sofa.jraft.rhea.options;
 
 import com.alipay.sofa.jraft.rhea.options.configured.BatchingOptionsConfigured;
 import com.alipay.sofa.jraft.rhea.options.configured.RpcOptionsConfigured;
+import com.alipay.sofa.jraft.util.Utils;
 
 /**
  *
@@ -49,8 +50,8 @@ public class RheaKVStoreOptions {
     private BatchingOptions        batchingOptions       = BatchingOptionsConfigured.newDefaultConfig();
     // If 'useParallelCompress' is true , We will compress and decompress Snapshot concurrently
     private boolean                useParallelCompress   = true;
-    private int                    compressCoreThreads   = (int) (Runtime.getRuntime().availableProcessors() * 0.75);
-    private int                    deCompressCoreThreads = Runtime.getRuntime().availableProcessors() + 1;
+    private int                    compressThreads       = Utils.cpus();
+    private int                    deCompressThreads     = Utils.cpus() + 1;
 
     public long getClusterId() {
         return clusterId;
@@ -162,20 +163,20 @@ public class RheaKVStoreOptions {
         this.useParallelCompress = useParallelCompress;
     }
 
-    public int getCompressCoreThreads() {
-        return compressCoreThreads;
+    public int getCompressThreads() {
+        return compressThreads;
     }
 
-    public void setCompressCoreThreads(int compressCoreThreads) {
-        this.compressCoreThreads = compressCoreThreads;
+    public void setCompressThreads(int compressThreads) {
+        this.compressThreads = compressThreads;
     }
 
-    public int getDeCompressCoreThreads() {
-        return deCompressCoreThreads;
+    public int getDeCompressThreads() {
+        return deCompressThreads;
     }
 
-    public void setDeCompressCoreThreads(int deCompressCoreThreads) {
-        this.deCompressCoreThreads = deCompressCoreThreads;
+    public void setDeCompressThreads(int deCompressThreads) {
+        this.deCompressThreads = deCompressThreads;
     }
 
     @Override
@@ -186,7 +187,7 @@ public class RheaKVStoreOptions {
                + ", rpcOptions=" + rpcOptions + ", failoverRetries=" + failoverRetries + ", futureTimeoutMillis="
                + futureTimeoutMillis + ", useParallelKVExecutor=" + useParallelKVExecutor + ", batchingOptions="
                + batchingOptions + ", useParallelCompress=" + useParallelCompress + ", compressCoreThreads="
-               + compressCoreThreads + ", deCompressCoreThreads=" + deCompressCoreThreads + '}';
+               + compressThreads + ", deCompressCoreThreads=" + deCompressThreads + '}';
     }
 
 }

--- a/jraft-rheakv/rheakv-core/src/main/java/com/alipay/sofa/jraft/rhea/options/configured/RheaKVStoreOptionsConfigured.java
+++ b/jraft-rheakv/rheakv-core/src/main/java/com/alipay/sofa/jraft/rhea/options/configured/RheaKVStoreOptionsConfigured.java
@@ -96,12 +96,12 @@ public final class RheaKVStoreOptionsConfigured implements Configured<RheaKVStor
     }
 
     public RheaKVStoreOptionsConfigured withCompressCoreThreads(final int compressCoreThreads) {
-        this.opts.setCompressCoreThreads(compressCoreThreads);
+        this.opts.setCompressThreads(compressCoreThreads);
         return this;
     }
 
     public RheaKVStoreOptionsConfigured withDeCompressCoreThreads(final int deCompressCoreThreads) {
-        this.opts.setDeCompressCoreThreads(deCompressCoreThreads);
+        this.opts.setDeCompressThreads(deCompressCoreThreads);
         return this;
     }
 

--- a/jraft-rheakv/rheakv-core/src/main/java/com/alipay/sofa/jraft/rhea/options/configured/RheaKVStoreOptionsConfigured.java
+++ b/jraft-rheakv/rheakv-core/src/main/java/com/alipay/sofa/jraft/rhea/options/configured/RheaKVStoreOptionsConfigured.java
@@ -90,6 +90,21 @@ public final class RheaKVStoreOptionsConfigured implements Configured<RheaKVStor
         return this;
     }
 
+    public RheaKVStoreOptionsConfigured withUseParallelCompress(final boolean useParallelCompress) {
+        this.opts.setUseParallelCompress(useParallelCompress);
+        return this;
+    }
+
+    public RheaKVStoreOptionsConfigured withCompressCoreThreads(final int compressCoreThreads) {
+        this.opts.setCompressCoreThreads(compressCoreThreads);
+        return this;
+    }
+
+    public RheaKVStoreOptionsConfigured withDeCompressCoreThreads(final int deCompressCoreThreads) {
+        this.opts.setDeCompressCoreThreads(deCompressCoreThreads);
+        return this;
+    }
+
     @Override
     public RheaKVStoreOptions config() {
         return this.opts;

--- a/jraft-rheakv/rheakv-core/src/main/java/com/alipay/sofa/jraft/rhea/options/configured/RheaKVStoreOptionsConfigured.java
+++ b/jraft-rheakv/rheakv-core/src/main/java/com/alipay/sofa/jraft/rhea/options/configured/RheaKVStoreOptionsConfigured.java
@@ -95,12 +95,12 @@ public final class RheaKVStoreOptionsConfigured implements Configured<RheaKVStor
         return this;
     }
 
-    public RheaKVStoreOptionsConfigured withCompressCoreThreads(final int compressCoreThreads) {
+    public RheaKVStoreOptionsConfigured withCompressThreads(final int compressCoreThreads) {
         this.opts.setCompressThreads(compressCoreThreads);
         return this;
     }
 
-    public RheaKVStoreOptionsConfigured withDeCompressCoreThreads(final int deCompressCoreThreads) {
+    public RheaKVStoreOptionsConfigured withDeCompressThreads(final int deCompressCoreThreads) {
         this.opts.setDeCompressThreads(deCompressCoreThreads);
         return this;
     }

--- a/jraft-rheakv/rheakv-core/src/main/java/com/alipay/sofa/jraft/rhea/options/configured/RheaKVStoreOptionsConfigured.java
+++ b/jraft-rheakv/rheakv-core/src/main/java/com/alipay/sofa/jraft/rhea/options/configured/RheaKVStoreOptionsConfigured.java
@@ -95,13 +95,13 @@ public final class RheaKVStoreOptionsConfigured implements Configured<RheaKVStor
         return this;
     }
 
-    public RheaKVStoreOptionsConfigured withCompressThreads(final int compressCoreThreads) {
-        this.opts.setCompressThreads(compressCoreThreads);
+    public RheaKVStoreOptionsConfigured withCompressThreads(final int compressThreads) {
+        this.opts.setCompressThreads(compressThreads);
         return this;
     }
 
-    public RheaKVStoreOptionsConfigured withDeCompressThreads(final int deCompressCoreThreads) {
-        this.opts.setDeCompressThreads(deCompressCoreThreads);
+    public RheaKVStoreOptionsConfigured withDeCompressThreads(final int deCompressThreads) {
+        this.opts.setDeCompressThreads(deCompressThreads);
         return this;
     }
 

--- a/jraft-rheakv/rheakv-core/src/main/java/com/alipay/sofa/jraft/rhea/storage/AbstractKVStoreSnapshotFile.java
+++ b/jraft-rheakv/rheakv-core/src/main/java/com/alipay/sofa/jraft/rhea/storage/AbstractKVStoreSnapshotFile.java
@@ -23,6 +23,8 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutorService;
 import java.util.zip.Checksum;
 
+import com.alipay.sofa.jraft.rhea.storage.zip.ZipStrategy;
+import com.alipay.sofa.jraft.rhea.storage.zip.ZipStrategyManager;
 import org.apache.commons.io.FileUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -119,7 +121,7 @@ public abstract class AbstractKVStoreSnapshotFile implements KVStoreSnapshotFile
         final String outputFile = Paths.get(writerPath, SNAPSHOT_ARCHIVE).toString();
         try {
             final Checksum checksum = new CRC64();
-            ZipUtil.compress(writerPath, SNAPSHOT_DIR, outputFile, checksum);
+            ZipStrategyManager.getDefault().compress(writerPath, SNAPSHOT_DIR, outputFile, checksum);
             metaBuilder.setChecksum(Long.toHexString(checksum.getValue()));
             if (writer.addFile(SNAPSHOT_ARCHIVE, metaBuilder.build())) {
                 done.run(Status.OK());
@@ -137,7 +139,7 @@ public abstract class AbstractKVStoreSnapshotFile implements KVStoreSnapshotFile
     protected void decompressSnapshot(final String readerPath, final LocalFileMeta meta) throws IOException {
         final String sourceFile = Paths.get(readerPath, SNAPSHOT_ARCHIVE).toString();
         final Checksum checksum = new CRC64();
-        ZipUtil.decompress(sourceFile, readerPath, checksum);
+        ZipStrategyManager.getDefault().deCompress(sourceFile, readerPath, checksum);
         if (meta.hasChecksum()) {
             Requires.requireTrue(meta.getChecksum().equals(Long.toHexString(checksum.getValue())),
                 "Snapshot checksum failed");

--- a/jraft-rheakv/rheakv-core/src/main/java/com/alipay/sofa/jraft/rhea/storage/AbstractKVStoreSnapshotFile.java
+++ b/jraft-rheakv/rheakv-core/src/main/java/com/alipay/sofa/jraft/rhea/storage/AbstractKVStoreSnapshotFile.java
@@ -17,13 +17,11 @@
 package com.alipay.sofa.jraft.rhea.storage;
 
 import java.io.File;
-import java.io.IOException;
 import java.nio.file.Paths;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutorService;
 import java.util.zip.Checksum;
 
-import com.alipay.sofa.jraft.rhea.storage.zip.ZipStrategy;
 import com.alipay.sofa.jraft.rhea.storage.zip.ZipStrategyManager;
 import org.apache.commons.io.FileUtils;
 import org.slf4j.Logger;
@@ -36,7 +34,6 @@ import com.alipay.sofa.jraft.rhea.metadata.Region;
 import com.alipay.sofa.jraft.rhea.serialization.Serializer;
 import com.alipay.sofa.jraft.rhea.serialization.Serializers;
 import com.alipay.sofa.jraft.rhea.util.StackTraceUtil;
-import com.alipay.sofa.jraft.rhea.util.ZipUtil;
 import com.alipay.sofa.jraft.storage.snapshot.SnapshotReader;
 import com.alipay.sofa.jraft.storage.snapshot.SnapshotWriter;
 import com.alipay.sofa.jraft.util.CRC64;
@@ -136,7 +133,7 @@ public abstract class AbstractKVStoreSnapshotFile implements KVStoreSnapshotFile
         }
     }
 
-    protected void decompressSnapshot(final String readerPath, final LocalFileMeta meta) throws IOException {
+    protected void decompressSnapshot(final String readerPath, final LocalFileMeta meta) throws Throwable {
         final String sourceFile = Paths.get(readerPath, SNAPSHOT_ARCHIVE).toString();
         final Checksum checksum = new CRC64();
         ZipStrategyManager.getDefault().deCompress(sourceFile, readerPath, checksum);

--- a/jraft-rheakv/rheakv-core/src/main/java/com/alipay/sofa/jraft/rhea/storage/zip/JDKZipStrategy.java
+++ b/jraft-rheakv/rheakv-core/src/main/java/com/alipay/sofa/jraft/rhea/storage/zip/JDKZipStrategy.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alipay.sofa.jraft.rhea.storage.zip;
+
+import com.alipay.sofa.jraft.rhea.util.ZipUtil;
+
+import java.io.IOException;
+import java.util.zip.Checksum;
+
+/**
+ * @author hzh
+ */
+public class JDKZipStrategy implements ZipStrategy {
+
+    @Override
+    public void compress(String rootDir, String sourceDir, String outputZipFile, Checksum checksum) throws IOException {
+        ZipUtil.compress(rootDir, sourceDir, outputZipFile, checksum);
+    }
+
+    @Override
+    public void deCompress(String sourceZipFile, String outputDir, Checksum checksum) throws IOException {
+        ZipUtil.decompress(sourceZipFile, outputDir, checksum);
+    }
+}

--- a/jraft-rheakv/rheakv-core/src/main/java/com/alipay/sofa/jraft/rhea/storage/zip/JDKZipStrategy.java
+++ b/jraft-rheakv/rheakv-core/src/main/java/com/alipay/sofa/jraft/rhea/storage/zip/JDKZipStrategy.java
@@ -17,8 +17,6 @@
 package com.alipay.sofa.jraft.rhea.storage.zip;
 
 import com.alipay.sofa.jraft.rhea.util.ZipUtil;
-
-import java.io.IOException;
 import java.util.zip.Checksum;
 
 /**
@@ -27,12 +25,21 @@ import java.util.zip.Checksum;
 public class JDKZipStrategy implements ZipStrategy {
 
     @Override
-    public void compress(String rootDir, String sourceDir, String outputZipFile, Checksum checksum) throws IOException {
+    public void compress(String rootDir, String sourceDir, String outputZipFile, Checksum checksum) throws Throwable {
         ZipUtil.compress(rootDir, sourceDir, outputZipFile, checksum);
     }
 
     @Override
-    public void deCompress(String sourceZipFile, String outputDir, Checksum checksum) throws IOException {
+    public void deCompress(String sourceZipFile, String outputDir, Checksum checksum) throws Throwable {
         ZipUtil.decompress(sourceZipFile, outputDir, checksum);
+    }
+
+    @Override
+    public boolean init() {
+        return true;
+    }
+
+    @Override
+    public void shutdown() {
     }
 }

--- a/jraft-rheakv/rheakv-core/src/main/java/com/alipay/sofa/jraft/rhea/storage/zip/JDKZipStrategy.java
+++ b/jraft-rheakv/rheakv-core/src/main/java/com/alipay/sofa/jraft/rhea/storage/zip/JDKZipStrategy.java
@@ -25,12 +25,14 @@ import java.util.zip.Checksum;
 public class JDKZipStrategy implements ZipStrategy {
 
     @Override
-    public void compress(String rootDir, String sourceDir, String outputZipFile, Checksum checksum) throws Throwable {
+    public void compress(final String rootDir, final String sourceDir, final String outputZipFile,
+                         final Checksum checksum) throws Throwable {
         ZipUtil.compress(rootDir, sourceDir, outputZipFile, checksum);
     }
 
     @Override
-    public void deCompress(String sourceZipFile, String outputDir, Checksum checksum) throws Throwable {
+    public void deCompress(final String sourceZipFile, final String outputDir, final Checksum checksum)
+                                                                                                       throws Throwable {
         ZipUtil.decompress(sourceZipFile, outputDir, checksum);
     }
 

--- a/jraft-rheakv/rheakv-core/src/main/java/com/alipay/sofa/jraft/rhea/storage/zip/JDKZipStrategy.java
+++ b/jraft-rheakv/rheakv-core/src/main/java/com/alipay/sofa/jraft/rhea/storage/zip/JDKZipStrategy.java
@@ -36,12 +36,4 @@ public class JDKZipStrategy implements ZipStrategy {
         ZipUtil.decompress(sourceZipFile, outputDir, checksum);
     }
 
-    @Override
-    public boolean init() {
-        return true;
-    }
-
-    @Override
-    public void shutdown() {
-    }
 }

--- a/jraft-rheakv/rheakv-core/src/main/java/com/alipay/sofa/jraft/rhea/storage/zip/ParallelZipStrategy.java
+++ b/jraft-rheakv/rheakv-core/src/main/java/com/alipay/sofa/jraft/rhea/storage/zip/ParallelZipStrategy.java
@@ -95,7 +95,7 @@ public class ParallelZipStrategy implements ZipStrategy {
         FileUtils.forceMkdir(zipFile.getParentFile());
 
         // parallel compress
-        final ExecutorService compressExecutor = newFixPool(this.compressThreads, "rheakv-raft-compress-executor");
+        final ExecutorService compressExecutor = newFixedPool(this.compressThreads, "rheakv-raft-compress-executor");
         final ZipArchiveScatterOutputStream scatterOutput = new ZipArchiveScatterOutputStream(compressExecutor);
         compressDirectoryToZipFile(rootFile, scatterOutput, sourceDir, ZipEntry.DEFLATED);
 
@@ -112,7 +112,7 @@ public class ParallelZipStrategy implements ZipStrategy {
 
     @Override
     public void deCompress(final String sourceZipFile, final String outputDir, final Checksum checksum) throws Throwable {
-        final ExecutorService deCompressExecutor = newFixPool(this.deCompressThreads, "rheakv-raft-decompress-executor");
+        final ExecutorService deCompressExecutor = newFixedPool(this.deCompressThreads, "rheakv-raft-decompress-executor");
         // compute the checksum in a single thread
         final Future<Boolean> checksumFuture = deCompressExecutor.submit(() -> {
             computeZipFileChecksumValue(sourceZipFile, checksum);
@@ -203,7 +203,7 @@ public class ParallelZipStrategy implements ZipStrategy {
         }
     }
 
-    private static ExecutorService newFixPool(final int coreThreads, final String poolName) {
+    private static ExecutorService newFixedPool(final int coreThreads, final String poolName) {
         return ThreadPoolUtil.newBuilder() //
             .poolName(poolName) //
             .enableMetric(true) //

--- a/jraft-rheakv/rheakv-core/src/main/java/com/alipay/sofa/jraft/rhea/storage/zip/ParallelZipStrategy.java
+++ b/jraft-rheakv/rheakv-core/src/main/java/com/alipay/sofa/jraft/rhea/storage/zip/ParallelZipStrategy.java
@@ -47,10 +47,10 @@ public class ParallelZipStrategy implements Lifecycle<ParallelZipStrategy>, ZipS
     private final int             compressCoreThreads;
     private final ExecutorService deCompressExecutor;
 
-    public ParallelZipStrategy(int deCompressThreadSize, int compressCoreThreads) {
+    public ParallelZipStrategy(int compressCoreThreads, int deCompressCoreThreads) {
         this.compressCoreThreads = compressCoreThreads;
-        this.deCompressCoreThreads = deCompressThreadSize;
-        this.deCompressExecutor = Executors.newFixedThreadPool(deCompressThreadSize);
+        this.deCompressCoreThreads = deCompressCoreThreads;
+        this.deCompressExecutor = Executors.newFixedThreadPool(deCompressCoreThreads);
     }
 
     // parallel output streams controller
@@ -124,8 +124,7 @@ public class ParallelZipStrategy implements Lifecycle<ParallelZipStrategy>, ZipS
         computeZipFileChecksumValue(sourceZipFile,checksum);
     }
 
-    private void compressDirectoryToZipFile(File dir, ZipArchiveScatterOutputStream scatterOutput, String sourceDir,
-                                            int method) throws IOException {
+    private void compressDirectoryToZipFile(File dir, ZipArchiveScatterOutputStream scatterOutput, String sourceDir, int method)  {
         if (dir == null) {
             return;
         }
@@ -187,7 +186,7 @@ public class ParallelZipStrategy implements Lifecycle<ParallelZipStrategy>, ZipS
             for (ZipArchiveEntry zipEntry : zipEntries) {
                 try (final InputStream is = zipFile.getRawInputStream(zipEntry);
                         final BufferedInputStream fis = new BufferedInputStream(is)) {
-                    int length = 0;
+                    int length ;
                     while (-1 != (length = fis.read(buffer))) {
                         checksum.update(buffer, 0, length);
                     }

--- a/jraft-rheakv/rheakv-core/src/main/java/com/alipay/sofa/jraft/rhea/storage/zip/ParallelZipStrategy.java
+++ b/jraft-rheakv/rheakv-core/src/main/java/com/alipay/sofa/jraft/rhea/storage/zip/ParallelZipStrategy.java
@@ -198,7 +198,8 @@ public class ParallelZipStrategy implements ZipStrategy {
                 final CheckedInputStream cis = new CheckedInputStream(bis, checksum);
                 final ZipArchiveInputStream zis = new ZipArchiveInputStream(cis)) {
             // checksum is calculated in the process
-            while ((zis.getNextZipEntry()) != null) ;
+            while ((zis.getNextZipEntry()) != null)
+                ;
         }
     }
 

--- a/jraft-rheakv/rheakv-core/src/main/java/com/alipay/sofa/jraft/rhea/storage/zip/ParallelZipStrategy.java
+++ b/jraft-rheakv/rheakv-core/src/main/java/com/alipay/sofa/jraft/rhea/storage/zip/ParallelZipStrategy.java
@@ -1,0 +1,209 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alipay.sofa.jraft.rhea.storage.zip;
+
+import com.alipay.sofa.jraft.Lifecycle;
+import com.alipay.sofa.jraft.rhea.util.Lists;
+import com.alipay.sofa.jraft.util.ExecutorServiceHelper;
+import com.alipay.sofa.jraft.util.Requires;
+import org.apache.commons.compress.archivers.zip.*;
+import org.apache.commons.compress.parallel.FileBasedScatterGatherBackingStore;
+import org.apache.commons.compress.parallel.InputStreamSupplier;
+import org.apache.commons.io.FileUtils;
+import org.apache.commons.io.IOUtils;
+import org.apache.commons.io.input.NullInputStream;
+
+import java.io.*;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.zip.Checksum;
+import java.util.zip.ZipEntry;
+
+/**
+ * @author hzh
+ */
+public class ParallelZipStrategy implements Lifecycle<ParallelZipStrategy>, ZipStrategy {
+
+    private final int             deCompressCoreThreads;
+    private final int             compressCoreThreads;
+    private final ExecutorService deCompressExecutor;
+
+    public ParallelZipStrategy(int deCompressThreadSize, int compressCoreThreads) {
+        this.compressCoreThreads = compressCoreThreads;
+        this.deCompressCoreThreads = deCompressThreadSize;
+        this.deCompressExecutor = Executors.newFixedThreadPool(deCompressThreadSize);
+    }
+
+    // parallel output streams controller
+    private static class ZipArchiveScatterOutputStream {
+
+        private final ParallelScatterZipCreator creator;
+
+        public ZipArchiveScatterOutputStream(int threadSize) {
+            this.creator = new ParallelScatterZipCreator(Executors.newFixedThreadPool(threadSize));
+        }
+
+        public void addEntry(ZipArchiveEntry entry, InputStreamSupplier supplier) {
+            creator.addArchiveEntry(entry, supplier);
+        }
+
+        public void writeTo(ZipArchiveOutputStream archiveOutput) throws Exception {
+            creator.writeTo(archiveOutput);
+        }
+
+    }
+
+    @Override
+    public void compress(String rootDir, String sourceDir, String outputZipFile, Checksum checksum) throws IOException {
+        final File rootFile = new File(Paths.get(rootDir, sourceDir).toString());
+        final File zipFile = new File(outputZipFile);
+        FileUtils.forceMkdir(zipFile.getParentFile());
+
+        //parallel compress
+        ZipArchiveScatterOutputStream scatterOutput = new ZipArchiveScatterOutputStream(this.compressCoreThreads);
+        compressDirectoryToZipFile(rootFile, scatterOutput, sourceDir, ZipEntry.DEFLATED);
+
+        //write to and flush
+        try (final BufferedOutputStream bos = new BufferedOutputStream(new FileOutputStream(zipFile));
+                final ZipArchiveOutputStream archiveOutput = new ZipArchiveOutputStream(bos)) {
+            scatterOutput.writeTo(archiveOutput);
+            archiveOutput.flush();
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+
+        //compute checksum
+        computeZipFileChecksumValue(outputZipFile, checksum);
+    }
+
+    @Override
+    public void deCompress(final String sourceZipFile, final String outputDir, final Checksum checksum) throws IOException {
+        try (final ZipFile zipFile = new ZipFile(new File(sourceZipFile))) {
+            final ArrayList<ZipArchiveEntry> zipEntries = Collections.list(zipFile.getEntries());
+            final List<Future<?>> futures = Lists.newArrayList();
+            //parallel deCompress
+            for (final ZipArchiveEntry zipEntry : zipEntries) {
+                final Future<?> future = deCompressExecutor.submit(() -> {
+                    try {
+                        unZipFile(zipFile, zipEntry, outputDir);
+                    } catch (IOException e) {
+                        e.printStackTrace();
+                    }
+                });
+                futures.add(future);
+            }
+            //blocking and caching exception
+            for (final Future<?> future : futures) {
+                try {
+                    future.get();
+                } catch (Throwable t) {
+                    t.printStackTrace();
+                }
+            }
+        }
+        //compute checksum
+        computeZipFileChecksumValue(sourceZipFile,checksum);
+    }
+
+    private void compressDirectoryToZipFile(File dir, ZipArchiveScatterOutputStream scatterOutput, String sourceDir,
+                                            int method) throws IOException {
+        if (dir == null) {
+            return;
+        }
+        if (dir.isFile()) {
+            addEntry(sourceDir, dir, scatterOutput, method);
+            return;
+        }
+        final File[] files = Requires.requireNonNull(dir.listFiles(), "files");
+        for (final File file : files) {
+            final String child = Paths.get(sourceDir, file.getName()).toString();
+            if (file.isDirectory()) {
+                compressDirectoryToZipFile(file, scatterOutput, child, method);
+            } else {
+                addEntry(child, file, scatterOutput, method);
+            }
+        }
+    }
+
+    /**
+     * add archive entry to the scatterOutputStream
+     */
+    private void addEntry(String filePath, File file, ZipArchiveScatterOutputStream scatterOutputStream, int method) {
+        final ZipArchiveEntry archiveEntry = new ZipArchiveEntry(filePath);
+        archiveEntry.setMethod(method);
+        scatterOutputStream.addEntry(archiveEntry, () -> {
+            try {
+                return file.isDirectory() ? new NullInputStream(0) :
+                                                    new BufferedInputStream(new FileInputStream(file));
+            } catch (FileNotFoundException e) {
+                e.printStackTrace();
+            }
+            return null;
+        });
+    }
+
+    /**
+     * unzip the archive entry to targetDir
+     */
+    private void unZipFile(ZipFile zipFile, ZipArchiveEntry entry, String targetDir) throws IOException {
+        final File targetFile = new File(Paths.get(targetDir, entry.getName()).toString());
+        FileUtils.forceMkdir(targetFile.getParentFile());
+        try (final InputStream is = zipFile.getInputStream(entry);
+                final BufferedInputStream fis = new BufferedInputStream(is);
+                final BufferedOutputStream bos = new BufferedOutputStream(new FileOutputStream(targetFile))) {
+            IOUtils.copy(fis, bos);
+        }
+    }
+
+    /**
+     * compute the value of checksum
+     */
+    private void computeZipFileChecksumValue(String zipPath, Checksum checksum) throws IOException {
+        File file = new File(zipPath);
+        if (!file.exists())
+            return;
+        byte[] buffer = new byte[8192];
+        try (final ZipFile zipFile = new ZipFile(file)) {
+            final ArrayList<ZipArchiveEntry> zipEntries = Collections.list(zipFile.getEntries());
+            for (ZipArchiveEntry zipEntry : zipEntries) {
+                try (final InputStream is = zipFile.getRawInputStream(zipEntry);
+                        final BufferedInputStream fis = new BufferedInputStream(is)) {
+                    int length = 0;
+                    while (-1 != (length = fis.read(buffer))) {
+                        checksum.update(buffer, 0, length);
+                    }
+                }
+            }
+        }
+    }
+
+    @Override
+    public boolean init(ParallelZipStrategy opts) {
+        return true;
+    }
+
+    @Override
+    public void shutdown() {
+        this.deCompressExecutor.shutdown();
+        ExecutorServiceHelper.shutdownAndAwaitTermination(this.deCompressExecutor);
+    }
+}

--- a/jraft-rheakv/rheakv-core/src/main/java/com/alipay/sofa/jraft/rhea/storage/zip/ParallelZipStrategy.java
+++ b/jraft-rheakv/rheakv-core/src/main/java/com/alipay/sofa/jraft/rhea/storage/zip/ParallelZipStrategy.java
@@ -61,9 +61,9 @@ public class ParallelZipStrategy implements ZipStrategy {
     private final int           compressThreads;
     private final int           deCompressThreads;
 
-    public ParallelZipStrategy(final int compressCoreThreads, final int deCompressCoreThreads) {
-        this.compressThreads = compressCoreThreads;
-        this.deCompressThreads = deCompressCoreThreads;
+    public ParallelZipStrategy(final int compressThreads, final int deCompressThreads) {
+        this.compressThreads = compressThreads;
+        this.deCompressThreads = deCompressThreads;
     }
 
     /**

--- a/jraft-rheakv/rheakv-core/src/main/java/com/alipay/sofa/jraft/rhea/storage/zip/ZipStrategy.java
+++ b/jraft-rheakv/rheakv-core/src/main/java/com/alipay/sofa/jraft/rhea/storage/zip/ZipStrategy.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alipay.sofa.jraft.rhea.storage.zip;
+
+import java.io.IOException;
+import java.util.zip.Checksum;
+
+/**
+ * @author hzh
+ */
+public interface ZipStrategy {
+
+    /**
+     * Compress files to zip
+     *
+     * @param rootDir    the origin file root dir
+     * @param sourceDir  the origin file source dir
+     * @param outputZipFile the target zip file
+     * @param checksum   checksum
+     */
+    public void compress(final String rootDir, final String sourceDir, final String outputZipFile,
+                         final Checksum checksum) throws IOException;
+
+    /**
+     * Decompress zip to files
+     *
+     * @param sourceZipFile the origin zip file
+     * @param outputDir  the target file dir
+     * @param checksum   checksum
+     */
+    public void deCompress(final String sourceZipFile, final String outputDir, final Checksum checksum)
+                                                                                                       throws IOException;
+
+}

--- a/jraft-rheakv/rheakv-core/src/main/java/com/alipay/sofa/jraft/rhea/storage/zip/ZipStrategy.java
+++ b/jraft-rheakv/rheakv-core/src/main/java/com/alipay/sofa/jraft/rhea/storage/zip/ZipStrategy.java
@@ -43,14 +43,4 @@ public interface ZipStrategy {
      */
     void deCompress(final String sourceZipFile, final String outputDir, final Checksum checksum) throws Throwable;
 
-    /**
-     * Initialize.
-     */
-    boolean init();
-
-    /**
-     * Dispose the resources.
-     */
-    void shutdown();
-
 }

--- a/jraft-rheakv/rheakv-core/src/main/java/com/alipay/sofa/jraft/rhea/storage/zip/ZipStrategy.java
+++ b/jraft-rheakv/rheakv-core/src/main/java/com/alipay/sofa/jraft/rhea/storage/zip/ZipStrategy.java
@@ -16,7 +16,6 @@
  */
 package com.alipay.sofa.jraft.rhea.storage.zip;
 
-import java.io.IOException;
 import java.util.zip.Checksum;
 
 /**
@@ -32,8 +31,8 @@ public interface ZipStrategy {
      * @param outputZipFile the target zip file
      * @param checksum   checksum
      */
-    public void compress(final String rootDir, final String sourceDir, final String outputZipFile,
-                         final Checksum checksum) throws IOException;
+    void compress(final String rootDir, final String sourceDir, final String outputZipFile, final Checksum checksum)
+                                                                                                                    throws Throwable;
 
     /**
      * Decompress zip to files
@@ -42,7 +41,16 @@ public interface ZipStrategy {
      * @param outputDir  the target file dir
      * @param checksum   checksum
      */
-    public void deCompress(final String sourceZipFile, final String outputDir, final Checksum checksum)
-                                                                                                       throws IOException;
+    void deCompress(final String sourceZipFile, final String outputDir, final Checksum checksum) throws Throwable;
+
+    /**
+     * Initialize.
+     */
+    boolean init();
+
+    /**
+     * Dispose the resources.
+     */
+    void shutdown();
 
 }

--- a/jraft-rheakv/rheakv-core/src/main/java/com/alipay/sofa/jraft/rhea/storage/zip/ZipStrategyManager.java
+++ b/jraft-rheakv/rheakv-core/src/main/java/com/alipay/sofa/jraft/rhea/storage/zip/ZipStrategyManager.java
@@ -48,7 +48,7 @@ public final class ZipStrategyManager {
         return zipStrategies[DEFAULT_STRATEGY];
     }
 
-    public static void init(RheaKVStoreOptions opts) {
+    public static void init(final RheaKVStoreOptions opts) {
         //add parallel zip strategy
         if (opts.isUseParallelCompress()) {
             if (zipStrategies[PARALLEL_STRATEGY] != null) {

--- a/jraft-rheakv/rheakv-core/src/main/java/com/alipay/sofa/jraft/rhea/storage/zip/ZipStrategyManager.java
+++ b/jraft-rheakv/rheakv-core/src/main/java/com/alipay/sofa/jraft/rhea/storage/zip/ZipStrategyManager.java
@@ -1,0 +1,54 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alipay.sofa.jraft.rhea.storage.zip;
+
+/**
+ * @author hzh
+ */
+public final class ZipStrategyManager {
+    private static ZipStrategy[] zipStrategies     = new ZipStrategy[5];
+    public static final byte     JDK_STRATEGY      = 1;
+    public static final byte     PARALLEL_STRATEGY = 2;
+
+    static {
+        addZipStrategy(JDK_STRATEGY, new JDKZipStrategy());
+    }
+
+    public static void addZipStrategy(int idx, ZipStrategy zipStrategy) {
+        if (zipStrategies.length <= idx) {
+            final ZipStrategy[] newZipStrategies = new ZipStrategy[idx + 5];
+            System.arraycopy(zipStrategies, 0, newZipStrategies, 0, zipStrategies.length);
+            zipStrategies = newZipStrategies;
+        }
+        zipStrategies[idx] = zipStrategy;
+    }
+
+    public static ZipStrategy getZipStrategy(int idx) {
+        return zipStrategies[idx];
+    }
+
+    public static ZipStrategy getDefault() {
+        if (zipStrategies[PARALLEL_STRATEGY] != null) {
+            System.out.println("get parallel zip strategy");
+            return zipStrategies[PARALLEL_STRATEGY];
+        }
+        return zipStrategies[JDK_STRATEGY];
+    }
+
+    private ZipStrategyManager() {
+    }
+}

--- a/jraft-rheakv/rheakv-core/src/main/java/com/alipay/sofa/jraft/rhea/storage/zip/ZipStrategyManager.java
+++ b/jraft-rheakv/rheakv-core/src/main/java/com/alipay/sofa/jraft/rhea/storage/zip/ZipStrategyManager.java
@@ -48,26 +48,19 @@ public final class ZipStrategyManager {
         return zipStrategies[DEFAULT_STRATEGY];
     }
 
-    private ZipStrategyManager() {
-    }
-
-    public static boolean init(final RheaKVStoreOptions opts) {
-        // add parallel zip strategy if necessary
+    public static void init(RheaKVStoreOptions opts) {
+        //add parallel zip strategy
         if (opts.isUseParallelCompress()) {
-            final ParallelZipStrategy parallelZipStrategy = new ParallelZipStrategy(opts.getCompressThreads(),
-                opts.getDeCompressThreads());
-            parallelZipStrategy.init();
-            addZipStrategy(PARALLEL_STRATEGY, parallelZipStrategy);
-            DEFAULT_STRATEGY = PARALLEL_STRATEGY;
-        }
-        return true;
-    }
-
-    public static void shutdown() {
-        for (final ZipStrategy zipStrategy : zipStrategies) {
-            if (zipStrategy != null) {
-                zipStrategy.shutdown();
+            if (zipStrategies[PARALLEL_STRATEGY] != null) {
+                final ZipStrategy zipStrategy = new ParallelZipStrategy(opts.getCompressThreads(),
+                    opts.getDeCompressThreads());
+                ZipStrategyManager.addZipStrategy(ZipStrategyManager.PARALLEL_STRATEGY, zipStrategy);
+                DEFAULT_STRATEGY = PARALLEL_STRATEGY;
             }
         }
     }
+
+    private ZipStrategyManager() {
+    }
+
 }

--- a/jraft-rheakv/rheakv-core/src/main/java/com/alipay/sofa/jraft/rhea/storage/zip/ZipStrategyManager.java
+++ b/jraft-rheakv/rheakv-core/src/main/java/com/alipay/sofa/jraft/rhea/storage/zip/ZipStrategyManager.java
@@ -49,7 +49,7 @@ public final class ZipStrategyManager {
     }
 
     public static void init(final RheaKVStoreOptions opts) {
-        //add parallel zip strategy
+        // add parallel zip strategy
         if (opts.isUseParallelCompress()) {
             if (zipStrategies[PARALLEL_STRATEGY] != null) {
                 final ZipStrategy zipStrategy = new ParallelZipStrategy(opts.getCompressThreads(),

--- a/jraft-rheakv/rheakv-core/src/main/java/com/alipay/sofa/jraft/rhea/storage/zip/ZipStrategyManager.java
+++ b/jraft-rheakv/rheakv-core/src/main/java/com/alipay/sofa/jraft/rhea/storage/zip/ZipStrategyManager.java
@@ -31,7 +31,7 @@ public final class ZipStrategyManager {
         addZipStrategy(JDK_STRATEGY, new JDKZipStrategy());
     }
 
-    public static void addZipStrategy(int idx, ZipStrategy zipStrategy) {
+    public static void addZipStrategy(final int idx, final ZipStrategy zipStrategy) {
         if (zipStrategies.length <= idx) {
             final ZipStrategy[] newZipStrategies = new ZipStrategy[idx + 5];
             System.arraycopy(zipStrategies, 0, newZipStrategies, 0, zipStrategies.length);
@@ -40,7 +40,7 @@ public final class ZipStrategyManager {
         zipStrategies[idx] = zipStrategy;
     }
 
-    public static ZipStrategy getZipStrategy(int idx) {
+    public static ZipStrategy getZipStrategy(final int idx) {
         return zipStrategies[idx];
     }
 
@@ -51,10 +51,10 @@ public final class ZipStrategyManager {
     private ZipStrategyManager() {
     }
 
-    public static boolean init(RheaKVStoreOptions opts) {
+    public static boolean init(final RheaKVStoreOptions opts) {
         // add parallel zip strategy if necessary
         if (opts.isUseParallelCompress()) {
-            ParallelZipStrategy parallelZipStrategy = new ParallelZipStrategy(opts.getCompressThreads(),
+            final ParallelZipStrategy parallelZipStrategy = new ParallelZipStrategy(opts.getCompressThreads(),
                 opts.getDeCompressThreads());
             parallelZipStrategy.init();
             addZipStrategy(PARALLEL_STRATEGY, parallelZipStrategy);
@@ -64,7 +64,7 @@ public final class ZipStrategyManager {
     }
 
     public static void shutdown() {
-        for (ZipStrategy zipStrategy : zipStrategies) {
+        for (final ZipStrategy zipStrategy : zipStrategies) {
             if (zipStrategy != null) {
                 zipStrategy.shutdown();
             }

--- a/jraft-rheakv/rheakv-core/src/test/java/com/alipay/sofa/jraft/rhea/storage/zip/JDKZipStrategyTest.java
+++ b/jraft-rheakv/rheakv-core/src/test/java/com/alipay/sofa/jraft/rhea/storage/zip/JDKZipStrategyTest.java
@@ -16,7 +16,6 @@
  */
 package com.alipay.sofa.jraft.rhea.storage.zip;
 
-import com.alipay.sofa.jraft.rhea.util.ZipUtil;
 import com.alipay.sofa.jraft.util.CRC64;
 import org.apache.commons.io.FileUtils;
 import org.junit.After;
@@ -32,8 +31,6 @@ import java.util.zip.Checksum;
 
 /**
  * @author hzh
- * @version 1.0
- * @date 2021/6/7 11:10
  */
 public class JDKZipStrategyTest {
     private File        sourceDir;
@@ -73,7 +70,7 @@ public class JDKZipStrategyTest {
     }
 
     @Test
-    public void zipTest() throws IOException {
+    public void zipTest() throws Throwable {
         final String rootPath = this.sourceDir.toPath().toAbsolutePath().getParent().toString();
         final Path outPath = Paths.get(rootPath, "kv.zip");
         final Checksum c1 = new CRC64();

--- a/jraft-rheakv/rheakv-core/src/test/java/com/alipay/sofa/jraft/rhea/storage/zip/JDKZipStrategyTest.java
+++ b/jraft-rheakv/rheakv-core/src/test/java/com/alipay/sofa/jraft/rhea/storage/zip/JDKZipStrategyTest.java
@@ -1,0 +1,91 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alipay.sofa.jraft.rhea.storage.zip;
+
+import com.alipay.sofa.jraft.rhea.util.ZipUtil;
+import com.alipay.sofa.jraft.util.CRC64;
+import org.apache.commons.io.FileUtils;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.zip.Checksum;
+
+/**
+ * @author hzh
+ * @version 1.0
+ * @date 2021/6/7 11:10
+ */
+public class JDKZipStrategyTest {
+    private File        sourceDir;
+
+    private ZipStrategy zipStrategy;
+
+    @Before
+    public void startup() throws IOException {
+        this.sourceDir = new File("zip_test");
+        this.zipStrategy = new JDKZipStrategy();
+
+        if (this.sourceDir.exists()) {
+            FileUtils.forceDelete(this.sourceDir);
+        }
+        FileUtils.forceMkdir(this.sourceDir);
+        final File f1 = Paths.get(this.sourceDir.getAbsolutePath(), "f1").toFile();
+        FileUtils.write(f1, "f1");
+        final File d1 = Paths.get(this.sourceDir.getAbsolutePath(), "d1").toFile();
+        FileUtils.forceMkdir(d1);
+        final File f11 = Paths.get(d1.getAbsolutePath(), "f11").toFile();
+        FileUtils.write(f11, "f11");
+
+        final File d2 = Paths.get(d1.getAbsolutePath(), "d2").toFile();
+        FileUtils.forceMkdir(d2);
+
+        final File d3 = Paths.get(d2.getAbsolutePath(), "d3").toFile();
+        FileUtils.forceMkdir(d3);
+
+        final File f31 = Paths.get(d3.getAbsolutePath(), "f31").toFile();
+        FileUtils.write(f31, "f32");
+
+    }
+
+    @After
+    public void teardown() throws IOException {
+        FileUtils.forceDelete(this.sourceDir);
+    }
+
+    @Test
+    public void zipTest() throws IOException {
+        final String rootPath = this.sourceDir.toPath().toAbsolutePath().getParent().toString();
+        final Path outPath = Paths.get(rootPath, "kv.zip");
+        final Checksum c1 = new CRC64();
+        zipStrategy.compress(rootPath, "zip_test", outPath.toString(), c1);
+
+        System.out.println(Long.toHexString(c1.getValue()));
+
+        final Checksum c2 = new CRC64();
+        zipStrategy.deCompress(Paths.get(rootPath, "kv.zip").toString(), rootPath, c2);
+
+        Assert.assertEquals(c1.getValue(), c2.getValue());
+
+        FileUtils.forceDelete(outPath.toFile());
+    }
+}

--- a/jraft-rheakv/rheakv-core/src/test/java/com/alipay/sofa/jraft/rhea/storage/zip/ParallelZipStrategyTest.java
+++ b/jraft-rheakv/rheakv-core/src/test/java/com/alipay/sofa/jraft/rhea/storage/zip/ParallelZipStrategyTest.java
@@ -1,0 +1,89 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alipay.sofa.jraft.rhea.storage.zip;
+
+import com.alipay.sofa.jraft.rhea.util.ZipUtil;
+import com.alipay.sofa.jraft.util.CRC64;
+import org.apache.commons.io.FileUtils;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.zip.Checksum;
+
+/**
+ * @author hzh
+ * @version 1.0
+ * @date 2021/6/7 11:11
+ */
+public class ParallelZipStrategyTest {
+    private File        sourceDir;
+    private ZipStrategy zipStrategy;
+
+    @Before
+    public void startup() throws IOException {
+        this.sourceDir = new File("zip_test");
+        this.zipStrategy = new ParallelZipStrategy(8, 6);
+
+        if (this.sourceDir.exists()) {
+            FileUtils.forceDelete(this.sourceDir);
+        }
+        FileUtils.forceMkdir(this.sourceDir);
+        final File f1 = Paths.get(this.sourceDir.getAbsolutePath(), "f1").toFile();
+        FileUtils.write(f1, "f1");
+        final File d1 = Paths.get(this.sourceDir.getAbsolutePath(), "d1").toFile();
+        FileUtils.forceMkdir(d1);
+        final File f11 = Paths.get(d1.getAbsolutePath(), "f11").toFile();
+        FileUtils.write(f11, "f11");
+
+        final File d2 = Paths.get(d1.getAbsolutePath(), "d2").toFile();
+        FileUtils.forceMkdir(d2);
+
+        final File d3 = Paths.get(d2.getAbsolutePath(), "d3").toFile();
+        FileUtils.forceMkdir(d3);
+
+        final File f31 = Paths.get(d3.getAbsolutePath(), "f31").toFile();
+        FileUtils.write(f31, "f32");
+    }
+
+    @After
+    public void teardown() throws IOException {
+        FileUtils.forceDelete(this.sourceDir);
+    }
+
+    @Test
+    public void zipTest() throws IOException {
+        final String rootPath = this.sourceDir.toPath().toAbsolutePath().getParent().toString();
+        final Path outPath = Paths.get(rootPath, "kv.zip");
+        final Checksum c1 = new CRC64();
+        zipStrategy.compress(rootPath, "zip_test", outPath.toString(), c1);
+
+        System.out.println(Long.toHexString(c1.getValue()));
+
+        final Checksum c2 = new CRC64();
+        zipStrategy.deCompress(Paths.get(rootPath, "kv.zip").toString(), rootPath, c2);
+
+        Assert.assertEquals(c1.getValue(), c2.getValue());
+
+        FileUtils.forceDelete(outPath.toFile());
+    }
+}

--- a/jraft-rheakv/rheakv-core/src/test/java/com/alipay/sofa/jraft/rhea/storage/zip/ParallelZipStrategyTest.java
+++ b/jraft-rheakv/rheakv-core/src/test/java/com/alipay/sofa/jraft/rhea/storage/zip/ParallelZipStrategyTest.java
@@ -16,7 +16,6 @@
  */
 package com.alipay.sofa.jraft.rhea.storage.zip;
 
-import com.alipay.sofa.jraft.rhea.util.ZipUtil;
 import com.alipay.sofa.jraft.util.CRC64;
 import org.apache.commons.io.FileUtils;
 import org.junit.After;
@@ -32,8 +31,6 @@ import java.util.zip.Checksum;
 
 /**
  * @author hzh
- * @version 1.0
- * @date 2021/6/7 11:11
  */
 public class ParallelZipStrategyTest {
     private File        sourceDir;
@@ -42,7 +39,8 @@ public class ParallelZipStrategyTest {
     @Before
     public void startup() throws IOException {
         this.sourceDir = new File("zip_test");
-        this.zipStrategy = new ParallelZipStrategy(8, 6);
+        this.zipStrategy = new ParallelZipStrategy(9, 6);
+        zipStrategy.init();
 
         if (this.sourceDir.exists()) {
             FileUtils.forceDelete(this.sourceDir);
@@ -67,11 +65,12 @@ public class ParallelZipStrategyTest {
 
     @After
     public void teardown() throws IOException {
+        zipStrategy.shutdown();
         FileUtils.forceDelete(this.sourceDir);
     }
 
     @Test
-    public void zipTest() throws IOException {
+    public void zipTest() throws Throwable {
         final String rootPath = this.sourceDir.toPath().toAbsolutePath().getParent().toString();
         final Path outPath = Paths.get(rootPath, "kv.zip");
         final Checksum c1 = new CRC64();

--- a/jraft-rheakv/rheakv-core/src/test/java/com/alipay/sofa/jraft/rhea/storage/zip/ParallelZipStrategyTest.java
+++ b/jraft-rheakv/rheakv-core/src/test/java/com/alipay/sofa/jraft/rhea/storage/zip/ParallelZipStrategyTest.java
@@ -40,7 +40,6 @@ public class ParallelZipStrategyTest {
     public void startup() throws IOException {
         this.sourceDir = new File("zip_test");
         this.zipStrategy = new ParallelZipStrategy(9, 6);
-        zipStrategy.init();
 
         if (this.sourceDir.exists()) {
             FileUtils.forceDelete(this.sourceDir);
@@ -65,7 +64,6 @@ public class ParallelZipStrategyTest {
 
     @After
     public void teardown() throws IOException {
-        zipStrategy.shutdown();
         FileUtils.forceDelete(this.sourceDir);
     }
 

--- a/pom.xml
+++ b/pom.xml
@@ -51,6 +51,7 @@
         <affinity.version>3.1.7</affinity.version>
         <asm.version>6.0</asm.version>
         <bolt.version>1.6.2</bolt.version>
+        <commons.compress.version>1.20</commons.compress.version>
         <commons.io.version>2.8.0</commons.io.version>
         <commons.lang.version>2.6</commons.lang.version>
         <disruptor.version>3.3.7</disruptor.version>
@@ -173,6 +174,11 @@
                 <groupId>commons-io</groupId>
                 <artifactId>commons-io</artifactId>
                 <version>${commons.io.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.commons</groupId>
+                <artifactId>commons-compress</artifactId>
+                <version>${commons.compress.version}</version>
             </dependency>
             <dependency>
                 <groupId>commons-lang</groupId>


### PR DESCRIPTION
# 并行压缩项目报告

## 1.引言

### 1.1 任务内容

​    在rheakv启动过程中,因snapshot压缩文件较大,导致长时间停留在解压缩的过程,严重的影响了系统的启动速度。同样,在安装snapshot的过程中,单线程压缩大文件也会影响性能.

​    为此,需要引入并行解压缩和并行压缩,来优化关于snapshot的压缩和解压缩的速度

### 1.2    参考资料

- [apache common-compress](https://commons.apache.org/proper/commons-compress/apidocs/org/apache/commons/compress/archivers/zip/class-use/ParallelScatterZipCreator.html)

## 2.设计思路

### 2.1 代码思路

1.对于压缩而言:

- Java自带ZipEntity压缩方式比较慢,会严重影响压缩效率。

- commons-compress实现的多线程压缩方式效率足够高，但使用不当会占满当前服务器的CPU,导致压缩过程CPU占用率过高,严重影响正常的raft服务.

  因此,可以通过控制ParallelScatterZipCreator类所使用的线程池的线程数,控制压缩所需占用的CPU,在提升压缩性能的同时减少对正常业务的影响
  当然,具体的线程数需要经过测试

2.对于解压缩而言:

- commons-compress提供了ZipFile这个类,用于读取压缩文件,并可以返回该压缩文件中的每一个文件条目ZipEntry,每一个ZipEntry可以单独的解压.为此,我想同样可以通过线程池的方式,将解压ZipEntry的任务投递到线程池中执行.

### 2.2 代码说明

1.首先,为了压缩方式的可扩展性,我采用了策略模式,现共有两种压缩方式:jdk原生的压缩(也即ZipUtil的代码)和基于common-compress的并行压缩.并在ZipStrategyManager中统一管理:

![image-20210608012602263](https://gitee.com/zisuu/picture/raw/master/img/20210608012623.png)

2.同时,增加了三个配置项,存放在RheaKVStoreOptions中:

![image-20210604003334084](https://gitee.com/zisuu/picture/raw/master/img/20210604003334.png)

compressCoreThreads和deCompressCoreThreads可由用户根据自己的服务器进行配置管理,后文有给出默认线程数的测试报告

3.另外,我并没有对原有的代码有太大的改动,只是在AbstractKVStoreSnapshotFile类中修改了压缩和解压缩涉及的一行代码:

代码对比:

![image-20210608012939981](https://gitee.com/zisuu/picture/raw/master/img/20210608012940.png)



![](https://gitee.com/zisuu/picture/raw/master/img/20210608013026.png)

### 2.3 开启并行压缩

可以通过以下配置开启并行压缩和解压缩:

```
final RheaKVStoreOptions opts = RheaKVStoreOptionsConfigured.newConfigured() //
        .withClusterName(Configs.CLUSTER_NAME) //
        .withUseParallelCompress(true) //开启并行压缩和解压缩
        .withCompressCoreThreads(6) //并行压缩线程数
        .withDeCompressCoreThreads(8) //并行解压缩线程数
        .withInitialServerList(Configs.ALL_NODE_ADDRESSES)
        .withStoreEngineOptions(storeOpts) //
        .withPlacementDriverOptions(pdOpts) //
        .config();
```

## 3.性能测试

### 3.1 性能对比

**测试环境**

- 操作系统 :window
- cpu: 8核
- 内存: 24g
- 磁盘: SSD
- 测试文件夹总大小:**20G**

**JDK原生方式**

JDK原生方式(也即ZipUtil中的代码):

压缩该文件夹需要的时间为: 15分钟

解压缩该文件夹的时间为: 16 分钟

**并行方式**

设定压缩和解压缩的线程数都为6核:

压缩该文件夹需要的时间为: 4.5分钟

解压缩该文件夹的时间为: 3.5分钟

可以发现,使用并行压缩和解压缩性能大大的提升了

### 3.2 并行压缩线程数测试

**测试环境**

- 操作系统 :window
- cpu: 8核
- 内存: 24g
- 磁盘: SSD
- 测试文件夹总大小:**10G**

接下来,我们将测试在不同线程数下,并行压缩的时间,以寻求最快的压缩时间和最适合的线程数

**代码**

![image-20210603010539177](https://gitee.com/zisuu/picture/raw/master/img/20210603010539.png)

**结果**

```
使用 8 线程，压缩耗时：125秒
使用 7 线程，压缩耗时：121秒
使用 6 线程，压缩耗时：117秒
使用 5 线程，压缩耗时：135秒
使用 4 线程，压缩耗时：153秒
使用 3 线程，压缩耗时：200秒
使用 2 线程，压缩耗时：250秒
使用 1 线程，压缩耗时：320秒
```

可以发现,在使用6线程,也即当 compressCoreThreads = 75% × cpu 时,压缩时间最短

### 3.3  并行解压缩线程数测试

**测试环境**

- 操作系统 :window
- cpu: 8核
- 内存: 24g
- 磁盘: SSD
- 测试文件夹总大小:**10G**

**代码**

![image-20210603010511553](https://gitee.com/zisuu/picture/raw/master/img/20210603010511.png)

**结果**

```
使用 13 线程，解压缩耗时：183秒
使用 12 线程，解压缩耗时：182秒
使用 11 线程，解压缩耗时：180秒
使用 10 线程，解压缩耗时：186秒
使用 9  线程，解压缩耗时：189秒
使用 8  线程，解压缩耗时：103秒
使用 7  线程，解压缩耗时：164秒
使用 6  线程，压缩耗时：186秒
......
```

可以发现,在大于8线程时,时间变化不大,8线程时耗时最小,小于8线程耗时又增多

## 4. 测试结论

经过第3步的性能测试,得出一下结论:

compressCoreThreads = 75% × cpu 

deCompressCoreThreads = 100% × cpu

例如,当cpu数为8核,压缩线程数为6核最合适,解压缩线程为8核最合适

考虑到当项目时,rheakv需要deCompress snapshot后才能正常运行,因此,可以考虑将解压缩线程数设置为接近100%CPU数(具体的由用户所决定)

## 5.所遇问题与解决方案

### 5.1 checksum

#### 问题

在测试过程中,发现,如果用以下的方式进行并行压缩和解压缩,二者算出来的checksum会不一致:

注

```
压缩:
//write to and flush
try (final BufferedOutputStream bos = new BufferedOutputStream(new FileOutputStream(zipFile));
        final CheckedOutputStream cos  = new CheckedOutputStream(bos, checksum);
        final ZipArchiveOutputStream archiveOutput = new ZipArchiveOutputStream(cos)) {
    scatterOutput.writeTo(archiveOutput);
    archiveOutput.flush();
} catch (Exception e) {
    e.printStackTrace();
}


```

```
解压缩:
/**
 * unzip the archive entry to targetDir
 */
private void unZipFile(ZipFile zipFile, ZipArchiveEntry entry, String targetDir) throws IOException {
    final File targetFile = new File(Paths.get(targetDir, entry.getName()).toString());
    FileUtils.forceMkdir(targetFile.getParentFile());
    try (final InputStream is = zipFile.getInputStream(entry);
         final BufferedInputStream fis = new BufferedInputStream(is);
            final CheckedInputStream cis = new CheckedInputStream(fis, checksum);
            final BufferedOutputStream bos = new BufferedOutputStream(new FileOutputStream(targetFile))) {
        IOUtils.copy(fis, bos);
    }
}
```

注:即使解压缩是单线程的,也会不一致

我在[ISSUE](https://github.com/sofastack/sofa-jraft/issues/569) 中提出了发生该问题的原因:

因为common-compress包在压缩文件的过程中,会同时写入header+content

而我们解压缩的过程,是只读取了content,而无法读取header,导致二者计算出来的checksum不一致

#### 解决方案(目前)

目前的解决方案比较粗暴,是在压缩和解压缩完之后,再读取一遍zip文件中每一个文件的content的流,计算checksum,如下:

```
/**
 * compute the value of checksum
 */
private void computeZipFileChecksumValue(String zipPath, Checksum checksum) throws IOException {
    File file = new File(zipPath);
    if (!file.exists())
        return;
    byte[] buffer = new byte[8192];
    try (final ZipFile zipFile = new ZipFile(file)) {
        final ArrayList<ZipArchiveEntry> zipEntries = Collections.list(zipFile.getEntries());
        for (ZipArchiveEntry zipEntry : zipEntries) {
            try (final InputStream is = zipFile.getRawInputStream(zipEntry);
                    final BufferedInputStream fis = new BufferedInputStream(is)) {
                int length = 0;
                while (-1 != (length = fis.read(buffer))) {
                    checksum.update(buffer, 0, length);
                }
            }
        }
    }
}
```

#### 改进方案

解压缩的过程,不重新再读取一遍zip文件.而是在解压缩的过程中,先并行解压缩,然后按照顺序依次计算每一个content流的checksum,这里可能需要借鉴一下fork-join框架的流程

至于并行压缩过程,目前还没有想到什么解决方案..


## 6.结语

现在代码需要改进的就是如何在并行压缩和解压缩的过程中就计算好checksum

初次贡献代码,做的不好的地方,敬请谅解,我会尽快修改!谢谢!





