### PR TITLE
Rre check connection before send install snapshot request

### DIFF
--- a/jraft-core/src/main/java/com/alipay/sofa/jraft/core/Replicator.java
+++ b/jraft-core/src/main/java/com/alipay/sofa/jraft/core/Replicator.java
@@ -618,6 +618,11 @@ public class Replicator implements ThreadId.OnError {
             return;
         }
         boolean doUnlock = true;
+        if (!rpcService.checkConnection(options.getPeerId().getEndpoint(), true)) {
+            LOG.error("Fail to check install snapshot connection to peer={}, give up to send install snapshot request.", options.getPeerId().getEndpoint());
+            unlockId();
+            return;
+        }
         try {
             Requires.requireTrue(this.reader == null,
                 "Replicator %s already has a snapshot reader, current state is %s", this.options.getPeerId(),

--- a/jraft-core/src/main/java/com/alipay/sofa/jraft/core/Replicator.java
+++ b/jraft-core/src/main/java/com/alipay/sofa/jraft/core/Replicator.java
@@ -620,7 +620,7 @@ public class Replicator implements ThreadId.OnError {
         boolean doUnlock = true;
         if (!rpcService.connect(options.getPeerId().getEndpoint())) {
             LOG.error("Fail to check install snapshot connection to peer={}, give up to send install snapshot request.", options.getPeerId().getEndpoint());
-            unlockId();
+            block(System.currentTimeMillis(), RaftError.EHOSTDOWN.getNumber());
             return;
         }
         try {

--- a/jraft-core/src/main/java/com/alipay/sofa/jraft/core/Replicator.java
+++ b/jraft-core/src/main/java/com/alipay/sofa/jraft/core/Replicator.java
@@ -620,7 +620,7 @@ public class Replicator implements ThreadId.OnError {
         boolean doUnlock = true;
         if (!rpcService.connect(options.getPeerId().getEndpoint())) {
             LOG.error("Fail to check install snapshot connection to peer={}, give up to send install snapshot request.", options.getPeerId().getEndpoint());
-            block(System.currentTimeMillis(), RaftError.EHOSTDOWN.getNumber());
+            block(Utils.nowMs(), RaftError.EHOSTDOWN.getNumber());
             return;
         }
         try {

--- a/jraft-core/src/main/java/com/alipay/sofa/jraft/core/Replicator.java
+++ b/jraft-core/src/main/java/com/alipay/sofa/jraft/core/Replicator.java
@@ -618,7 +618,7 @@ public class Replicator implements ThreadId.OnError {
             return;
         }
         boolean doUnlock = true;
-        if (!rpcService.checkConnection(options.getPeerId().getEndpoint(), true)) {
+        if (!rpcService.connect(options.getPeerId().getEndpoint())) {
             LOG.error("Fail to check install snapshot connection to peer={}, give up to send install snapshot request.", options.getPeerId().getEndpoint());
             unlockId();
             return;


### PR DESCRIPTION
### Motivation:
fixees #705
pre check connection before send install snapshot request, to avoid performance loss of reader initialization.
