### PR TITLE
1.3.9

### DIFF
--- a/jraft-core/pom.xml
+++ b/jraft-core/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>jraft-parent</artifactId>
         <groupId>com.alipay.sofa</groupId>
-        <version>1.3.8</version>
+        <version>1.3.9</version>
     </parent>
     <artifactId>jraft-core</artifactId>
     <packaging>jar</packaging>

--- a/jraft-example/pom.xml
+++ b/jraft-example/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>jraft-parent</artifactId>
         <groupId>com.alipay.sofa</groupId>
-        <version>1.3.8</version>
+        <version>1.3.9</version>
     </parent>
     <artifactId>jraft-example</artifactId>
     <packaging>jar</packaging>

--- a/jraft-extension/pom.xml
+++ b/jraft-extension/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>jraft-parent</artifactId>
         <groupId>com.alipay.sofa</groupId>
-        <version>1.3.8</version>
+        <version>1.3.9</version>
     </parent>
 
     <artifactId>jraft-extension</artifactId>

--- a/jraft-extension/rpc-grpc-impl/pom.xml
+++ b/jraft-extension/rpc-grpc-impl/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>jraft-extension</artifactId>
         <groupId>com.alipay.sofa</groupId>
-        <version>1.3.8</version>
+        <version>1.3.9</version>
     </parent>
 
     <artifactId>rpc-grpc-impl</artifactId>

--- a/jraft-rheakv/pom.xml
+++ b/jraft-rheakv/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>jraft-parent</artifactId>
         <groupId>com.alipay.sofa</groupId>
-        <version>1.3.8</version>
+        <version>1.3.9</version>
     </parent>
 
     <artifactId>jraft-rheakv</artifactId>

--- a/jraft-rheakv/rheakv-core/pom.xml
+++ b/jraft-rheakv/rheakv-core/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>jraft-rheakv</artifactId>
         <groupId>com.alipay.sofa</groupId>
-        <version>1.3.8</version>
+        <version>1.3.9</version>
     </parent>
 
     <artifactId>jraft-rheakv-core</artifactId>

--- a/jraft-rheakv/rheakv-pd/pom.xml
+++ b/jraft-rheakv/rheakv-pd/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>jraft-rheakv</artifactId>
         <groupId>com.alipay.sofa</groupId>
-        <version>1.3.8</version>
+        <version>1.3.9</version>
     </parent>
 
     <artifactId>jraft-rheakv-pd</artifactId>

--- a/jraft-test/pom.xml
+++ b/jraft-test/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>jraft-parent</artifactId>
         <groupId>com.alipay.sofa</groupId>
-        <version>1.3.8</version>
+        <version>1.3.9</version>
     </parent>
     <artifactId>jraft-test</artifactId>
     <packaging>jar</packaging>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>com.alipay.sofa</groupId>
     <artifactId>jraft-parent</artifactId>
-    <version>1.3.8</version>
+    <version>1.3.9</version>
     <packaging>pom</packaging>
 
     <name>${project.groupId}:${project.artifactId}</name>


### PR DESCRIPTION
* [x] unit test
 * [x] [jepsen verification](https://github.com/sofastack/sofa-jraft-jepsen)
    - [x] configuration-test: remove and add a random node
    - [x] bridge-test: weaving the network into happy little intersecting majority rings
    - [x] pause-test: pausing random node with SIGSTOP/SIGCONT
    - [x] crash-test: killing random nodes and restarting them
    - [x] partition-test: Cuts the network into randomly chosen halves
    - [x] partition-majority-test: Cuts the network into randomly majority groups
 * [x] release note
 * [ ] release


## 1.3.9

2021-11.29


- Features
    - 升级 rocksdb 版本到 6.22.1.1 #674 
    - 安全升级：org.apache.commons:commons-compress 到 1.21
    - 升级 bolt 到 1.6.4 修复失败建连被阻塞一秒从而影响到选主
    - 提供 rocksdb max wal log size 等参数用于控制 rocksdb 占用磁盘大小 #704 
    - 优化 NodeImpl#shutdown 后立刻调用 join，简化 Node 关闭操作 #722 
    
- Bug Fixes
    - 修复 grpc 通信层在域名的 IP 变更时无法刷新连接一直失败 #690 

- Breaking Changes
    - 无

- 致谢（排名不分先后）
@alievmirza @xiaoheng1 @horizonzy @qiujiayu @xh1202 @hzh0425 @XiaoyiPeng @wanglunhui2012 @marks-yag @NoBugInHeaven 