### PR TITLE
Make ReadIndexHeartbeatResponseClosure some property volatile.

### DIFF
--- a/jraft-core/src/main/java/com/alipay/sofa/jraft/core/NodeImpl.java
+++ b/jraft-core/src/main/java/com/alipay/sofa/jraft/core/NodeImpl.java
@@ -1434,9 +1434,9 @@ public class NodeImpl implements Node, RaftServerService {
         final RpcResponseClosure<ReadIndexResponse> closure;
         final int                                   quorum;
         final int                                   failPeersThreshold;
-        int                                         ackSuccess;
-        int                                         ackFailures;
-        boolean                                     isDone;
+        volatile int                                ackSuccess;
+        volatile int                                ackFailures;
+        volatile boolean                            isDone;
 
         public ReadIndexHeartbeatResponseClosure(final RpcResponseClosure<ReadIndexResponse> closure,
                                                  final ReadIndexResponse.Builder rb, final int quorum,


### PR DESCRIPTION
### Motivation:

ReadIndexHeartbeatResponseClosure maybe will be back call in different thread, so make some stateful property volatile.