### PR TITLE
1.3.8

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,7 +29,10 @@ jobs:
         with:
           java-version: 1.8
       - name: Maven Test
-        run: mvn --projects jraft-core test || mvn --projects jraft-core test || mvn --projects jraft-core test
+        run: mvn clean install -DskipTests=true -Dmaven.javadoc.skip=true -B -V
+          && (mvn --projects jraft-core test
+            || mvn --projects jraft-core test
+            || mvn --projects jraft-core test)
 
   test_rheakv_core:
     needs: check_format
@@ -41,7 +44,10 @@ jobs:
         with:
           java-version: 1.8
       - name: Maven Test
-        run: mvn --projects jraft-rheakv/rheakv-core test || mvn --projects jraft-rheakv/rheakv-core test || mvn --projects jraft-rheakv/rheakv-core test
+        run: mvn clean install -DskipTests=true -Dmaven.javadoc.skip=true -B -V
+          && (mvn --projects jraft-rheakv/rheakv-core test
+            || mvn --projects jraft-rheakv/rheakv-core test
+            || mvn --projects jraft-rheakv/rheakv-core test)
 
   test_rheakv_pd:
     needs: check_format
@@ -53,7 +59,10 @@ jobs:
         with:
           java-version: 1.8
       - name: Maven Test
-        run: mvn --projects jraft-rheakv/rheakv-pd test || mvn --projects jraft-rheakv/rheakv-pd test || mvn --projects jraft-rheakv/rheakv-pd test
+        run: mvn clean install -DskipTests=true -Dmaven.javadoc.skip=true -B -V
+          && (mvn --projects jraft-rheakv/rheakv-pd test
+            || mvn --projects jraft-rheakv/rheakv-pd test
+            || mvn --projects jraft-rheakv/rheakv-pd test)
 
   test_rpc_grpc_impl:
     needs: check_format
@@ -65,4 +74,7 @@ jobs:
         with:
           java-version: 1.8
       - name: Maven Test
-        run: mvn --projects jraft-extension/rpc-grpc-impl test || mvn --projects jraft-extension/rpc-grpc-impl test || mvn --projects jraft-extension/rpc-grpc-impl test
+        run: mvn clean install -DskipTests=true -Dmaven.javadoc.skip=true -B -V
+          && (mvn --projects jraft-extension/rpc-grpc-impl test
+            || mvn --projects jraft-extension/rpc-grpc-impl test
+            || mvn --projects jraft-extension/rpc-grpc-impl test)

--- a/jraft-core/pom.xml
+++ b/jraft-core/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>jraft-parent</artifactId>
         <groupId>com.alipay.sofa</groupId>
-        <version>1.3.7</version>
+        <version>1.3.8</version>
     </parent>
     <artifactId>jraft-core</artifactId>
     <packaging>jar</packaging>

--- a/jraft-example/pom.xml
+++ b/jraft-example/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>jraft-parent</artifactId>
         <groupId>com.alipay.sofa</groupId>
-        <version>1.3.7</version>
+        <version>1.3.8</version>
     </parent>
     <artifactId>jraft-example</artifactId>
     <packaging>jar</packaging>

--- a/jraft-extension/pom.xml
+++ b/jraft-extension/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>jraft-parent</artifactId>
         <groupId>com.alipay.sofa</groupId>
-        <version>1.3.7</version>
+        <version>1.3.8</version>
     </parent>
 
     <artifactId>jraft-extension</artifactId>

--- a/jraft-extension/rpc-grpc-impl/pom.xml
+++ b/jraft-extension/rpc-grpc-impl/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>jraft-extension</artifactId>
         <groupId>com.alipay.sofa</groupId>
-        <version>1.3.7</version>
+        <version>1.3.8</version>
     </parent>
 
     <artifactId>rpc-grpc-impl</artifactId>

--- a/jraft-rheakv/pom.xml
+++ b/jraft-rheakv/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>jraft-parent</artifactId>
         <groupId>com.alipay.sofa</groupId>
-        <version>1.3.7</version>
+        <version>1.3.8</version>
     </parent>
 
     <artifactId>jraft-rheakv</artifactId>

--- a/jraft-rheakv/rheakv-core/pom.xml
+++ b/jraft-rheakv/rheakv-core/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>jraft-rheakv</artifactId>
         <groupId>com.alipay.sofa</groupId>
-        <version>1.3.7</version>
+        <version>1.3.8</version>
     </parent>
 
     <artifactId>jraft-rheakv-core</artifactId>

--- a/jraft-rheakv/rheakv-pd/pom.xml
+++ b/jraft-rheakv/rheakv-pd/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>jraft-rheakv</artifactId>
         <groupId>com.alipay.sofa</groupId>
-        <version>1.3.7</version>
+        <version>1.3.8</version>
     </parent>
 
     <artifactId>jraft-rheakv-pd</artifactId>

--- a/jraft-test/pom.xml
+++ b/jraft-test/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>jraft-parent</artifactId>
         <groupId>com.alipay.sofa</groupId>
-        <version>1.3.7</version>
+        <version>1.3.8</version>
     </parent>
     <artifactId>jraft-test</artifactId>
     <packaging>jar</packaging>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>com.alipay.sofa</groupId>
     <artifactId>jraft-parent</artifactId>
-    <version>1.3.7</version>
+    <version>1.3.8</version>
     <packaging>pom</packaging>
 
     <name>${project.groupId}:${project.artifactId}</name>


### PR DESCRIPTION
* [x] unit test
 * [x] [jepsen verification](https://github.com/sofastack/sofa-jraft-jepsen)
    - [x] configuration-test: remove and add a random node
    - [x] bridge-test: weaving the network into happy little intersecting majority rings
    - [x] pause-test: pausing random node with SIGSTOP/SIGCONT
    - [x] crash-test: killing random nodes and restarting them
    - [x] partition-test: Cuts the network into randomly chosen halves
    - [x] partition-majority-test: Cuts the network into randomly majority groups
 * [x] release note
 * [ ] release


## 1.3.8

2021-08-09


- Features
    - Snapshot 支持并行压缩/解压缩，充分利用多核，加速在 snapshot 较大的时的 load 和 save 速度 #603 
    - CliService 提供 learner 到 follower 的转换 API
    - Node 暴露 getNodeState API 方便运维使用
    
- Bug Fixes
    - 修复 install snapshot retry 失败的 bug #606 
    - 一些 help GC 的优化 #619 #629 
    - 修复 segment log 的 producer 和 consumer 之间可能发生的死锁 #649 
    - 修复在 replicator 销毁时移除相应的 metric 失败 #643 
    - 修复 RheaKV 在成员发生变更时没有刷新路由表的 bug #652 

- Breaking Changes
    - 无

- 致谢（排名不分先后）
@seeflood @a364176773 @horizonzy @hzh0425 @xiaoheng1 @312223105 

