### PR TITLE
rocksdb support config max wal log size, default value is 1G.

### DIFF
--- a/jraft-core/src/main/java/com/alipay/sofa/jraft/util/StorageOptionsFactory.java
+++ b/jraft-core/src/main/java/com/alipay/sofa/jraft/util/StorageOptionsFactory.java
@@ -122,11 +122,11 @@ public final class StorageOptionsFactory {
         // are always kept open.
         opts.setMaxOpenFiles(-1);
 
-        // To limit the num of LOG, Once LOG exceed this num, RocksDB will delete old LOG
+        // To limit the num of LOG. Once LOG exceed this num, RocksDB will delete old LOG
         // automatically.
         opts.setKeepLogFileNum(100);
 
-        // To limit the size of WALs, Once WALs exceed this size, RocksDB will start
+        // To limit the size of WALs. Once WALs exceed this size, RocksDB will start
         // forcing the flush of column families to allow deletion of some oldest WALs.
         // We make it 1G as default.
         opts.setMaxTotalWalSize(1 << 30);


### PR DESCRIPTION
### Motivation:
Fixes-#700
rocksdb's write operation will generate wal log, and rheaKv and raft log both use rocksdb.

So we support a way to limit the wal file num. 
`rhea.rocksdb.user.max_total_wal_size.bytes` to config rhea kv max_total_wal_size, defualt valus is `1G`.
`jraft.log.storage.rocksdb.max_total_wal_size.bytes` to config raft log storage max_total_wal_size, default value is `1G`.
 


