### PR TITLE
fix: grpc conn refresh

### DIFF
--- a/jraft-core/src/test/java/com/alipay/sofa/jraft/rpc/ConnectionRefreshTest.java
+++ b/jraft-core/src/test/java/com/alipay/sofa/jraft/rpc/ConnectionRefreshTest.java
@@ -1,0 +1,60 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alipay.sofa.jraft.rpc;
+
+import org.junit.Ignore;
+import org.junit.Test;
+
+import com.alipay.sofa.jraft.rpc.impl.PingRequestProcessor;
+import com.alipay.sofa.jraft.util.Endpoint;
+import com.alipay.sofa.jraft.util.RpcFactoryHelper;
+
+/**
+ *
+ * @author jiachun.fjc
+ */
+public class ConnectionRefreshTest {
+
+    @Ignore
+    @Test
+    public void simulation() throws InterruptedException {
+        ProtobufMsgFactory.load();
+
+        final RpcServer server = RpcFactoryHelper.rpcFactory().createRpcServer(new Endpoint("127.0.0.1", 19991));
+        server.registerProcessor(new PingRequestProcessor());
+        server.init(null);
+
+        final Endpoint target = new Endpoint("my.test.host1.com", 19991);
+
+        final RpcClient client = RpcFactoryHelper.rpcFactory().createRpcClient();
+        client.init(null);
+
+        final RpcRequests.PingRequest req = RpcRequests.PingRequest.newBuilder() //
+            .setSendTimestamp(System.currentTimeMillis()) //
+            .build();
+
+        for (int i = 0; i < 1000; i++) {
+            try {
+                final Object resp = client.invokeSync(target, req, 3000);
+                System.out.println(resp);
+            } catch (final Exception e) {
+                e.printStackTrace();
+            }
+            Thread.sleep(1000);
+        }
+    }
+}

--- a/jraft-core/src/test/resources/log4j2.xml
+++ b/jraft-core/src/test/resources/log4j2.xml
@@ -3,12 +3,12 @@
 
     <Appenders>
         <Console name="Console" target="SYSTEM_OUT">
-            <PatternLayout pattern="%d{YYYY-MM-dd HH:mm:ss} [%t] %-5p %c{1}:%L - %msg%n"/>
+            <PatternLayout pattern="%d{YYYY-MM-dd HH:mm:ss.SSS} [%t] %-5p %c{1}:%L - %msg%n"/>
         </Console>
 
         <RollingFile name="RollingFile" filename="log/jraft-test.log"
                      filepattern="log/%d{YYYYMMddHHmmss}-jraft-test.log">
-            <PatternLayout pattern="%d{YYYY-MM-dd HH:mm:ss} [%t] %-5p %c{1}:%L - %msg%n"/>
+            <PatternLayout pattern="%d{YYYY-MM-dd HH:mm:ss.SSS} [%t] %-5p %c{1}:%L - %msg%n"/>
             <Policies>
                 <SizeBasedTriggeringPolicy size="100 MB"/>
             </Policies>

--- a/jraft-extension/rpc-grpc-impl/src/main/java/com/alipay/sofa/jraft/rpc/impl/GrpcClient.java
+++ b/jraft-extension/rpc-grpc-impl/src/main/java/com/alipay/sofa/jraft/rpc/impl/GrpcClient.java
@@ -203,6 +203,9 @@ public class GrpcClient implements RpcClient {
 
     private void onChannelReady(final Endpoint endpoint) {
         LOG.info("The channel {} has successfully established.", endpoint);
+
+        clearConnFailuresCount(endpoint);
+
         final ReplicatorGroup rpGroup = this.replicatorGroup;
         if (rpGroup != null) {
             try {
@@ -280,6 +283,10 @@ public class GrpcClient implements RpcClient {
 
     private int incConnFailuresCount(final Endpoint endpoint) {
         return this.transientFailures.computeIfAbsent(endpoint, ep -> new AtomicInteger()).incrementAndGet();
+    }
+
+    private void clearConnFailuresCount(final Endpoint endpoint) {
+        this.transientFailures.remove(endpoint);
     }
 
     private void mayResetConnectBackoff(final Endpoint endpoint, final ManagedChannel ch) {

--- a/jraft-extension/rpc-grpc-impl/src/test/java/com/alipay/sofa/jraft/rpc/ConnectionRefreshTest.java
+++ b/jraft-extension/rpc-grpc-impl/src/test/java/com/alipay/sofa/jraft/rpc/ConnectionRefreshTest.java
@@ -1,0 +1,60 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alipay.sofa.jraft.rpc;
+
+import org.junit.Ignore;
+import org.junit.Test;
+
+import com.alipay.sofa.jraft.rpc.impl.PingRequestProcessor;
+import com.alipay.sofa.jraft.util.Endpoint;
+import com.alipay.sofa.jraft.util.RpcFactoryHelper;
+
+/**
+ *
+ * @author jiachun.fjc
+ */
+public class ConnectionRefreshTest {
+
+    @Ignore
+    @Test
+    public void simulation() throws InterruptedException {
+        ProtobufMsgFactory.load();
+
+        final RpcServer server = RpcFactoryHelper.rpcFactory().createRpcServer(new Endpoint("127.0.0.1", 19991));
+        server.registerProcessor(new PingRequestProcessor());
+        server.init(null);
+
+        final Endpoint target = new Endpoint("my.test.host1.com", 19991);
+
+        final RpcClient client = RpcFactoryHelper.rpcFactory().createRpcClient();
+        client.init(null);
+
+        final RpcRequests.PingRequest req = RpcRequests.PingRequest.newBuilder() //
+            .setSendTimestamp(System.currentTimeMillis()) //
+            .build();
+
+        for (int i = 0; i < 1000; i++) {
+            try {
+                final Object resp = client.invokeSync(target, req, 3000);
+                System.out.println(resp);
+            } catch (final Exception e) {
+                e.printStackTrace();
+            }
+            Thread.sleep(1000);
+        }
+    }
+}


### PR DESCRIPTION
### Motivation:

 when the grpc connection failures too many times(default: 3), reset the connect backoff and reconnect immediately


### Result:

Fixes #683 

If there is no issue then describe the changes introduced by this PR.
