### PR TITLE
Support a config to make read index read failfast.

### DIFF
--- a/jraft-core/src/main/java/com/alipay/sofa/jraft/core/ReadOnlyServiceImpl.java
+++ b/jraft-core/src/main/java/com/alipay/sofa/jraft/core/ReadOnlyServiceImpl.java
@@ -190,10 +190,16 @@ public class ReadOnlyServiceImpl implements ReadOnlyService, LastAppliedLogIndex
                     doUnlock = false;
                     notifySuccess(readIndexStatus);
                 } else {
-                    // Not applied, add it to pending-notify cache.
-                    ReadOnlyServiceImpl.this.pendingNotifyStatus
-                        .computeIfAbsent(readIndexStatus.getIndex(), k -> new ArrayList<>(10)) //
-                        .add(readIndexStatus);
+                    if (readIndexStatus.isOverReadIndexToleranceThreshold(ReadOnlyServiceImpl.this.fsmCaller.getLastAppliedIndex(), ReadOnlyServiceImpl.this.raftOptions.getReadIndexToleranceThreshold())) {
+                        ReadOnlyServiceImpl.this.lock.unlock();
+                        doUnlock = false;
+                        notifyFail(new Status(-1, "Fail to run ReadIndex task, the gap of current node's apply index between leader's commit index over readIndexToleranceThreshold"));
+                    } else  {
+                        // Not applied, add it to pending-notify cache.
+                        ReadOnlyServiceImpl.this.pendingNotifyStatus
+                            .computeIfAbsent(readIndexStatus.getIndex(), k -> new ArrayList<>(10)) //
+                            .add(readIndexStatus);
+                    }
                 }
             } finally {
                 if (doUnlock) {
@@ -405,6 +411,11 @@ public class ReadOnlyServiceImpl implements ReadOnlyService, LastAppliedLogIndex
     @OnlyForTest
     TreeMap<Long, List<ReadIndexStatus>> getPendingNotifyStatus() {
         return this.pendingNotifyStatus;
+    }
+
+    @OnlyForTest
+    RaftOptions getRaftOptions() {
+        return raftOptions;
     }
 
     private void reportError(final ReadIndexStatus status, final Status st) {

--- a/jraft-core/src/main/java/com/alipay/sofa/jraft/core/ReadOnlyServiceImpl.java
+++ b/jraft-core/src/main/java/com/alipay/sofa/jraft/core/ReadOnlyServiceImpl.java
@@ -190,10 +190,10 @@ public class ReadOnlyServiceImpl implements ReadOnlyService, LastAppliedLogIndex
                     doUnlock = false;
                     notifySuccess(readIndexStatus);
                 } else {
-                    if (readIndexStatus.isOverReadIndexToleranceThreshold(ReadOnlyServiceImpl.this.fsmCaller.getLastAppliedIndex(), ReadOnlyServiceImpl.this.raftOptions.getReadIndexToleranceThreshold())) {
+                    if (readIndexStatus.isOverMaxReadIndexLag(ReadOnlyServiceImpl.this.fsmCaller.getLastAppliedIndex(), ReadOnlyServiceImpl.this.raftOptions.getMaxReadIndexLag())) {
                         ReadOnlyServiceImpl.this.lock.unlock();
                         doUnlock = false;
-                        notifyFail(new Status(-1, "Fail to run ReadIndex task, the gap of current node's apply index between leader's commit index over readIndexToleranceThreshold"));
+                        notifyFail(new Status(-1, "Fail to run ReadIndex task, the gap of current node's apply index between leader's commit index over maxReadIndexLag"));
                     } else  {
                         // Not applied, add it to pending-notify cache.
                         ReadOnlyServiceImpl.this.pendingNotifyStatus

--- a/jraft-core/src/main/java/com/alipay/sofa/jraft/entity/ReadIndexStatus.java
+++ b/jraft-core/src/main/java/com/alipay/sofa/jraft/entity/ReadIndexStatus.java
@@ -42,6 +42,13 @@ public class ReadIndexStatus {
         return appliedIndex >= this.index;
     }
 
+    public boolean isOverReadIndexToleranceThreshold(long applyIndex, int readIndexToleranceThreshold) {
+        if (readIndexToleranceThreshold < 0) {
+            return false;
+        }
+        return this.index - applyIndex > readIndexToleranceThreshold;
+    }
+
     public long getIndex() {
         return index;
     }

--- a/jraft-core/src/main/java/com/alipay/sofa/jraft/entity/ReadIndexStatus.java
+++ b/jraft-core/src/main/java/com/alipay/sofa/jraft/entity/ReadIndexStatus.java
@@ -42,11 +42,11 @@ public class ReadIndexStatus {
         return appliedIndex >= this.index;
     }
 
-    public boolean isOverReadIndexToleranceThreshold(long applyIndex, int readIndexToleranceThreshold) {
-        if (readIndexToleranceThreshold < 0) {
+    public boolean isOverMaxReadIndexLag(long applyIndex, int maxReadIndexLag) {
+        if (maxReadIndexLag < 0) {
             return false;
         }
-        return this.index - applyIndex > readIndexToleranceThreshold;
+        return this.index - applyIndex > maxReadIndexLag;
     }
 
     public long getIndex() {

--- a/jraft-core/src/main/java/com/alipay/sofa/jraft/option/RaftOptions.java
+++ b/jraft-core/src/main/java/com/alipay/sofa/jraft/option/RaftOptions.java
@@ -81,6 +81,19 @@ public class RaftOptions implements Copiable<RaftOptions> {
      * in that case.
      */
     private ReadOnlyOption readOnlyOptions                      = ReadOnlyOption.ReadOnlySafe;
+
+    /**
+     * Read index read need compare current node's apply index with leader's commit index.
+     * Only current node's apply index catch up leader's commit index, then call back success to read index closure.
+     * Therefore, there is a waiting time. The default wait timeout is 2s. It means that the waiting time
+     * over 2s, then call back failure to read index closure. If current node occur problem, it's apply index maybe
+     * behind leader's commit index. In read index timeout, it can't catch up, the timeout is waste.
+     * Here supply a config to fix it. If the gap greater than readIndexToleranceThreshold, fail fast to call back failure
+     * read index closure.
+     * @since 1.4.0
+     */
+    private int            readIndexToleranceThreshold          = -1;
+
     /**
      * Candidate steps down when election reaching timeout, default is true(enabled).
      * @since 1.3.0
@@ -117,6 +130,14 @@ public class RaftOptions implements Copiable<RaftOptions> {
 
     public void setReadOnlyOptions(final ReadOnlyOption readOnlyOptions) {
         this.readOnlyOptions = readOnlyOptions;
+    }
+
+    public int getReadIndexToleranceThreshold() {
+        return readIndexToleranceThreshold;
+    }
+
+    public void setReadIndexToleranceThreshold(int readIndexToleranceThreshold) {
+        this.readIndexToleranceThreshold = readIndexToleranceThreshold;
     }
 
     public boolean isReplicatorPipeline() {

--- a/jraft-core/src/main/java/com/alipay/sofa/jraft/option/RaftOptions.java
+++ b/jraft-core/src/main/java/com/alipay/sofa/jraft/option/RaftOptions.java
@@ -88,11 +88,11 @@ public class RaftOptions implements Copiable<RaftOptions> {
      * Therefore, there is a waiting time. The default wait timeout is 2s. It means that the waiting time
      * over 2s, then call back failure to read index closure. If current node occur problem, it's apply index maybe
      * behind leader's commit index. In read index timeout, it can't catch up, the timeout is waste.
-     * Here supply a config to fix it. If the gap greater than readIndexToleranceThreshold, fail fast to call back failure
+     * Here supply a config to fix it. If the gap greater than maxReadIndexLag, fail fast to call back failure
      * read index closure.
      * @since 1.4.0
      */
-    private int            readIndexToleranceThreshold          = -1;
+    private int maxReadIndexLag = -1;
 
     /**
      * Candidate steps down when election reaching timeout, default is true(enabled).
@@ -132,12 +132,12 @@ public class RaftOptions implements Copiable<RaftOptions> {
         this.readOnlyOptions = readOnlyOptions;
     }
 
-    public int getReadIndexToleranceThreshold() {
-        return readIndexToleranceThreshold;
+    public int getMaxReadIndexLag() {
+        return maxReadIndexLag;
     }
 
-    public void setReadIndexToleranceThreshold(int readIndexToleranceThreshold) {
-        this.readIndexToleranceThreshold = readIndexToleranceThreshold;
+    public void setMaxReadIndexLag(int maxReadIndexLag) {
+        this.maxReadIndexLag = maxReadIndexLag;
     }
 
     public boolean isReplicatorPipeline() {

--- a/jraft-core/src/main/java/com/alipay/sofa/jraft/option/RaftOptions.java
+++ b/jraft-core/src/main/java/com/alipay/sofa/jraft/option/RaftOptions.java
@@ -92,7 +92,7 @@ public class RaftOptions implements Copiable<RaftOptions> {
      * read index closure.
      * @since 1.4.0
      */
-    private int maxReadIndexLag = -1;
+    private int            maxReadIndexLag                      = -1;
 
     /**
      * Candidate steps down when election reaching timeout, default is true(enabled).

--- a/jraft-core/src/test/java/com/alipay/sofa/jraft/core/ReadOnlyServiceTest.java
+++ b/jraft-core/src/test/java/com/alipay/sofa/jraft/core/ReadOnlyServiceTest.java
@@ -268,13 +268,13 @@ public class ReadOnlyServiceTest {
     }
 
     @Test
-    public void testOverReadIndexToleranceThreshold() throws Exception {
+    public void testOverMaxReadIndexLag() throws Exception {
         Mockito.when(this.fsmCaller.getLastAppliedIndex()).thenReturn(1L);
-        readOnlyServiceImpl.getRaftOptions().setReadIndexToleranceThreshold(50);
+        readOnlyServiceImpl.getRaftOptions().setMaxReadIndexLag(50);
 
         final byte[] requestContext = TestUtils.getRandomBytes();
         final CountDownLatch latch = new CountDownLatch(1);
-        final String errMsg = "Fail to run ReadIndex task, the gap of current node's apply index between leader's commit index over readIndexToleranceThreshold";
+        final String errMsg = "Fail to run ReadIndex task, the gap of current node's apply index between leader's commit index over maxReadIndexLag";
         this.readOnlyServiceImpl.addRequest(requestContext, new ReadIndexClosure() {
 
             @Override

--- a/jraft-core/src/test/java/com/alipay/sofa/jraft/core/ReadOnlyServiceTest.java
+++ b/jraft-core/src/test/java/com/alipay/sofa/jraft/core/ReadOnlyServiceTest.java
@@ -266,4 +266,51 @@ public class ReadOnlyServiceTest {
         latch.await();
         assertTrue(this.readOnlyServiceImpl.getPendingNotifyStatus().isEmpty());
     }
+
+    @Test
+    public void testOverReadIndexToleranceThreshold() throws Exception {
+        Mockito.when(this.fsmCaller.getLastAppliedIndex()).thenReturn(1L);
+        readOnlyServiceImpl.getRaftOptions().setReadIndexToleranceThreshold(50);
+
+        final byte[] requestContext = TestUtils.getRandomBytes();
+        final CountDownLatch latch = new CountDownLatch(1);
+        final String errMsg = "Fail to run ReadIndex task, the gap of current node's apply index between leader's commit index over readIndexToleranceThreshold";
+        this.readOnlyServiceImpl.addRequest(requestContext, new ReadIndexClosure() {
+
+            @Override
+            public void run(final Status status, final long index, final byte[] reqCtx) {
+                assertFalse(status.isOk());
+                assertEquals(status.getErrorMsg(), errMsg);
+                assertEquals(index, -1);
+                assertArrayEquals(reqCtx, requestContext);
+                latch.countDown();
+            }
+        });
+        this.readOnlyServiceImpl.flush();
+
+        final ArgumentCaptor<RpcResponseClosure> closureCaptor = ArgumentCaptor.forClass(RpcResponseClosure.class);
+
+        Mockito.verify(this.node).handleReadIndexRequest(Mockito.argThat(new ArgumentMatcher<ReadIndexRequest>() {
+
+            @Override
+            public boolean matches(final Object argument) {
+                if (argument instanceof ReadIndexRequest) {
+                    final ReadIndexRequest req = (ReadIndexRequest) argument;
+                    return req.getGroupId().equals("test") && req.getServerId().equals("localhost:8081:0")
+                           && req.getEntriesCount() == 1
+                           && Arrays.equals(requestContext, req.getEntries(0).toByteArray());
+                }
+                return false;
+            }
+
+        }), closureCaptor.capture());
+
+        final RpcResponseClosure closure = closureCaptor.getValue();
+
+        assertNotNull(closure);
+
+        closure.setResponse(ReadIndexResponse.newBuilder().setIndex(52).setSuccess(true).build());
+        closure.run(Status.OK());
+        latch.await();
+    }
 }


### PR DESCRIPTION
### Motivation:
Read index read need compare current node's apply index with leader's commit index. Only current node's apply index catch up leader's commit index, then call back success to read index closure. Therefore, there is a waiting time. The default wait timeout is 2s. It means that the waiting time over 2s, then call back failure to read index closure. If current node occur problem, it's apply index maybe behind leader's commit index. In read index timeout, it can't catch up, the timeout is waste. Here supply a config to fix it. If the gap greater than readIndexToleranceThreshold, fail fast to call back failure read index closure.

     
