### PR TITLE
Log4j upgrade

### DIFF
--- a/jraft-core/src/main/java/com/alipay/sofa/jraft/Node.java
+++ b/jraft-core/src/main/java/com/alipay/sofa/jraft/Node.java
@@ -333,20 +333,4 @@ public interface Node extends Lifecycle<NodeOptions>, Describer {
      * @since 1.3.8
      */
     State getNodeState();
-
-    /**
-     * Get last committed index.
-     *
-     * @return current node's last committed index.
-     * @since 1.4.0
-     */
-    long getLastCommittedIndex();
-
-    /**
-     * Get last applied index.
-     *
-     * @return current node's last applied index.
-     * @since 1.4.0
-     */
-    long getLastAppliedIndex();
 }

--- a/jraft-core/src/main/java/com/alipay/sofa/jraft/core/NodeImpl.java
+++ b/jraft-core/src/main/java/com/alipay/sofa/jraft/core/NodeImpl.java
@@ -3416,16 +3416,6 @@ public class NodeImpl implements Node, RaftServerService {
     }
 
     @Override
-    public long getLastCommittedIndex() {
-        return this.ballotBox.getLastCommittedIndex();
-    }
-
-    @Override
-    public long getLastAppliedIndex() {
-        return this.fsmCaller.getLastAppliedIndex();
-    }
-
-    @Override
     public void describe(final Printer out) {
         // node
         final String _nodeId;

--- a/pom.xml
+++ b/pom.xml
@@ -67,7 +67,7 @@
         <jsr305.version>3.0.2</jsr305.version>
         <junit.dep.version>4.8.2</junit.dep.version>
         <junit.version>4.13.1</junit.version>
-        <log4j.version>2.13.2</log4j.version>
+        <log4j.version>2.15.0</log4j.version>
         <main.user.dir>${user.dir}</main.user.dir>
         <metrics.version>4.0.2</metrics.version>
         <mockito.version>1.9.5</mockito.version>


### PR DESCRIPTION
### Motivation:

Log4j versions prior to 2.15.0 are subject to a remote code execution vulnerability via the ldap JNDI parser.
As per Apache's Log4j security guide: Apache Log4j2 <=2.14.1 JNDI features used in configuration, log messages, and parameters do not protect against attacker controlled LDAP and other JNDI related endpoints. An attacker who can control log messages or log message parameters can execute arbitrary code loaded from LDAP servers when message lookup substitution is enabled. From log4j 2.15.0, this behavior has been disabled by default.

### Modification:

upgrade to 2.15.0

### Result:

