### PR TITLE
Move the unmap function of the SegmentFile to Utils

### DIFF
--- a/jraft-core/src/main/java/com/alipay/sofa/jraft/util/Utils.java
+++ b/jraft-core/src/main/java/com/alipay/sofa/jraft/util/Utils.java
@@ -392,7 +392,7 @@ public final class Utils {
     }
 
     /**
-     * un map file
+     * Unmap mappedByteBuffer
      * See https://stackoverflow.com/questions/2972986/how-to-unmap-a-file-from-memory-mapped-using-filechannel-in-java
      */
     public static void unmap(final MappedByteBuffer cb) {

--- a/jraft-core/src/main/java/com/alipay/sofa/jraft/util/Utils.java
+++ b/jraft-core/src/main/java/com/alipay/sofa/jraft/util/Utils.java
@@ -20,8 +20,11 @@ import java.io.Closeable;
 import java.io.File;
 import java.io.IOException;
 import java.lang.management.ManagementFactory;
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
 import java.net.InetAddress;
 import java.nio.ByteBuffer;
+import java.nio.MappedByteBuffer;
 import java.nio.channels.FileChannel;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.AtomicMoveNotSupportedException;
@@ -385,6 +388,41 @@ public final class Utils {
         try (final FileChannel fc = FileChannel.open(file.toPath(), isDir ? StandardOpenOption.READ
             : StandardOpenOption.WRITE)) {
             fc.force(true);
+        }
+    }
+
+    /**
+     * un map file
+     * See https://stackoverflow.com/questions/2972986/how-to-unmap-a-file-from-memory-mapped-using-filechannel-in-java
+     */
+    public static void unmap(final MappedByteBuffer cb) {
+        // JavaSpecVer: 1.6, 1.7, 1.8, 9, 10
+        final boolean isOldJDK = System.getProperty("java.specification.version", "99").startsWith("1.");
+        try {
+            if (isOldJDK) {
+                final Method cleaner = cb.getClass().getMethod("cleaner");
+                cleaner.setAccessible(true);
+                final Method clean = Class.forName("sun.misc.Cleaner").getMethod("clean");
+                clean.setAccessible(true);
+                clean.invoke(cleaner.invoke(cb));
+            } else {
+                Class unsafeClass;
+                try {
+                    unsafeClass = Class.forName("sun.misc.Unsafe");
+                } catch (final Exception ex) {
+                    // jdk.internal.misc.Unsafe doesn't yet have an invokeCleaner() method,
+                    // but that method should be added if sun.misc.Unsafe is removed.
+                    unsafeClass = Class.forName("jdk.internal.misc.Unsafe");
+                }
+                final Method clean = unsafeClass.getMethod("invokeCleaner", ByteBuffer.class);
+                clean.setAccessible(true);
+                final Field theUnsafeField = unsafeClass.getDeclaredField("theUnsafe");
+                theUnsafeField.setAccessible(true);
+                final Object theUnsafe = theUnsafeField.get(null);
+                clean.invoke(theUnsafe, cb);
+            }
+        } catch (final Exception ex) {
+            LOG.error("Fail to un-mapped segment file.", ex);
         }
     }
 


### PR DESCRIPTION
Move the function of unmap in SegmentFile to Utils
As todo:
![image](https://user-images.githubusercontent.com/58988019/123548198-61c07080-d796-11eb-8ee1-c3b82f7a71c0.png)



This function will be reused by the SegmentFile and the upcoming OffsetIndex of the SegmentFile