### PR TITLE
Optimize resetPendingStatusError's call back.

### DIFF
--- a/jraft-core/src/main/java/com/alipay/sofa/jraft/core/ReadOnlyServiceImpl.java
+++ b/jraft-core/src/main/java/com/alipay/sofa/jraft/core/ReadOnlyServiceImpl.java
@@ -237,12 +237,14 @@ public class ReadOnlyServiceImpl implements ReadOnlyService, LastAppliedLogIndex
     private void resetPendingStatusError(final Status st) {
         this.lock.lock();
         try {
-            for (final List<ReadIndexStatus> statuses : this.pendingNotifyStatus.values()) {
+            final Iterator<List<ReadIndexStatus>> it = this.pendingNotifyStatus.values().iterator();
+            while (it.hasNext()) {
+                final List<ReadIndexStatus> statuses = it.next();
                 for (final ReadIndexStatus status : statuses) {
                     reportError(status, st);
                 }
+                it.remove();
             }
-            this.pendingNotifyStatus.clear();
         } finally {
             this.lock.unlock();
         }


### PR DESCRIPTION
### Motivation:
If StateMachine error, will invoke resetPendingStatusError. If pendingNotifyStatus hold much status, at status closure run, it maybe request to leader to get data. So here step by step to run closure and remove it from pendingNotifyStatus.






