### PR TITLE
Export api of getLastCommittedIndex and getLastAppliedIndex.

### DIFF
--- a/jraft-core/src/main/java/com/alipay/sofa/jraft/Node.java
+++ b/jraft-core/src/main/java/com/alipay/sofa/jraft/Node.java
@@ -333,4 +333,20 @@ public interface Node extends Lifecycle<NodeOptions>, Describer {
      * @since 1.3.8
      */
     State getNodeState();
+
+    /**
+     * Get last committed index.
+     *
+     * @return current node's last committed index.
+     * @since 1.4.0
+     */
+    long getLastCommittedIndex();
+
+    /**
+     * Get last applied index.
+     *
+     * @return current node's last applied index.
+     * @since 1.4.0
+     */
+    long getLastAppliedIndex();
 }

--- a/jraft-core/src/main/java/com/alipay/sofa/jraft/core/NodeImpl.java
+++ b/jraft-core/src/main/java/com/alipay/sofa/jraft/core/NodeImpl.java
@@ -3416,6 +3416,16 @@ public class NodeImpl implements Node, RaftServerService {
     }
 
     @Override
+    public long getLastCommittedIndex() {
+        return this.ballotBox.getLastCommittedIndex();
+    }
+
+    @Override
+    public long getLastAppliedIndex() {
+        return this.fsmCaller.getLastAppliedIndex();
+    }
+
+    @Override
     public void describe(final Printer out) {
         // node
         final String _nodeId;


### PR DESCRIPTION
### Motivation:
Export api of getLastCommittedIndex and getLastAppliedIndex.
Some user maybe need  lastCommittedIndex and lastAppliedIndex to do some business logic, so export the api.

