### PR TITLE
feat/Grpc_streaming_appendEntries_feature

### DIFF
--- a/jraft-core/pom.xml
+++ b/jraft-core/pom.xml
@@ -113,6 +113,19 @@
             <groupId>com.alipay.sofa</groupId>
             <artifactId>hessian</artifactId>
         </dependency>
+        <!-- grpc  -->
+        <dependency>
+            <groupId>io.grpc</groupId>
+            <artifactId>grpc-netty-shaded</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.grpc</groupId>
+            <artifactId>grpc-protobuf</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.grpc</groupId>
+            <artifactId>grpc-stub</artifactId>
+        </dependency>
         <!-- metrics -->
         <dependency>
             <groupId>io.dropwizard.metrics</groupId>

--- a/jraft-core/src/main/java/com/alipay/sofa/jraft/rpc/RpcClient.java
+++ b/jraft-core/src/main/java/com/alipay/sofa/jraft/rpc/RpcClient.java
@@ -21,6 +21,8 @@ import com.alipay.sofa.jraft.ReplicatorGroup;
 import com.alipay.sofa.jraft.error.RemotingException;
 import com.alipay.sofa.jraft.option.RpcOptions;
 import com.alipay.sofa.jraft.util.Endpoint;
+import com.google.protobuf.Message;
+import io.grpc.stub.StreamObserver;
 
 /**
  *
@@ -107,4 +109,33 @@ public interface RpcClient extends Lifecycle<RpcOptions> {
      */
     void invokeAsync(final Endpoint endpoint, final Object request, final InvokeContext ctx, final InvokeCallback callback,
                      final long timeoutMs) throws InterruptedException, RemotingException;
+
+
+    /**
+     * Streaming invocation with a callback.
+     *
+     * @param endpoint  target address
+     * @param request   request object
+     * @param callback  invoke callback
+     * @param timeoutMs timeout millisecond
+     * @return request stream observer.
+     */
+    default StreamObserver<Message> invokeBidiStreaming(final Endpoint endpoint, final Object request, final InvokeCallback callback,
+                                                        final long timeoutMs) {
+        return invokeBidiStreaming(endpoint, request, null, callback, timeoutMs);
+    }
+
+
+
+    /**
+     * Streaming invocation with a callback.
+     *
+     * @param endpoint  target address
+     * @param request   request object
+     * @param callback  invoke callback
+     * @param timeoutMs timeout millisecond
+     * @return request stream observer.
+     */
+    StreamObserver<Message> invokeBidiStreaming(final Endpoint endpoint, final Object request, final InvokeContext ctx, final InvokeCallback callback,
+                                                final long timeoutMs);
 }

--- a/jraft-core/src/main/java/com/alipay/sofa/jraft/rpc/RpcServer.java
+++ b/jraft-core/src/main/java/com/alipay/sofa/jraft/rpc/RpcServer.java
@@ -40,6 +40,13 @@ public interface RpcServer extends Lifecycle<Void> {
     void registerProcessor(final RpcProcessor<?> processor);
 
     /**
+     * Register streaming user processor.
+     *
+     * @param processor the user processor which has a interest
+     */
+    void registerBidiStreamingProcessor(final RpcProcessor<?> processor);
+
+    /**
      *
      * @return bound port
      */

--- a/jraft-core/src/main/java/com/alipay/sofa/jraft/rpc/impl/BoltRpcClient.java
+++ b/jraft-core/src/main/java/com/alipay/sofa/jraft/rpc/impl/BoltRpcClient.java
@@ -16,9 +16,6 @@
  */
 package com.alipay.sofa.jraft.rpc.impl;
 
-import java.util.Map;
-import java.util.concurrent.Executor;
-
 import com.alipay.remoting.ConnectionEventType;
 import com.alipay.remoting.RejectedExecutionPolicy;
 import com.alipay.remoting.config.switches.GlobalSwitch;
@@ -32,6 +29,11 @@ import com.alipay.sofa.jraft.rpc.RpcClient;
 import com.alipay.sofa.jraft.rpc.impl.core.ClientServiceConnectionEventProcessor;
 import com.alipay.sofa.jraft.util.Endpoint;
 import com.alipay.sofa.jraft.util.Requires;
+import com.google.protobuf.Message;
+import io.grpc.stub.StreamObserver;
+
+import java.util.Map;
+import java.util.concurrent.Executor;
 
 /**
  * Bolt rpc client impl.
@@ -115,6 +117,14 @@ public class BoltRpcClient implements RpcClient {
         } catch (final com.alipay.remoting.exception.RemotingException e) {
             throw new RemotingException(e);
         }
+    }
+
+    // Bolt don't support streaming invoke
+    @Override
+    public StreamObserver<Message> invokeBidiStreaming(final Endpoint endpoint, final Object request,
+                                                       final InvokeContext ctx, final InvokeCallback callback,
+                                                       final long timeoutMs) {
+        throw new IllegalStateException("not implemented");
     }
 
     public com.alipay.remoting.rpc.RpcClient getRpcClient() {

--- a/jraft-core/src/main/java/com/alipay/sofa/jraft/rpc/impl/BoltRpcServer.java
+++ b/jraft-core/src/main/java/com/alipay/sofa/jraft/rpc/impl/BoltRpcServer.java
@@ -16,8 +16,6 @@
  */
 package com.alipay.sofa.jraft.rpc.impl;
 
-import java.util.concurrent.Executor;
-
 import com.alipay.remoting.AsyncContext;
 import com.alipay.remoting.BizContext;
 import com.alipay.remoting.ConnectionEventType;
@@ -28,6 +26,8 @@ import com.alipay.sofa.jraft.rpc.RpcContext;
 import com.alipay.sofa.jraft.rpc.RpcProcessor;
 import com.alipay.sofa.jraft.rpc.RpcServer;
 import com.alipay.sofa.jraft.util.Requires;
+
+import java.util.concurrent.Executor;
 
 /**
  * Bolt RPC server impl.
@@ -142,6 +142,11 @@ public class BoltRpcServer implements RpcServer {
                 return processor.executor();
             }
         });
+    }
+
+    @Override
+    public void registerBidiStreamingProcessor(final RpcProcessor<?> processor) {
+        throw new IllegalStateException("not implemented");
     }
 
     public com.alipay.remoting.rpc.RpcServer getServer() {

--- a/jraft-core/src/test/java/com/alipay/sofa/jraft/rpc/AbstractClientServiceTest.java
+++ b/jraft-core/src/test/java/com/alipay/sofa/jraft/rpc/AbstractClientServiceTest.java
@@ -16,18 +16,6 @@
  */
 package com.alipay.sofa.jraft.rpc;
 
-import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.Future;
-
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.ArgumentCaptor;
-import org.mockito.Mock;
-import org.mockito.Mockito;
-import org.mockito.runners.MockitoJUnitRunner;
-
 import com.alipay.sofa.jraft.Status;
 import com.alipay.sofa.jraft.error.InvokeTimeoutException;
 import com.alipay.sofa.jraft.error.RaftError;
@@ -40,6 +28,17 @@ import com.alipay.sofa.jraft.test.TestUtils;
 import com.alipay.sofa.jraft.util.Endpoint;
 import com.alipay.sofa.jraft.util.RpcFactoryHelper;
 import com.google.protobuf.Message;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;

--- a/pom.xml
+++ b/pom.xml
@@ -57,6 +57,7 @@
         <disruptor.version>3.3.7</disruptor.version>
         <hamcrest.version>1.3</hamcrest.version>
         <hessian.version>3.3.6</hessian.version>
+        <io.grpc.version>1.17.0</io.grpc.version>
         <jacoco.path>${project.build.directory}/jacoco.exec</jacoco.path>
         <jacoco.skip>true</jacoco.skip>
         <java.source.version>1.8</java.source.version>
@@ -136,6 +137,22 @@
                 <groupId>com.alipay.sofa</groupId>
                 <artifactId>hessian</artifactId>
                 <version>${hessian.version}</version>
+            </dependency>
+            <!-- grpc  -->
+            <dependency>
+                <groupId>io.grpc</groupId>
+                <artifactId>grpc-netty-shaded</artifactId>
+                <version>${io.grpc.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.grpc</groupId>
+                <artifactId>grpc-protobuf</artifactId>
+                <version>${io.grpc.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.grpc</groupId>
+                <artifactId>grpc-stub</artifactId>
+                <version>${io.grpc.version}</version>
             </dependency>
             <!-- log facade -->
             <dependency>


### PR DESCRIPTION
issue : https://github.com/sofastack/sofa-jraft/issues/672

 

- [x]  首先 在 rpc api 中新增 streaming 接口（RpcClient, RpcServer），然后基于 grpc 实现之
- [ ]  抽象出 Replicator，将现有的 Replicator 作为默认的一种实现
- [ ]  基于 streaming API 实现一个崭新的 Replicator，将这个特性基于 SPI 扩展，使用哪种 Replicator 由用户选择
