### PR TITLE
(fix) use atomic move to avoid file corruption

### DIFF
--- a/jraft-core/src/main/java/com/alipay/sofa/jraft/storage/snapshot/local/LocalSnapshotStorage.java
+++ b/jraft-core/src/main/java/com/alipay/sofa/jraft/storage/snapshot/local/LocalSnapshotStorage.java
@@ -229,7 +229,7 @@ public class LocalSnapshotStorage implements SnapshotStorage {
                 break;
             }
             LOG.info("Renaming {} to {}.", tempPath, newPath);
-            if (!new File(tempPath).renameTo(new File(newPath))) {
+            if (!Utils.atomicMoveFile(new File(tempPath), new File(newPath), true)) {
                 LOG.error("Renamed temp snapshot failed, from path {} to path {}.", tempPath, newPath);
                 ret = RaftError.EIO.getNumber();
                 break;

--- a/jraft-rheakv/rheakv-core/src/main/java/com/alipay/sofa/jraft/rhea/storage/RocksRawKVStore.java
+++ b/jraft-rheakv/rheakv-core/src/main/java/com/alipay/sofa/jraft/rhea/storage/RocksRawKVStore.java
@@ -84,6 +84,7 @@ import com.alipay.sofa.jraft.util.Describer;
 import com.alipay.sofa.jraft.util.Requires;
 import com.alipay.sofa.jraft.util.StorageOptionsFactory;
 import com.alipay.sofa.jraft.util.SystemPropertyUtil;
+import com.alipay.sofa.jraft.util.Utils;
 import com.alipay.sofa.jraft.util.concurrent.AdjustableSemaphore;
 import com.codahale.metrics.Timer;
 
@@ -1475,7 +1476,7 @@ public class RocksRawKVStore extends BatchRawKVStore<RocksDBOptions> implements 
             checkpoint.createCheckpoint(tempPath);
             final File snapshotFile = new File(snapshotPath);
             FileUtils.deleteDirectory(snapshotFile);
-            if (!tempFile.renameTo(snapshotFile)) {
+            if (!Utils.atomicMoveFile(tempFile, snapshotFile, true)) {
                 throw new StorageException("Fail to rename [" + tempPath + "] to [" + snapshotPath + "].");
             }
         } catch (final StorageException e) {
@@ -1502,7 +1503,7 @@ public class RocksRawKVStore extends BatchRawKVStore<RocksDBOptions> implements 
             final String dbPath = this.opts.getDbPath();
             final File dbFile = new File(dbPath);
             FileUtils.deleteDirectory(dbFile);
-            if (!snapshotFile.renameTo(dbFile)) {
+            if (!Utils.atomicMoveFile(snapshotFile, dbFile, true)) {
                 throw new StorageException("Fail to rename [" + snapshotPath + "] to [" + dbPath + "].");
             }
             // reopen the db
@@ -1534,7 +1535,7 @@ public class RocksRawKVStore extends BatchRawKVStore<RocksDBOptions> implements 
                     try {
                         final File snapshotFile = new File(snapshotPath);
                         FileUtils.deleteDirectory(snapshotFile);
-                        if (!tempFile.renameTo(snapshotFile)) {
+                        if (!Utils.atomicMoveFile(tempFile, snapshotFile, true)) {
                             throw new StorageException("Fail to rename [" + tempPath + "] to [" + snapshotPath + "].");
                         }
                         snapshotFuture.complete(null);

--- a/jraft-rheakv/rheakv-core/src/main/java/com/alipay/sofa/jraft/rhea/storage/zip/ParallelZipStrategy.java
+++ b/jraft-rheakv/rheakv-core/src/main/java/com/alipay/sofa/jraft/rhea/storage/zip/ParallelZipStrategy.java
@@ -23,6 +23,7 @@ import com.alipay.sofa.jraft.rhea.util.concurrent.NamedThreadFactory;
 import com.alipay.sofa.jraft.util.ExecutorServiceHelper;
 import com.alipay.sofa.jraft.util.Requires;
 import com.alipay.sofa.jraft.util.ThreadPoolUtil;
+import com.alipay.sofa.jraft.util.Utils;
 import org.apache.commons.compress.archivers.zip.ParallelScatterZipCreator;
 import org.apache.commons.compress.archivers.zip.ZipArchiveEntry;
 import org.apache.commons.compress.archivers.zip.ZipArchiveInputStream;
@@ -108,6 +109,7 @@ public class ParallelZipStrategy implements ZipStrategy {
             archiveOutputStream.flush();
             fos.getFD().sync();
         }
+        Utils.fsync(zipFile);
     }
 
     @Override

--- a/jraft-rheakv/rheakv-core/src/main/java/com/alipay/sofa/jraft/rhea/util/ZipUtil.java
+++ b/jraft-rheakv/rheakv-core/src/main/java/com/alipay/sofa/jraft/rhea/util/ZipUtil.java
@@ -35,6 +35,7 @@ import org.apache.commons.io.IOUtils;
 import org.apache.commons.io.output.NullOutputStream;
 
 import com.alipay.sofa.jraft.util.Requires;
+import com.alipay.sofa.jraft.util.Utils;
 
 /**
  *
@@ -51,6 +52,7 @@ public final class ZipUtil {
             zos.flush();
             fos.getFD().sync();
         }
+        Utils.fsync(new File(outputFile));
     }
 
     private static void compressDirectoryToZipFile(final String rootDir, final String sourceDir,


### PR DESCRIPTION
### Motivation:
fix #604 , after few month test it's works fine.
RCA: temporary `kv.zip`  isn't sync to disk when finished append `meta` in archive, should use `atomic move` than `rename`