### PR TITLE
(fix) Potential blocking risk for thread calling JoinableClosure#run(status)

### DIFF
--- a/jraft-core/src/main/java/com/alipay/sofa/jraft/closure/JoinableClosure.java
+++ b/jraft-core/src/main/java/com/alipay/sofa/jraft/closure/JoinableClosure.java
@@ -38,8 +38,11 @@ public class JoinableClosure implements Closure {
 
     @Override
     public void run(final Status status) {
-        this.closure.run(status);
-        latch.countDown();
+        try {
+            this.closure.run(status);
+        } finally {
+            latch.countDown();
+        }
     }
 
     public void join() throws InterruptedException {


### PR DESCRIPTION
### Motivation:

CountDownLatch is best placed into finally statement to avoid thread blocking when calls Closure#run(status) throw an exception.
Although will not appear in the current project, it may occur in subsequent iterations.

### Modification:

amend method: JoinableClosure#run(status)

