### PR TITLE
(feat) Snapshot file to interrupt concurrent transmission(#503)

### DIFF
--- a/jraft-core/src/main/java/com/alipay/sofa/jraft/entity/LocalFileMetaOutter.java
+++ b/jraft-core/src/main/java/com/alipay/sofa/jraft/entity/LocalFileMetaOutter.java
@@ -154,6 +154,16 @@ public final class LocalFileMetaOutter {
          * <code>optional string checksum = 3;</code>
          */
         com.google.protobuf.ByteString getChecksumBytes();
+
+        /**
+         * <code>optional int32 sliceTotal = 4;</code>
+         */
+        boolean hasSliceTotal();
+
+        /**
+         * <code>optional int32 sliceTotal = 4;</code>
+         */
+        int getSliceTotal();
     }
 
     /**
@@ -173,6 +183,7 @@ public final class LocalFileMetaOutter {
             userMeta_ = com.google.protobuf.ByteString.EMPTY;
             source_ = 0;
             checksum_ = "";
+            sliceTotal_ = 0;
         }
 
         @java.lang.Override
@@ -225,6 +236,11 @@ public final class LocalFileMetaOutter {
                             com.google.protobuf.ByteString bs = input.readBytes();
                             bitField0_ |= 0x00000004;
                             checksum_ = bs;
+                            break;
+                        }
+                        case 32: {
+                            bitField0_ |= 0x00000008;
+                            sliceTotal_ = input.readInt32();
                             break;
                         }
                     }
@@ -328,6 +344,23 @@ public final class LocalFileMetaOutter {
             }
         }
 
+        public static final int SLICETOTAL_FIELD_NUMBER = 4;
+        private int             sliceTotal_;
+
+        /**
+         * <code>optional int32 sliceTotal = 4;</code>
+         */
+        public boolean hasSliceTotal() {
+            return ((bitField0_ & 0x00000008) == 0x00000008);
+        }
+
+        /**
+         * <code>optional int32 sliceTotal = 4;</code>
+         */
+        public int getSliceTotal() {
+            return sliceTotal_;
+        }
+
         private byte memoizedIsInitialized = -1;
 
         public final boolean isInitialized() {
@@ -351,6 +384,9 @@ public final class LocalFileMetaOutter {
             if (((bitField0_ & 0x00000004) == 0x00000004)) {
                 com.google.protobuf.GeneratedMessageV3.writeString(output, 3, checksum_);
             }
+            if (((bitField0_ & 0x00000008) == 0x00000008)) {
+                output.writeInt32(4, sliceTotal_);
+            }
             unknownFields.writeTo(output);
         }
 
@@ -368,6 +404,9 @@ public final class LocalFileMetaOutter {
             }
             if (((bitField0_ & 0x00000004) == 0x00000004)) {
                 size += com.google.protobuf.GeneratedMessageV3.computeStringSize(3, checksum_);
+            }
+            if (((bitField0_ & 0x00000008) == 0x00000008)) {
+                size += com.google.protobuf.CodedOutputStream.computeInt32Size(4, sliceTotal_);
             }
             size += unknownFields.getSerializedSize();
             memoizedSize = size;
@@ -397,6 +436,10 @@ public final class LocalFileMetaOutter {
             if (hasChecksum()) {
                 result = result && getChecksum().equals(other.getChecksum());
             }
+            result = result && (hasSliceTotal() == other.hasSliceTotal());
+            if (hasSliceTotal()) {
+                result = result && (getSliceTotal() == other.getSliceTotal());
+            }
             result = result && unknownFields.equals(other.unknownFields);
             return result;
         }
@@ -419,6 +462,10 @@ public final class LocalFileMetaOutter {
             if (hasChecksum()) {
                 hash = (37 * hash) + CHECKSUM_FIELD_NUMBER;
                 hash = (53 * hash) + getChecksum().hashCode();
+            }
+            if (hasSliceTotal()) {
+                hash = (37 * hash) + SLICETOTAL_FIELD_NUMBER;
+                hash = (53 * hash) + getSliceTotal();
             }
             hash = (29 * hash) + unknownFields.hashCode();
             memoizedHashCode = hash;
@@ -555,6 +602,8 @@ public final class LocalFileMetaOutter {
                 bitField0_ = (bitField0_ & ~0x00000002);
                 checksum_ = "";
                 bitField0_ = (bitField0_ & ~0x00000004);
+                sliceTotal_ = 0;
+                bitField0_ = (bitField0_ & ~0x00000008);
                 return this;
             }
 
@@ -591,6 +640,10 @@ public final class LocalFileMetaOutter {
                     to_bitField0_ |= 0x00000004;
                 }
                 result.checksum_ = checksum_;
+                if (((from_bitField0_ & 0x00000008) == 0x00000008)) {
+                    to_bitField0_ |= 0x00000008;
+                }
+                result.sliceTotal_ = sliceTotal_;
                 result.bitField0_ = to_bitField0_;
                 onBuilt();
                 return result;
@@ -644,6 +697,9 @@ public final class LocalFileMetaOutter {
                     bitField0_ |= 0x00000004;
                     checksum_ = other.checksum_;
                     onChanged();
+                }
+                if (other.hasSliceTotal()) {
+                    setSliceTotal(other.getSliceTotal());
                 }
                 this.mergeUnknownFields(other.unknownFields);
                 onChanged();
@@ -832,6 +888,42 @@ public final class LocalFileMetaOutter {
                 return this;
             }
 
+            private int sliceTotal_;
+
+            /**
+             * <code>optional int32 sliceTotal = 4;</code>
+             */
+            public boolean hasSliceTotal() {
+                return ((bitField0_ & 0x00000008) == 0x00000008);
+            }
+
+            /**
+             * <code>optional int32 sliceTotal = 4;</code>
+             */
+            public int getSliceTotal() {
+                return sliceTotal_;
+            }
+
+            /**
+             * <code>optional int32 sliceTotal = 4;</code>
+             */
+            public Builder setSliceTotal(int value) {
+                bitField0_ |= 0x00000008;
+                sliceTotal_ = value;
+                onChanged();
+                return this;
+            }
+
+            /**
+             * <code>optional int32 sliceTotal = 4;</code>
+             */
+            public Builder clearSliceTotal() {
+                bitField0_ = (bitField0_ & ~0x00000008);
+                sliceTotal_ = 0;
+                onChanged();
+                return this;
+            }
+
             public final Builder setUnknownFields(final com.google.protobuf.UnknownFieldSet unknownFields) {
                 return super.setUnknownFields(unknownFields);
             }
@@ -887,12 +979,13 @@ public final class LocalFileMetaOutter {
 
     private static com.google.protobuf.Descriptors.FileDescriptor descriptor;
     static {
-        java.lang.String[] descriptorData = { "\n\025local_file_meta.proto\022\005jraft\"W\n\rLocalF"
+        java.lang.String[] descriptorData = { "\n\025local_file_meta.proto\022\005jraft\"k\n\rLocalF"
                                               + "ileMeta\022\021\n\tuser_meta\030\001 \001(\014\022!\n\006source\030\002 \001"
-                                              + "(\0162\021.jraft.FileSource\022\020\n\010checksum\030\003 \001(\t*"
-                                              + ">\n\nFileSource\022\025\n\021FILE_SOURCE_LOCAL\020\000\022\031\n\025"
-                                              + "FILE_SOURCE_REFERENCE\020\001B3\n\034com.alipay.so"
-                                              + "fa.jraft.entityB\023LocalFileMetaOutter" };
+                                              + "(\0162\021.jraft.FileSource\022\020\n\010checksum\030\003 \001(\t\022"
+                                              + "\022\n\nsliceTotal\030\004 \001(\005*>\n\nFileSource\022\025\n\021FIL"
+                                              + "E_SOURCE_LOCAL\020\000\022\031\n\025FILE_SOURCE_REFERENC"
+                                              + "E\020\001B3\n\034com.alipay.sofa.jraft.entityB\023Loc"
+                                              + "alFileMetaOutter" };
         com.google.protobuf.Descriptors.FileDescriptor.InternalDescriptorAssigner assigner = new com.google.protobuf.Descriptors.FileDescriptor.InternalDescriptorAssigner() {
             public com.google.protobuf.ExtensionRegistry assignDescriptors(com.google.protobuf.Descriptors.FileDescriptor root) {
                 descriptor = root;
@@ -903,8 +996,8 @@ public final class LocalFileMetaOutter {
             new com.google.protobuf.Descriptors.FileDescriptor[] {}, assigner);
         internal_static_jraft_LocalFileMeta_descriptor = getDescriptor().getMessageTypes().get(0);
         internal_static_jraft_LocalFileMeta_fieldAccessorTable = new com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
-            internal_static_jraft_LocalFileMeta_descriptor,
-            new java.lang.String[] { "UserMeta", "Source", "Checksum", });
+            internal_static_jraft_LocalFileMeta_descriptor, new java.lang.String[] { "UserMeta", "Source", "Checksum",
+            "SliceTotal", });
     }
 
     // @@protoc_insertion_point(outer_class_scope)

--- a/jraft-core/src/main/java/com/alipay/sofa/jraft/option/NodeOptions.java
+++ b/jraft-core/src/main/java/com/alipay/sofa/jraft/option/NodeOptions.java
@@ -35,37 +35,38 @@ import com.alipay.sofa.jraft.util.Utils;
  */
 public class NodeOptions extends RpcOptions implements Copiable<NodeOptions> {
 
-    public static final JRaftServiceFactory defaultServiceFactory  = JRaftServiceLoader.load(JRaftServiceFactory.class) //
-                                                                       .first();
+    public static final JRaftServiceFactory defaultServiceFactory        = JRaftServiceLoader.load(
+                                                                             JRaftServiceFactory.class) //
+                                                                             .first();
 
     // A follower would become a candidate if it doesn't receive any message
     // from the leader in |election_timeout_ms| milliseconds
     // Default: 1000 (1s)
-    private int                             electionTimeoutMs      = 1000;                                         // follower to candidate timeout
+    private int                             electionTimeoutMs            = 1000;                     // follower to candidate timeout
 
     // One node's local priority value would be set to | electionPriority |
     // value when it starts up.If this value is set to 0,the node will never be a leader.
     // If this node doesn't support priority election,then set this value to -1.
     // Default: -1
-    private int                             electionPriority       = ElectionPriority.Disabled;
+    private int                             electionPriority             = ElectionPriority.Disabled;
 
     // If next leader is not elected until next election timeout, it exponentially
     // decay its local target priority, for example target_priority = target_priority - gap
     // Default: 10
-    private int                             decayPriorityGap       = 10;
+    private int                             decayPriorityGap             = 10;
 
     // Leader lease time's ratio of electionTimeoutMs,
     // To minimize the effects of clock drift, we should make that:
     // clockDrift + leaderLeaseTimeoutMs < electionTimeout
     // Default: 90, Max: 100
-    private int                             leaderLeaseTimeRatio   = 90;
+    private int                             leaderLeaseTimeRatio         = 90;
 
     // A snapshot saving would be triggered every |snapshot_interval_s| seconds
     // if this was reset as a positive number
     // If |snapshot_interval_s| <= 0, the time based snapshot would be disabled.
     //
     // Default: 3600 (1 hour)
-    private int                             snapshotIntervalSecs   = 3600;
+    private int                             snapshotIntervalSecs         = 3600;
 
     // A snapshot saving would be triggered every |snapshot_interval_s| seconds,
     // and at this moment when state machine's lastAppliedIndex value
@@ -74,14 +75,14 @@ public class NodeOptions extends RpcOptions implements Copiable<NodeOptions> {
     // If |snapshotLogIndexMargin| <= 0, the distance based snapshot would be disable.
     //
     // Default: 0
-    private int                             snapshotLogIndexMargin = 0;
+    private int                             snapshotLogIndexMargin       = 0;
 
     // We will regard a adding peer as caught up if the margin between the
     // last_log_index of this peer and the last_log_index of leader is less than
     // |catchup_margin|
     //
     // Default: 1000
-    private int                             catchupMargin          = 1000;
+    private int                             catchupMargin                = 1000;
 
     // If node is starting from a empty environment (both LogStorage and
     // SnapshotStorage are empty), it would use |initial_conf| as the
@@ -89,7 +90,7 @@ public class NodeOptions extends RpcOptions implements Copiable<NodeOptions> {
     // the existing environment.
     //
     // Default: A empty group
-    private Configuration                   initialConf            = new Configuration();
+    private Configuration                   initialConf                  = new Configuration();
 
     // The specific StateMachine implemented your business logic, which must be
     // a valid instance.
@@ -108,7 +109,7 @@ public class NodeOptions extends RpcOptions implements Copiable<NodeOptions> {
     // to avoid useless transmission. Two files in local and remote are duplicate,
     // only if they has the same filename and the same checksum (stored in file meta).
     // Default: false
-    private boolean                         filterBeforeCopyRemote = false;
+    private boolean                         filterBeforeCopyRemote       = true;
 
     // If non-null, we will pass this throughput_snapshot_throttle to SnapshotExecutor
     // Default: NULL
@@ -116,29 +117,34 @@ public class NodeOptions extends RpcOptions implements Copiable<NodeOptions> {
 
     // If true, RPCs through raft_cli will be denied.
     // Default: false
-    private boolean                         disableCli             = false;
+    private boolean                         disableCli                   = false;
 
     /**
      * Whether use global timer pool, if true, the {@code timerPoolSize} will be invalid.
      */
-    private boolean                         sharedTimerPool        = false;
+    private boolean                         sharedTimerPool              = false;
     /**
      * Timer manager thread pool size
      */
-    private int                             timerPoolSize          = Utils.cpus() * 3 > 20 ? 20 : Utils.cpus() * 3;
+    private int                             timerPoolSize                = Utils.cpus() * 3 > 20 ? 20
+                                                                             : Utils.cpus() * 3;
 
     /**
      * CLI service request RPC executor pool size, use default executor if -1.
      */
-    private int                             cliRpcThreadPoolSize   = Utils.cpus();
+    private int                             cliRpcThreadPoolSize         = Utils.cpus();
     /**
      * RAFT request RPC executor pool size, use default executor if -1.
      */
-    private int                             raftRpcThreadPoolSize  = Utils.cpus() * 6;
+    private int                             raftRpcThreadPoolSize        = Utils.cpus() * 6;
+    /**
+     * SNAPSHOT file copy executor pool size, use default executor if -1.
+     */
+    private int                             snapshotCopierThreadPoolSize = Utils.cpus();
     /**
      * Whether to enable metrics for node.
      */
-    private boolean                         enableMetrics          = false;
+    private boolean                         enableMetrics                = false;
 
     /**
      *  If non-null, we will pass this SnapshotThrottle to SnapshotExecutor
@@ -149,24 +155,24 @@ public class NodeOptions extends RpcOptions implements Copiable<NodeOptions> {
     /**
      * Whether use global election timer
      */
-    private boolean                         sharedElectionTimer    = false;
+    private boolean                         sharedElectionTimer          = false;
     /**
      * Whether use global vote timer
      */
-    private boolean                         sharedVoteTimer        = false;
+    private boolean                         sharedVoteTimer              = false;
     /**
      * Whether use global step down timer
      */
-    private boolean                         sharedStepDownTimer    = false;
+    private boolean                         sharedStepDownTimer          = false;
     /**
      * Whether use global snapshot timer
      */
-    private boolean                         sharedSnapshotTimer    = false;
+    private boolean                         sharedSnapshotTimer          = false;
 
     /**
      * Custom service factory.
      */
-    private JRaftServiceFactory             serviceFactory         = defaultServiceFactory;
+    private JRaftServiceFactory             serviceFactory               = defaultServiceFactory;
 
     public JRaftServiceFactory getServiceFactory() {
         return this.serviceFactory;
@@ -401,6 +407,14 @@ public class NodeOptions extends RpcOptions implements Copiable<NodeOptions> {
         this.sharedSnapshotTimer = sharedSnapshotTimer;
     }
 
+    public int getSnapshotCopierThreadPoolSize() {
+        return snapshotCopierThreadPoolSize;
+    }
+
+    public void setSnapshotCopierThreadPoolSize(int snapshotCopierThreadPoolSize) {
+        this.snapshotCopierThreadPoolSize = snapshotCopierThreadPoolSize;
+    }
+
     @Override
     public NodeOptions copy() {
         final NodeOptions nodeOptions = new NodeOptions();
@@ -422,6 +436,7 @@ public class NodeOptions extends RpcOptions implements Copiable<NodeOptions> {
         nodeOptions.setSharedVoteTimer(this.sharedVoteTimer);
         nodeOptions.setSharedStepDownTimer(this.sharedStepDownTimer);
         nodeOptions.setSharedSnapshotTimer(this.sharedSnapshotTimer);
+        nodeOptions.setSnapshotCopierThreadPoolSize(this.snapshotCopierThreadPoolSize);
         return nodeOptions;
     }
 
@@ -438,6 +453,7 @@ public class NodeOptions extends RpcOptions implements Copiable<NodeOptions> {
                + raftRpcThreadPoolSize + ", enableMetrics=" + enableMetrics + ", snapshotThrottle=" + snapshotThrottle
                + ", sharedElectionTimer=" + sharedElectionTimer + ", sharedVoteTimer=" + sharedVoteTimer
                + ", sharedStepDownTimer=" + sharedStepDownTimer + ", sharedSnapshotTimer=" + sharedSnapshotTimer
-               + ", serviceFactory=" + serviceFactory + ", raftOptions=" + raftOptions + "} " + super.toString();
+               + ", serviceFactory=" + serviceFactory + ", raftOptions=" + raftOptions
+               + ", snapshotCopierThreadPoolSize=" + snapshotCopierThreadPoolSize + "}" + super.toString();
     }
 }

--- a/jraft-core/src/main/java/com/alipay/sofa/jraft/option/RaftOptions.java
+++ b/jraft-core/src/main/java/com/alipay/sofa/jraft/option/RaftOptions.java
@@ -86,6 +86,10 @@ public class RaftOptions implements Copiable<RaftOptions> {
      * @since 1.3.0
      */
     private boolean        stepDownWhenVoteTimedout             = true;
+    /**
+     * Size of each slice
+     */
+    private long           sliceSize                            = 10;
 
     public boolean isStepDownWhenVoteTimedout() {
         return this.stepDownWhenVoteTimedout;
@@ -231,6 +235,14 @@ public class RaftOptions implements Copiable<RaftOptions> {
         this.openStatistics = openStatistics;
     }
 
+    public long getSliceSize() {
+        return sliceSize;
+    }
+
+    public void setSliceSize(long sliceSize) {
+        this.sliceSize = sliceSize;
+    }
+
     @Override
     public RaftOptions copy() {
         final RaftOptions raftOptions = new RaftOptions();
@@ -251,6 +263,7 @@ public class RaftOptions implements Copiable<RaftOptions> {
         raftOptions.setDisruptorPublishEventWaitTimeoutSecs(this.disruptorPublishEventWaitTimeoutSecs);
         raftOptions.setEnableLogEntryChecksum(this.enableLogEntryChecksum);
         raftOptions.setReadOnlyOptions(this.readOnlyOptions);
+        raftOptions.setSliceSize(this.sliceSize);
         return raftOptions;
     }
 
@@ -265,6 +278,6 @@ public class RaftOptions implements Copiable<RaftOptions> {
                + ", maxReplicatorInflightMsgs=" + this.maxReplicatorInflightMsgs + ", disruptorBufferSize="
                + this.disruptorBufferSize + ", disruptorPublishEventWaitTimeoutSecs="
                + this.disruptorPublishEventWaitTimeoutSecs + ", enableLogEntryChecksum=" + this.enableLogEntryChecksum
-               + ", readOnlyOptions=" + this.readOnlyOptions + '}';
+               + ", readOnlyOptions=" + this.readOnlyOptions + ", sliceSize=" + this.sliceSize + '}';
     }
 }

--- a/jraft-core/src/main/java/com/alipay/sofa/jraft/rpc/RpcRequests.java
+++ b/jraft-core/src/main/java/com/alipay/sofa/jraft/rpc/RpcRequests.java
@@ -10972,6 +10972,16 @@ public final class RpcRequests {
          * <code>optional bool read_partly = 5;</code>
          */
         boolean getReadPartly();
+
+        /**
+         * <code>required int32 slice_id = 6;</code>
+         */
+        boolean hasSliceId();
+
+        /**
+         * <code>required int32 slice_id = 6;</code>
+         */
+        int getSliceId();
     }
 
     /**
@@ -10993,6 +11003,7 @@ public final class RpcRequests {
             count_ = 0L;
             offset_ = 0L;
             readPartly_ = false;
+            sliceId_ = 0;
         }
 
         @java.lang.Override
@@ -11048,6 +11059,11 @@ public final class RpcRequests {
                         case 40: {
                             bitField0_ |= 0x00000010;
                             readPartly_ = input.readBool();
+                            break;
+                        }
+                        case 48: {
+                            bitField0_ |= 0x00000020;
+                            sliceId_ = input.readInt32();
                             break;
                         }
                     }
@@ -11182,6 +11198,23 @@ public final class RpcRequests {
             return readPartly_;
         }
 
+        public static final int SLICE_ID_FIELD_NUMBER = 6;
+        private int             sliceId_;
+
+        /**
+         * <code>required int32 slice_id = 6;</code>
+         */
+        public boolean hasSliceId() {
+            return ((bitField0_ & 0x00000020) == 0x00000020);
+        }
+
+        /**
+         * <code>required int32 slice_id = 6;</code>
+         */
+        public int getSliceId() {
+            return sliceId_;
+        }
+
         private byte memoizedIsInitialized = -1;
 
         public final boolean isInitialized() {
@@ -11207,6 +11240,10 @@ public final class RpcRequests {
                 memoizedIsInitialized = 0;
                 return false;
             }
+            if (!hasSliceId()) {
+                memoizedIsInitialized = 0;
+                return false;
+            }
             memoizedIsInitialized = 1;
             return true;
         }
@@ -11226,6 +11263,9 @@ public final class RpcRequests {
             }
             if (((bitField0_ & 0x00000010) == 0x00000010)) {
                 output.writeBool(5, readPartly_);
+            }
+            if (((bitField0_ & 0x00000020) == 0x00000020)) {
+                output.writeInt32(6, sliceId_);
             }
             unknownFields.writeTo(output);
         }
@@ -11250,6 +11290,9 @@ public final class RpcRequests {
             }
             if (((bitField0_ & 0x00000010) == 0x00000010)) {
                 size += com.google.protobuf.CodedOutputStream.computeBoolSize(5, readPartly_);
+            }
+            if (((bitField0_ & 0x00000020) == 0x00000020)) {
+                size += com.google.protobuf.CodedOutputStream.computeInt32Size(6, sliceId_);
             }
             size += unknownFields.getSerializedSize();
             memoizedSize = size;
@@ -11287,6 +11330,10 @@ public final class RpcRequests {
             if (hasReadPartly()) {
                 result = result && (getReadPartly() == other.getReadPartly());
             }
+            result = result && (hasSliceId() == other.hasSliceId());
+            if (hasSliceId()) {
+                result = result && (getSliceId() == other.getSliceId());
+            }
             result = result && unknownFields.equals(other.unknownFields);
             return result;
         }
@@ -11317,6 +11364,10 @@ public final class RpcRequests {
             if (hasReadPartly()) {
                 hash = (37 * hash) + READ_PARTLY_FIELD_NUMBER;
                 hash = (53 * hash) + com.google.protobuf.Internal.hashBoolean(getReadPartly());
+            }
+            if (hasSliceId()) {
+                hash = (37 * hash) + SLICE_ID_FIELD_NUMBER;
+                hash = (53 * hash) + getSliceId();
             }
             hash = (29 * hash) + unknownFields.hashCode();
             memoizedHashCode = hash;
@@ -11456,6 +11507,8 @@ public final class RpcRequests {
                 bitField0_ = (bitField0_ & ~0x00000008);
                 readPartly_ = false;
                 bitField0_ = (bitField0_ & ~0x00000010);
+                sliceId_ = 0;
+                bitField0_ = (bitField0_ & ~0x00000020);
                 return this;
             }
 
@@ -11500,6 +11553,10 @@ public final class RpcRequests {
                     to_bitField0_ |= 0x00000010;
                 }
                 result.readPartly_ = readPartly_;
+                if (((from_bitField0_ & 0x00000020) == 0x00000020)) {
+                    to_bitField0_ |= 0x00000020;
+                }
+                result.sliceId_ = sliceId_;
                 result.bitField0_ = to_bitField0_;
                 onBuilt();
                 return result;
@@ -11560,6 +11617,9 @@ public final class RpcRequests {
                 if (other.hasReadPartly()) {
                     setReadPartly(other.getReadPartly());
                 }
+                if (other.hasSliceId()) {
+                    setSliceId(other.getSliceId());
+                }
                 this.mergeUnknownFields(other.unknownFields);
                 onChanged();
                 return this;
@@ -11576,6 +11636,9 @@ public final class RpcRequests {
                     return false;
                 }
                 if (!hasOffset()) {
+                    return false;
+                }
+                if (!hasSliceId()) {
                     return false;
                 }
                 return true;
@@ -11817,6 +11880,42 @@ public final class RpcRequests {
             public Builder clearReadPartly() {
                 bitField0_ = (bitField0_ & ~0x00000010);
                 readPartly_ = false;
+                onChanged();
+                return this;
+            }
+
+            private int sliceId_;
+
+            /**
+             * <code>required int32 slice_id = 6;</code>
+             */
+            public boolean hasSliceId() {
+                return ((bitField0_ & 0x00000020) == 0x00000020);
+            }
+
+            /**
+             * <code>required int32 slice_id = 6;</code>
+             */
+            public int getSliceId() {
+                return sliceId_;
+            }
+
+            /**
+             * <code>required int32 slice_id = 6;</code>
+             */
+            public Builder setSliceId(int value) {
+                bitField0_ |= 0x00000020;
+                sliceId_ = value;
+                onChanged();
+                return this;
+            }
+
+            /**
+             * <code>required int32 slice_id = 6;</code>
+             */
+            public Builder clearSliceId() {
+                bitField0_ = (bitField0_ & ~0x00000020);
+                sliceId_ = 0;
                 onChanged();
                 return this;
             }
@@ -14738,18 +14837,19 @@ public final class RpcRequests {
                                               + "ted_index\030\010 \002(\003\022\014\n\004data\030\t \001(\014\"{\n\025AppendE"
                                               + "ntriesResponse\022\014\n\004term\030\001 \002(\003\022\017\n\007success\030"
                                               + "\002 \002(\010\022\026\n\016last_log_index\030\003 \001(\003\022+\n\rerrorRe"
-                                              + "sponse\030c \001(\0132\024.jraft.ErrorResponse\"i\n\016Ge"
+                                              + "sponse\030c \001(\0132\024.jraft.ErrorResponse\"{\n\016Ge"
                                               + "tFileRequest\022\021\n\treader_id\030\001 \002(\003\022\020\n\010filen"
                                               + "ame\030\002 \002(\t\022\r\n\005count\030\003 \002(\003\022\016\n\006offset\030\004 \002(\003"
-                                              + "\022\023\n\013read_partly\030\005 \001(\010\"l\n\017GetFileResponse"
-                                              + "\022\013\n\003eof\030\001 \002(\010\022\014\n\004data\030\002 \002(\014\022\021\n\tread_size"
-                                              + "\030\003 \001(\003\022+\n\rerrorResponse\030c \001(\0132\024.jraft.Er"
-                                              + "rorResponse\"Y\n\020ReadIndexRequest\022\020\n\010group"
-                                              + "_id\030\001 \002(\t\022\021\n\tserver_id\030\002 \002(\t\022\017\n\007entries\030"
-                                              + "\003 \003(\014\022\017\n\007peer_id\030\004 \001(\t\"`\n\021ReadIndexRespo"
-                                              + "nse\022\r\n\005index\030\001 \002(\003\022\017\n\007success\030\002 \002(\010\022+\n\re"
-                                              + "rrorResponse\030c \001(\0132\024.jraft.ErrorResponse"
-                                              + "B(\n\031com.alipay.sofa.jraft.rpcB\013RpcReques" + "ts" };
+                                              + "\022\023\n\013read_partly\030\005 \001(\010\022\020\n\010slice_id\030\006 \002(\005\""
+                                              + "l\n\017GetFileResponse\022\013\n\003eof\030\001 \002(\010\022\014\n\004data\030"
+                                              + "\002 \002(\014\022\021\n\tread_size\030\003 \001(\003\022+\n\rerrorRespons"
+                                              + "e\030c \001(\0132\024.jraft.ErrorResponse\"Y\n\020ReadInd"
+                                              + "exRequest\022\020\n\010group_id\030\001 \002(\t\022\021\n\tserver_id"
+                                              + "\030\002 \002(\t\022\017\n\007entries\030\003 \003(\014\022\017\n\007peer_id\030\004 \001(\t"
+                                              + "\"`\n\021ReadIndexResponse\022\r\n\005index\030\001 \002(\003\022\017\n\007"
+                                              + "success\030\002 \002(\010\022+\n\rerrorResponse\030c \001(\0132\024.j"
+                                              + "raft.ErrorResponseB(\n\031com.alipay.sofa.jr"
+                                              + "aft.rpcB\013RpcRequests" };
         com.google.protobuf.Descriptors.FileDescriptor.InternalDescriptorAssigner assigner = new com.google.protobuf.Descriptors.FileDescriptor.InternalDescriptorAssigner() {
             public com.google.protobuf.ExtensionRegistry assignDescriptors(com.google.protobuf.Descriptors.FileDescriptor root) {
                 descriptor = root;
@@ -14804,7 +14904,7 @@ public final class RpcRequests {
         internal_static_jraft_GetFileRequest_descriptor = getDescriptor().getMessageTypes().get(11);
         internal_static_jraft_GetFileRequest_fieldAccessorTable = new com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
             internal_static_jraft_GetFileRequest_descriptor, new java.lang.String[] { "ReaderId", "Filename", "Count",
-            "Offset", "ReadPartly", });
+            "Offset", "ReadPartly", "SliceId", });
         internal_static_jraft_GetFileResponse_descriptor = getDescriptor().getMessageTypes().get(12);
         internal_static_jraft_GetFileResponse_fieldAccessorTable = new com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
             internal_static_jraft_GetFileResponse_descriptor, new java.lang.String[] { "Eof", "Data", "ReadSize",

--- a/jraft-core/src/main/java/com/alipay/sofa/jraft/storage/io/FileReader.java
+++ b/jraft-core/src/main/java/com/alipay/sofa/jraft/storage/io/FileReader.java
@@ -33,6 +33,13 @@ public interface FileReader {
     int EOF = -1;
 
     /**
+     * Get the slice size.
+     *
+     * @return slice size of the file
+     */
+    long getSliceSize();
+
+    /**
      * Get the file path.
      *
      * @return path of the file
@@ -51,7 +58,6 @@ public interface FileReader {
      * @throws RetryAgainException if it's not allowed to read partly
      * or it's allowed but throughput is throttled to 0, try again.
      */
-    int readFile(final ByteBufferCollector buf, final String fileName, final long offset, final long maxCount)
-                                                                                                              throws IOException,
-                                                                                                              RetryAgainException;
+    int readFile(final ByteBufferCollector buf, final String fileName, final long sliceId, final long offset,
+                 final long maxCount) throws IOException, RetryAgainException;
 }

--- a/jraft-core/src/main/java/com/alipay/sofa/jraft/storage/io/LocalDirReader.java
+++ b/jraft-core/src/main/java/com/alipay/sofa/jraft/storage/io/LocalDirReader.java
@@ -40,10 +40,17 @@ public class LocalDirReader implements FileReader {
     private static final Logger LOG = LoggerFactory.getLogger(LocalDirReader.class);
 
     private final String        path;
+    protected final long        sliceSize;
 
-    public LocalDirReader(String path) {
+    public LocalDirReader(String path, long sliceSize) {
         super();
         this.path = path;
+        this.sliceSize = sliceSize;
+    }
+
+    @Override
+    public long getSliceSize() {
+        return sliceSize;
     }
 
     @Override
@@ -52,45 +59,33 @@ public class LocalDirReader implements FileReader {
     }
 
     @Override
-    public int readFile(final ByteBufferCollector buf, final String fileName, final long offset, final long maxCount)
-                                                                                                                     throws IOException,
-                                                                                                                     RetryAgainException {
-        return readFileWithMeta(buf, fileName, null, offset, maxCount);
+    public int readFile(final ByteBufferCollector buf, final String fileName, final long sliceId, final long offset,
+                        final long maxCount) throws IOException, RetryAgainException {
+        return readFileWithMeta(buf, fileName, sliceId, null, offset, maxCount);
     }
 
     @SuppressWarnings("unused")
-    protected int readFileWithMeta(final ByteBufferCollector buf, final String fileName, final Message fileMeta,
-                                   long offset, final long maxCount) throws IOException, RetryAgainException {
+    protected int readFileWithMeta(final ByteBufferCollector buf, final String fileName, final long sliceId,
+                                   final Message fileMeta, long offset, final long maxCount) throws IOException {
         buf.expandIfNecessary();
         final String filePath = this.path + File.separator + fileName;
         final File file = new File(filePath);
         try (final FileInputStream input = new FileInputStream(file); final FileChannel fc = input.getChannel()) {
             int totalRead = 0;
-            while (true) {
-                final int nread = fc.read(buf.getBuffer(), offset);
-                if (nread <= 0) {
+            final int nread = fc.read(buf.getBuffer(), sliceId * sliceSize + offset);
+            if (nread <= 0) {
+                return EOF;
+            }
+            buf.getBuffer().position(nread);
+            totalRead += nread;
+            if (totalRead == sliceSize - offset) {
+                return EOF;
+            } else {
+                //Last slice
+                if (sliceId * sliceSize + nread == file.length()) {
                     return EOF;
                 }
-                totalRead += nread;
-                if (totalRead < maxCount) {
-                    if (buf.hasRemaining()) {
-                        return EOF;
-                    } else {
-                        buf.expandAtMost((int) (maxCount - totalRead));
-                        offset += nread;
-                    }
-                } else {
-                    final long fsize = file.length();
-                    if (fsize < 0) {
-                        LOG.warn("Invalid file length {}", filePath);
-                        return EOF;
-                    }
-                    if (fsize == offset + nread) {
-                        return EOF;
-                    } else {
-                        return totalRead;
-                    }
-                }
+                return totalRead;
             }
         }
     }

--- a/jraft-core/src/main/java/com/alipay/sofa/jraft/storage/snapshot/local/LocalSnapshotMetaTable.java
+++ b/jraft-core/src/main/java/com/alipay/sofa/jraft/storage/snapshot/local/LocalSnapshotMetaTable.java
@@ -100,6 +100,10 @@ public class LocalSnapshotMetaTable {
         return this.fileMap.putIfAbsent(fileName, meta) == null;
     }
 
+    public void putFile(final String fileName, final LocalFileMeta meta) {
+        this.fileMap.put(fileName, meta);
+    }
+
     /**
      * Removes a file metadata.
      */

--- a/jraft-core/src/main/java/com/alipay/sofa/jraft/storage/snapshot/local/LocalSnapshotReader.java
+++ b/jraft-core/src/main/java/com/alipay/sofa/jraft/storage/snapshot/local/LocalSnapshotReader.java
@@ -53,6 +53,7 @@ public class LocalSnapshotReader extends SnapshotReader {
     private final String                 path;
     private final LocalSnapshotStorage   snapshotStorage;
     private final SnapshotThrottle       snapshotThrottle;
+    private final RaftOptions            raftOptions;
 
     @Override
     public void close() throws IOException {
@@ -69,6 +70,7 @@ public class LocalSnapshotReader extends SnapshotReader {
         this.path = path;
         this.readerId = 0;
         this.metaTable = new LocalSnapshotMetaTable(raftOptions);
+        this.raftOptions = raftOptions;
     }
 
     @OnlyForTest
@@ -123,7 +125,8 @@ public class LocalSnapshotReader extends SnapshotReader {
             return null;
         }
         if (this.readerId == 0) {
-            final SnapshotFileReader reader = new SnapshotFileReader(this.path, this.snapshotThrottle);
+            final SnapshotFileReader reader = new SnapshotFileReader(this.path, this.snapshotThrottle,
+                raftOptions.getSliceSize());
             reader.setMetaTable(this.metaTable);
             if (!reader.open()) {
                 LOG.error("Open snapshot {} failed.", this.path);

--- a/jraft-core/src/main/java/com/alipay/sofa/jraft/storage/snapshot/local/LocalSnapshotWriter.java
+++ b/jraft-core/src/main/java/com/alipay/sofa/jraft/storage/snapshot/local/LocalSnapshotWriter.java
@@ -90,7 +90,7 @@ public class LocalSnapshotWriter extends SnapshotWriter {
 
     @Override
     public void close() throws IOException {
-        close(false);
+        close(true);
     }
 
     @Override

--- a/jraft-core/src/main/resources/local_file_meta.proto
+++ b/jraft-core/src/main/resources/local_file_meta.proto
@@ -15,4 +15,5 @@ message LocalFileMeta {
     optional bytes user_meta   = 1;
     optional FileSource source = 2;
     optional string checksum   = 3;
+    optional int32 sliceTotal = 4;
 }

--- a/jraft-core/src/main/resources/rpc.proto
+++ b/jraft-core/src/main/resources/rpc.proto
@@ -90,6 +90,7 @@ message GetFileRequest {
   required int64 count = 3;
   required int64 offset = 4;
   optional bool read_partly = 5;
+  required int32 slice_id = 6;
 }
 
 message GetFileResponse {

--- a/jraft-core/src/test/java/com/alipay/sofa/jraft/storage/FileServiceTest.java
+++ b/jraft-core/src/test/java/com/alipay/sofa/jraft/storage/FileServiceTest.java
@@ -46,7 +46,7 @@ public class FileServiceTest {
     @Before
     public void setup() throws Exception {
         this.path = TestUtils.mkTempDir();
-        this.fileReader = new LocalDirReader(path);
+        this.fileReader = new LocalDirReader(path, 1024);
     }
 
     @After
@@ -99,7 +99,7 @@ public class FileServiceTest {
         writeData();
         long readerId = FileService.getInstance().addReader(this.fileReader);
         RpcRequests.GetFileRequest request = RpcRequests.GetFileRequest.newBuilder().setCount(Integer.MAX_VALUE)
-            .setFilename("data").setOffset(0).setReaderId(readerId).build();
+            .setFilename("data").setOffset(0).setReaderId(readerId).setSliceId(0).build();
         RpcContext asyncContext = Mockito.mock(RpcContext.class);
         Message msg = FileService.getInstance().handleGetFile(request, new RpcRequestClosure(asyncContext));
         assertTrue(msg instanceof RpcRequests.GetFileResponse);

--- a/jraft-core/src/test/java/com/alipay/sofa/jraft/storage/io/LocalFileReaderTest.java
+++ b/jraft-core/src/test/java/com/alipay/sofa/jraft/storage/io/LocalFileReaderTest.java
@@ -37,14 +37,14 @@ public class LocalFileReaderTest extends BaseStorageTest {
     @Before
     public void setup() throws Exception {
         super.setup();
-        this.fileReader = new LocalDirReader(path);
+        this.fileReader = new LocalDirReader(path, 1024);
     }
 
     @Test
     public void testReadFile() throws Exception {
         final ByteBufferCollector bufRef = ByteBufferCollector.allocate();
         try {
-            this.fileReader.readFile(bufRef, "unfound", 0, 1024);
+            this.fileReader.readFile(bufRef, "unfound", 0, 0, 1024);
             fail();
         } catch (final FileNotFoundException e) {
 
@@ -56,7 +56,7 @@ public class LocalFileReaderTest extends BaseStorageTest {
     }
 
     private void assertReadResult(ByteBufferCollector bufRef, String data) throws Exception {
-        final int read = this.fileReader.readFile(bufRef, "data", 0, 1024);
+        final int read = this.fileReader.readFile(bufRef, "data", 0, 0, 1024);
         assertEquals(-1, read);
         final ByteBuffer buf = bufRef.getBuffer();
         buf.flip();
@@ -86,13 +86,13 @@ public class LocalFileReaderTest extends BaseStorageTest {
         }
         FileUtils.writeStringToFile(file, data);
 
-        int read = this.fileReader.readFile(bufRef, "data", 0, 1024);
+        int read = this.fileReader.readFile(bufRef, "data", 0, 0, 1024);
         assertEquals(1024, read);
-        read = this.fileReader.readFile(bufRef, "data", 1024, 1024);
+        read = this.fileReader.readFile(bufRef, "data", 0, 1024, 1024);
         assertEquals(1024, read);
-        read = this.fileReader.readFile(bufRef, "data", 1024 + 1024, 1024);
+        read = this.fileReader.readFile(bufRef, "data", 0, 1024 + 1024, 1024);
         assertEquals(1024, read);
-        read = this.fileReader.readFile(bufRef, "data", 1024 + 1024 + 1024, 1024);
+        read = this.fileReader.readFile(bufRef, "data", 0, 1024 + 1024 + 1024, 1024);
         assertEquals(-1, read);
 
         final ByteBuffer buf = bufRef.getBuffer();

--- a/jraft-core/src/test/java/com/alipay/sofa/jraft/storage/snapshot/local/SnapshotFileReaderTest.java
+++ b/jraft-core/src/test/java/com/alipay/sofa/jraft/storage/snapshot/local/SnapshotFileReaderTest.java
@@ -40,7 +40,7 @@ public class SnapshotFileReaderTest extends BaseStorageTest {
     @Before
     public void setup() throws Exception {
         super.setup();
-        this.reader = new SnapshotFileReader(path, null);
+        this.reader = new SnapshotFileReader(path, null, 0);
         metaTable = new LocalSnapshotMetaTable(new RaftOptions());
         this.reader.setMetaTable(metaTable);
     }
@@ -49,7 +49,7 @@ public class SnapshotFileReaderTest extends BaseStorageTest {
     public void testReadMetaFile() throws Exception {
         final ByteBufferCollector bufRef = ByteBufferCollector.allocate(1024);
         final LocalFileMetaOutter.LocalFileMeta meta = addDataMeta();
-        assertEquals(-1, this.reader.readFile(bufRef, Snapshot.JRAFT_SNAPSHOT_META_FILE, 0, Integer.MAX_VALUE));
+        assertEquals(-1, this.reader.readFile(bufRef, Snapshot.JRAFT_SNAPSHOT_META_FILE, 0, 0, Integer.MAX_VALUE));
 
         final ByteBuffer buf = bufRef.getBuffer();
         buf.flip();
@@ -69,7 +69,7 @@ public class SnapshotFileReaderTest extends BaseStorageTest {
     public void testReadFile() throws Exception {
         final ByteBufferCollector bufRef = ByteBufferCollector.allocate();
         try {
-            this.reader.readFile(bufRef, "unfound", 0, 1024);
+            this.reader.readFile(bufRef, "unfound", 0, 0, 1024);
             fail();
         } catch (final FileNotFoundException e) {
 
@@ -78,7 +78,7 @@ public class SnapshotFileReaderTest extends BaseStorageTest {
         final String data = writeData();
         addDataMeta();
 
-        final int read = this.reader.readFile(bufRef, "data", 0, 1024);
+        final int read = this.reader.readFile(bufRef, "data", 0, 0, 1024);
         assertEquals(-1, read);
         final ByteBuffer buf = bufRef.getBuffer();
         buf.flip();


### PR DESCRIPTION
### Motivation:

快照在网络传输过程中可能由于各种原因导致传输中断的问题，此改动增加了大文件并行传输和断点续传的功能

### Modification:

设计思路：

1.首先leader在InstallSnapshot流程中的loadMetaTable的时候计算快照文件的分片数目，将快照文件的分片数据放入LocalFileMeta

传输给follower。

2.follower获取到LocalFileMeta，取其中的文件名，然后查看本机是否有已接收的快照分片段，将各个快照分片段的文件大小并行

传输给leader。

3.leader接收到follower的GetFileRequest，从指定的文件断点位置传输数据。

4.所有的快照分片传输完毕，将分片合并，合并完成后删除掉分片文件。

### Result:

Fixes #503

