### PR TITLE
Process in io thread

### DIFF
--- a/jraft-core/src/main/java/com/alipay/sofa/jraft/rpc/RpcProcessor.java
+++ b/jraft-core/src/main/java/com/alipay/sofa/jraft/rpc/RpcProcessor.java
@@ -58,6 +58,10 @@ public interface RpcProcessor<T> {
         return null;
     }
 
+    default boolean processInIOThread() {
+        return false;
+    }
+
     /**
      * Executor selector interface.
      */

--- a/jraft-core/src/main/java/com/alipay/sofa/jraft/rpc/impl/BoltRpcServer.java
+++ b/jraft-core/src/main/java/com/alipay/sofa/jraft/rpc/impl/BoltRpcServer.java
@@ -144,7 +144,7 @@ public class BoltRpcServer implements RpcServer {
 
             @Override
             public boolean processInIOThread() {
-                return true;
+                return processor.processInIOThread();
             }
         });
     }

--- a/jraft-core/src/main/java/com/alipay/sofa/jraft/rpc/impl/BoltRpcServer.java
+++ b/jraft-core/src/main/java/com/alipay/sofa/jraft/rpc/impl/BoltRpcServer.java
@@ -141,6 +141,11 @@ public class BoltRpcServer implements RpcServer {
             public Executor getExecutor() {
                 return processor.executor();
             }
+
+            @Override
+            public boolean processInIOThread() {
+                return true;
+            }
         });
     }
 


### PR DESCRIPTION
对于用户请求：com.alipay.sofa.jraft.core.ReadOnlyServiceImpl#addRequest 和 com.alipay.sofa.jraft.core.NodeImpl#apply 都会启用 Disruptor 进行异步处理。为了减少上下文切换， 允许用户设置  processInIOThread()。