### PR TITLE
实现基于BDB的日志存储

### DIFF
--- a/jraft-extension/bdb-log-storage-impl/pom.xml
+++ b/jraft-extension/bdb-log-storage-impl/pom.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <artifactId>jraft-extension</artifactId>
+        <groupId>com.alipay.sofa</groupId>
+        <version>1.3.9</version>
+    </parent>
+    <artifactId>bdb-log-storage-impl</artifactId>
+    <name>bdb-log-storage-impl</name>
+    <url>http://maven.apache.org</url>
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+    <dependencies>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>jraft-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.sleepycat</groupId>
+            <artifactId>je</artifactId>
+            <version>18.3.12</version>
+        </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/jraft-extension/bdb-log-storage-impl/src/main/java/com/alipay/sofa/jraft/core/BDBLogStorageJRaftServiceFactory.java
+++ b/jraft-extension/bdb-log-storage-impl/src/main/java/com/alipay/sofa/jraft/core/BDBLogStorageJRaftServiceFactory.java
@@ -27,7 +27,7 @@ import com.alipay.sofa.jraft.util.SPI;
  * @author cff
  *
  */
-@SPI
+@SPI(priority = 1)
 public class BDBLogStorageJRaftServiceFactory extends DefaultJRaftServiceFactory {
 
     @Override

--- a/jraft-extension/bdb-log-storage-impl/src/main/java/com/alipay/sofa/jraft/core/BDBLogStorageJRaftServiceFactory.java
+++ b/jraft-extension/bdb-log-storage-impl/src/main/java/com/alipay/sofa/jraft/core/BDBLogStorageJRaftServiceFactory.java
@@ -1,0 +1,37 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alipay.sofa.jraft.core;
+
+import com.alipay.sofa.jraft.core.DefaultJRaftServiceFactory;
+import com.alipay.sofa.jraft.option.RaftOptions;
+import com.alipay.sofa.jraft.storage.LogStorage;
+import com.alipay.sofa.jraft.storage.impl.BDBLogStorage;
+import com.alipay.sofa.jraft.util.SPI;
+
+/**
+ * override createLogStorage
+ * @author cff
+ *
+ */
+@SPI
+public class BDBLogStorageJRaftServiceFactory extends DefaultJRaftServiceFactory {
+
+    @Override
+    public LogStorage createLogStorage(String uri, RaftOptions raftOptions) {
+        return new BDBLogStorage(uri, raftOptions);
+    }
+}

--- a/jraft-extension/bdb-log-storage-impl/src/main/java/com/alipay/sofa/jraft/storage/impl/BDBLogStorage.java
+++ b/jraft-extension/bdb-log-storage-impl/src/main/java/com/alipay/sofa/jraft/storage/impl/BDBLogStorage.java
@@ -1,0 +1,531 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alipay.sofa.jraft.storage.impl;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReadWriteLock;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
+
+import org.apache.commons.io.FileUtils;
+import org.apache.commons.io.IOUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.alipay.sofa.jraft.conf.Configuration;
+import com.alipay.sofa.jraft.conf.ConfigurationEntry;
+import com.alipay.sofa.jraft.conf.ConfigurationManager;
+import com.alipay.sofa.jraft.entity.EnumOutter.EntryType;
+import com.alipay.sofa.jraft.entity.LogEntry;
+import com.alipay.sofa.jraft.entity.LogId;
+import com.alipay.sofa.jraft.entity.codec.LogEntryDecoder;
+import com.alipay.sofa.jraft.entity.codec.LogEntryEncoder;
+import com.alipay.sofa.jraft.option.LogStorageOptions;
+import com.alipay.sofa.jraft.option.RaftOptions;
+import com.alipay.sofa.jraft.storage.LogStorage;
+import com.alipay.sofa.jraft.util.Bits;
+import com.alipay.sofa.jraft.util.BytesUtil;
+import com.alipay.sofa.jraft.util.Describer;
+import com.alipay.sofa.jraft.util.Requires;
+import com.alipay.sofa.jraft.util.Utils;
+import com.sleepycat.je.Cursor;
+import com.sleepycat.je.CursorConfig;
+import com.sleepycat.je.Database;
+import com.sleepycat.je.DatabaseConfig;
+import com.sleepycat.je.DatabaseEntry;
+import com.sleepycat.je.DatabaseException;
+import com.sleepycat.je.Environment;
+import com.sleepycat.je.EnvironmentConfig;
+import com.sleepycat.je.EnvironmentStats;
+import com.sleepycat.je.LockMode;
+import com.sleepycat.je.OperationStatus;
+import com.sleepycat.je.StatsConfig;
+import com.sleepycat.je.Transaction;
+
+/**
+ * Log storage based on bdb.
+ * 
+ * @author cff
+ *
+ */
+public class BDBLogStorage implements LogStorage, Describer {
+
+    private static final Logger LOG                   = LoggerFactory.getLogger(BDBLogStorage.class);
+    static final String         DEFAULT_DATABASE_NAME = "jraft-log";
+    static final String         CONF_DATABASE_NAME    = "jraft-conf";
+
+    private Database            defaultTable;
+    private Database            confTable;
+    private Environment         environment;
+    private final String        homePath;
+    private boolean             opened                = false;
+
+    private LogEntryEncoder     logEntryEncoder;
+    private LogEntryDecoder     logEntryDecoder;
+
+    private final ReadWriteLock readWriteLock         = new ReentrantReadWriteLock();
+    private final Lock          readLock              = this.readWriteLock.readLock();
+    private final Lock          writeLock             = this.readWriteLock.writeLock();
+
+    private final boolean       sync;
+    //	private final boolean openStatistics;
+
+    private volatile long       firstLogIndex         = 1;
+    private volatile boolean    hasLoadFirstLogIndex;
+
+    /**
+     * First log index and last log index key in configuration column family.
+     */
+    public static final byte[]  FIRST_LOG_IDX_KEY     = Utils.getBytes("meta/firstLogIndex");
+
+    public BDBLogStorage(final String homePath, final RaftOptions raftOptions) {
+        super();
+        Requires.requireNonNull(homePath, "Null homePath");
+        this.homePath = homePath;
+        this.sync = raftOptions.isSync();
+        //		this.openStatistics = raftOptions.isOpenStatistics();
+    }
+
+    @Override
+    public boolean init(LogStorageOptions opts) {
+        Requires.requireNonNull(opts, "Null LogStorageOptions opts");
+        Requires.requireNonNull(opts.getConfigurationManager(), "Null conf manager");
+        Requires.requireNonNull(opts.getLogEntryCodecFactory(), "Null log entry codec factory");
+        this.logEntryDecoder = opts.getLogEntryCodecFactory().decoder();
+        this.logEntryEncoder = opts.getLogEntryCodecFactory().encoder();
+        this.writeLock.lock();
+        try {
+            if (this.defaultTable != null) {
+                LOG.warn("BDBLogStorage init() already.");
+                return true;
+            }
+            initAndLoad(opts.getConfigurationManager());
+            return true;
+        } catch (IOException | DatabaseException e) {
+            LOG.error("Fail to init BDBLogStorage, path={}.", this.homePath, e);
+        } finally {
+            this.writeLock.unlock();
+        }
+        return false;
+    }
+
+    private void openDatabase() throws DatabaseException, IOException {
+        if (this.opened) {
+            return;
+        }
+        final File databaseHomeDir = new File(homePath);
+        FileUtils.forceMkdir(databaseHomeDir);
+        EnvironmentConfig environmentConfig = new EnvironmentConfig();
+        environmentConfig.setTransactional(true);
+        environmentConfig.setAllowCreate(true);
+        DatabaseConfig databaseConfig = new DatabaseConfig();
+        databaseConfig.setAllowCreate(true);
+        databaseConfig.setTransactional(true);
+        this.environment = new Environment(databaseHomeDir, environmentConfig);
+        this.defaultTable = this.environment.openDatabase(null, DEFAULT_DATABASE_NAME, databaseConfig);
+        this.confTable = this.environment.openDatabase(null, CONF_DATABASE_NAME, databaseConfig);
+        this.opened = true;
+    }
+
+    private void load(final ConfigurationManager confManager) {
+        try (Cursor cursor = this.confTable.openCursor(null, new CursorConfig())) {
+            DatabaseEntry key = new DatabaseEntry();
+            DatabaseEntry data = new DatabaseEntry();
+            OperationStatus operationStatus = cursor.getFirst(key, data, LockMode.DEFAULT);
+            while (isSuccessOperation(operationStatus)) {
+                final byte[] keyBytes = key.getData();
+                final byte[] valueBytes = data.getData();
+                if (keyBytes.length == Long.BYTES) {
+                    final LogEntry entry = this.logEntryDecoder.decode(valueBytes);
+                    if (entry != null) {
+                        if (entry.getType() == EntryType.ENTRY_TYPE_CONFIGURATION) {
+                            final ConfigurationEntry confEntry = new ConfigurationEntry();
+                            confEntry.setId(new LogId(entry.getId().getIndex(), entry.getId().getTerm()));
+                            confEntry.setConf(new Configuration(entry.getPeers(), entry.getLearners()));
+                            if (entry.getOldPeers() != null) {
+                                confEntry.setOldConf(new Configuration(entry.getOldPeers(), entry.getOldLearners()));
+                            }
+                            if (confManager != null) {
+                                confManager.add(confEntry);
+                            }
+                        }
+                    } else {
+                        LOG.warn("Fail to decode conf entry at index {}, the log data is: {}.",
+                            Bits.getLong(keyBytes, 0), BytesUtil.toHex(valueBytes));
+                    }
+                } else if (Arrays.equals(FIRST_LOG_IDX_KEY, keyBytes)) {
+                    // FIRST_LOG_IDX_KEY storage
+                    setFirstLogIndex(Bits.getLong(valueBytes, 0));
+                    // truncatePrefixInBackground(0L, this.firstLogIndex);
+                } else {
+                    // Unknown entry
+                    LOG.warn("Unknown entry in configuration storage key={}, value={}.", BytesUtil.toHex(keyBytes),
+                        BytesUtil.toHex(valueBytes));
+                }
+                operationStatus = cursor.getNext(key, data, LockMode.DEFAULT);
+            }
+        }
+    }
+
+    private void initAndLoad(final ConfigurationManager confManager) throws DatabaseException, IOException {
+        this.hasLoadFirstLogIndex = false;
+        this.firstLogIndex = 1;
+        openDatabase();
+        load(confManager);
+    }
+
+    private void closeDatabase() {
+        this.opened = false;
+        try {
+            IOUtils.close(defaultTable, confTable, environment);
+        } catch (IOException e) {
+            // ignore
+        }
+        this.defaultTable = null;
+        this.confTable = null;
+        this.environment = null;
+
+    }
+
+    @Override
+    public void shutdown() {
+        this.writeLock.lock();
+        try {
+            closeDatabase();
+            LOG.info("BDBLogStorage shutdown, the db path is: {}.", this.homePath);
+        } finally {
+            this.writeLock.unlock();
+        }
+    }
+
+    @Override
+    public void describe(Printer out) {
+        this.readLock.lock();
+        try {
+            if (opened) {
+                out.println(String.format("Database is opened. the path: %s", this.homePath));
+                StatsConfig statsConfig = new StatsConfig();
+                EnvironmentStats stats = environment.getStats(statsConfig);
+                out.println(stats);
+            } else {
+                out.println(String.format("Database not open. the path: %s", this.homePath));
+            }
+        } finally {
+            this.readLock.unlock();
+        }
+    }
+
+    private void setFirstLogIndex(long firstLogIndex) {
+        this.firstLogIndex = firstLogIndex;
+        this.hasLoadFirstLogIndex = true;
+    }
+
+    @Override
+    public long getFirstLogIndex() {
+        this.readLock.lock();
+        try {
+            if (this.hasLoadFirstLogIndex) {
+                return this.firstLogIndex;
+            }
+            checkState();
+            try (Cursor cursor = this.defaultTable.openCursor(null, new CursorConfig());) {
+                DatabaseEntry key = new DatabaseEntry();
+                DatabaseEntry data = new DatabaseEntry();
+                OperationStatus operationStatus = cursor.getFirst(key, data, LockMode.DEFAULT);
+                if (OperationStatus.SUCCESS.equals(operationStatus)) {
+                    final long firstLogIndex = Bits.getLong(key.getData(), 0);
+                    saveFirstLogIndex(firstLogIndex);
+                    setFirstLogIndex(firstLogIndex);
+                    return firstLogIndex;
+                }
+            }
+        } finally {
+            this.readLock.unlock();
+        }
+        return 1L;
+    }
+
+    @Override
+    public long getLastLogIndex() {
+        this.readLock.lock();
+        Cursor cursor = null;
+        try {
+            checkState();
+            cursor = this.defaultTable.openCursor(null, new CursorConfig());
+            DatabaseEntry key = new DatabaseEntry();
+            DatabaseEntry data = new DatabaseEntry();
+            OperationStatus operationStatus = cursor.getLast(key, data, LockMode.DEFAULT);
+            if (OperationStatus.SUCCESS.equals(operationStatus)) {
+                return Bits.getLong(key.getData(), 0);
+            }
+        } finally {
+            this.readLock.unlock();
+            if (cursor != null) {
+                cursor.close();
+            }
+        }
+        return 0L;
+    }
+
+    @Override
+    public LogEntry getEntry(long index) {
+        this.readLock.lock();
+        try {
+            checkState();
+            if (this.hasLoadFirstLogIndex && index < this.firstLogIndex) {
+                return null;
+            }
+            DatabaseEntry logEntry = new DatabaseEntry();
+            OperationStatus operationStatus = this.defaultTable.get(null, getKeyDatabaseEntry(index), logEntry,
+                LockMode.DEFAULT);
+            if (isSuccessOperation(operationStatus)) {
+                return toLogEntry(logEntry);
+            }
+        } catch (DatabaseException e) {
+            LOG.error("Fail to get log entry at index {}.", index, e);
+        } finally {
+            this.readLock.unlock();
+        }
+        return null;
+    }
+
+    @Override
+    public long getTerm(long index) {
+        final LogEntry entry = getEntry(index);
+        if (entry != null) {
+            return entry.getId().getTerm();
+        }
+        return 0;
+    }
+
+    @Override
+    public boolean appendEntry(LogEntry entry) {
+        if (entry == null) {
+            return false;
+        }
+        this.readLock.lock();
+        Transaction txn = null;
+        try {
+            checkState();
+            DatabaseEntry key = getKeyDatabaseEntry(entry.getId().getIndex());
+            DatabaseEntry value = toDatabaseEntry(entry);
+            txn = beginTransaction();
+            if (entry.getType() == EntryType.ENTRY_TYPE_CONFIGURATION) {
+                this.confTable.put(txn, key, value);
+            }
+            this.defaultTable.put(txn, key, value);
+            txn.commit();
+            syncIfNeed();
+            return true;
+        } catch (DatabaseException e) {
+            LOG.error("Fail to append entry.", e);
+            if (txn != null) {
+                txn.abort();
+            }
+        } finally {
+            this.readLock.unlock();
+        }
+        return false;
+    }
+
+    @Override
+    public int appendEntries(List<LogEntry> entries) {
+        if (entries == null || entries.isEmpty()) {
+            return 0;
+        }
+        final int entriesCount = entries.size();
+        this.readLock.lock();
+        Transaction txn = null;
+        try {
+            checkState();
+            txn = beginTransaction();
+            for (int i = 0; i < entriesCount; i++) {
+                final LogEntry entry = entries.get(i);
+                DatabaseEntry key = getKeyDatabaseEntry(entry.getId().getIndex());
+                DatabaseEntry value = toDatabaseEntry(entry);
+                if (entry.getType() == EntryType.ENTRY_TYPE_CONFIGURATION) {
+                    this.confTable.put(txn, key, value);
+                }
+                this.defaultTable.put(txn, key, value);
+            }
+            txn.commit();
+            syncIfNeed();
+            return entriesCount;
+        } catch (DatabaseException e) {
+            LOG.error("Fail to appendEntries.", e);
+            if (txn != null) {
+                txn.abort();
+            }
+        } finally {
+            this.readLock.unlock();
+        }
+        return 0;
+    }
+
+    @Override
+    public boolean truncatePrefix(long firstIndexKept) {
+        this.readLock.lock();
+        try {
+            checkState();
+            final long startIndex = getFirstLogIndex();
+            final boolean ret = saveFirstLogIndex(firstIndexKept);
+            if (ret) {
+                setFirstLogIndex(firstIndexKept);
+            }
+            truncatePrefixInBackground(startIndex, firstIndexKept);
+            return true;
+        } catch (DatabaseException e) {
+            LOG.error("Fail to truncatePrefix {}.", firstIndexKept, e);
+        } finally {
+            this.readLock.unlock();
+        }
+        return false;
+    }
+
+    @Override
+    public boolean truncateSuffix(long lastIndexKept) {
+        this.readLock.lock();
+        try {
+            checkState();
+            final long lastLogIndex = getLastLogIndex();
+            for (long index = lastIndexKept + 1; index <= lastLogIndex; index++) {
+                DatabaseEntry key = getKeyDatabaseEntry(index);
+                this.confTable.delete(null, key);
+                this.defaultTable.delete(null, key);
+            }
+            return true;
+        } catch (DatabaseException e) {
+            LOG.error("Fail to truncateSuffix {}.", lastIndexKept, e);
+        } finally {
+            this.readLock.unlock();
+        }
+        return false;
+    }
+
+    @Override
+    public boolean reset(long nextLogIndex) {
+        if (nextLogIndex <= 0) {
+            throw new IllegalArgumentException("Invalid next log index.");
+        }
+        this.writeLock.lock();
+        try {
+            LogEntry entry = getEntry(nextLogIndex);
+            closeDatabase();
+            FileUtils.deleteDirectory(new File(this.homePath));
+            initAndLoad(null);
+            if (entry == null) {
+                entry = new LogEntry();
+                entry.setType(EntryType.ENTRY_TYPE_NO_OP);
+                entry.setId(new LogId(nextLogIndex, 0));
+                LOG.warn("Entry not found for nextLogIndex {} when reset.", nextLogIndex);
+            }
+            return appendEntry(entry);
+        } catch (IOException | DatabaseException e) {
+            LOG.error("Fail to reset next log index.", e);
+        } finally {
+            this.writeLock.unlock();
+        }
+        return false;
+    }
+
+    protected byte[] getKeyBytes(final long index) {
+        final byte[] ks = new byte[8];
+        Bits.putLong(ks, 0, index);
+        return ks;
+    }
+
+    protected DatabaseEntry getKeyDatabaseEntry(final long index) {
+        return new DatabaseEntry(getKeyBytes(index));
+    }
+
+    protected boolean isSuccessOperation(OperationStatus status) {
+        return status != null && OperationStatus.SUCCESS.equals(status);
+    }
+
+    protected LogEntry toLogEntry(DatabaseEntry logEntry) {
+        if (logEntry == null || logEntry.getSize() == 0) {
+            return null;
+        }
+        return this.logEntryDecoder.decode(logEntry.getData());
+    }
+
+    protected DatabaseEntry toDatabaseEntry(LogEntry logEntry) {
+        return new DatabaseEntry(this.logEntryEncoder.encode(logEntry));
+    }
+
+    private void syncIfNeed() {
+        if (sync) {
+            this.environment.sync();
+        }
+    }
+
+    /**
+     * Save the first log index into {@link BDBLogStorage#confTable} }
+     */
+    private boolean saveFirstLogIndex(final long firstLogIndex) {
+        this.readLock.lock();
+        try {
+            checkState();
+            DatabaseEntry firstLogIndexKey = new DatabaseEntry(FIRST_LOG_IDX_KEY);
+            DatabaseEntry firstLogIndexValue = getKeyDatabaseEntry(firstLogIndex);
+            this.confTable.put(null, firstLogIndexKey, firstLogIndexValue);
+            syncIfNeed();
+            return true;
+        } catch (DatabaseException e) {
+            LOG.error("Fail to save first log index {}.", firstLogIndex, e);
+        } finally {
+            this.readLock.unlock();
+        }
+        return false;
+    }
+
+    private Transaction beginTransaction() {
+        return environment.beginTransaction(null, null);
+    }
+
+    /**
+     * [startIndex, firstIndexKept)
+     */
+    private void truncatePrefixInBackground(final long startIndex, final long firstIndexKept) {
+		if (startIndex > firstIndexKept) {
+			return;
+		}
+		// delete logs in background.
+		Utils.runInThread(() -> {
+			this.readLock.lock();
+			try {
+				checkState();
+				for (long index = startIndex; index < firstIndexKept; index++) {
+					DatabaseEntry key = getKeyDatabaseEntry(index);
+					this.confTable.delete(null, key);// Delete it first; otherwise, it may never be deleted
+					this.defaultTable.delete(null, key);
+				}
+			} catch (DatabaseException e) {
+				LOG.error("Fail to truncatePrefix {}.", firstIndexKept, e);
+			} finally {
+				this.readLock.unlock();
+			}
+		});
+	}
+
+    private void checkState() {
+        Requires.requireTrue(opened, "Database not open. the path: %s", this.homePath);
+    }
+}

--- a/jraft-extension/bdb-log-storage-impl/src/main/java/com/alipay/sofa/jraft/storage/impl/BDBLogStorage.java
+++ b/jraft-extension/bdb-log-storage-impl/src/main/java/com/alipay/sofa/jraft/storage/impl/BDBLogStorage.java
@@ -85,7 +85,6 @@ public class BDBLogStorage implements LogStorage, Describer {
     private final Lock          writeLock             = this.readWriteLock.writeLock();
 
     private final boolean       sync;
-    //	private final boolean openStatistics;
 
     private volatile long       firstLogIndex         = 1;
     private volatile boolean    hasLoadFirstLogIndex;
@@ -100,7 +99,6 @@ public class BDBLogStorage implements LogStorage, Describer {
         Requires.requireNonNull(homePath, "Null homePath");
         this.homePath = homePath;
         this.sync = raftOptions.isSync();
-        //		this.openStatistics = raftOptions.isOpenStatistics();
     }
 
     @Override
@@ -173,7 +171,7 @@ public class BDBLogStorage implements LogStorage, Describer {
                 } else if (Arrays.equals(FIRST_LOG_IDX_KEY, keyBytes)) {
                     // FIRST_LOG_IDX_KEY storage
                     setFirstLogIndex(Bits.getLong(valueBytes, 0));
-                    // truncatePrefixInBackground(0L, this.firstLogIndex);
+                    truncatePrefixInBackground(0L, this.firstLogIndex);
                 } else {
                     // Unknown entry
                     LOG.warn("Unknown entry in configuration storage key={}, value={}.", BytesUtil.toHex(keyBytes),
@@ -335,7 +333,7 @@ public class BDBLogStorage implements LogStorage, Describer {
             syncIfNeed();
             return true;
         } catch (DatabaseException e) {
-            LOG.error("Fail to append entry.", e);
+            LOG.error("Fail to append entry {}.", entry, e);
             if (txn != null) {
                 txn.abort();
             }
@@ -369,7 +367,7 @@ public class BDBLogStorage implements LogStorage, Describer {
             syncIfNeed();
             return entriesCount;
         } catch (DatabaseException e) {
-            LOG.error("Fail to appendEntries.", e);
+            LOG.error("Fail to appendEntries. first one = {}, entries count = {}", entries.get(0), entriesCount, e);
             if (txn != null) {
                 txn.abort();
             }

--- a/jraft-extension/bdb-log-storage-impl/src/main/resources/META-INF/services/com.alipay.sofa.jraft.JRaftServiceFactory
+++ b/jraft-extension/bdb-log-storage-impl/src/main/resources/META-INF/services/com.alipay.sofa.jraft.JRaftServiceFactory
@@ -1,0 +1,1 @@
+com.alipay.sofa.jraft.core.BDBLogStorageJRaftServiceFactory

--- a/jraft-extension/bdb-log-storage-impl/src/test/java/com/alipay/sofa/jraft/storage/BaseStorageTest.java
+++ b/jraft-extension/bdb-log-storage-impl/src/test/java/com/alipay/sofa/jraft/storage/BaseStorageTest.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alipay.sofa.jraft.storage;
+
+import java.io.File;
+import java.io.IOException;
+
+import org.apache.commons.io.FileUtils;
+import org.junit.After;
+
+import com.alipay.sofa.jraft.test.TestUtils;
+
+public class BaseStorageTest {
+    protected String path;
+
+    public void setup() throws Exception {
+        this.path = TestUtils.mkTempDir();
+        FileUtils.forceMkdir(new File(this.path));
+    }
+
+    @After
+    public void teardown() throws Exception {
+        FileUtils.deleteDirectory(new File(this.path));
+    }
+
+    protected String writeData() throws IOException {
+        File file = new File(this.path + File.separator + "data");
+        String data = "jraft is great!";
+        FileUtils.writeStringToFile(file, data);
+        return data;
+    }
+
+}

--- a/jraft-extension/bdb-log-storage-impl/src/test/java/com/alipay/sofa/jraft/storage/impl/BDBLogStorageTest.java
+++ b/jraft-extension/bdb-log-storage-impl/src/test/java/com/alipay/sofa/jraft/storage/impl/BDBLogStorageTest.java
@@ -1,0 +1,30 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alipay.sofa.jraft.storage.impl;
+
+import com.alipay.sofa.jraft.option.RaftOptions;
+import com.alipay.sofa.jraft.storage.LogStorage;
+
+public class BDBLogStorageTest extends BaseLogStorageTest {
+
+    @Override
+    protected LogStorage newLogStorage() {
+        System.out.println(this.path);
+        return new BDBLogStorage(this.path, new RaftOptions());
+    }
+
+}

--- a/jraft-extension/bdb-log-storage-impl/src/test/java/com/alipay/sofa/jraft/storage/impl/BaseLogStorageTest.java
+++ b/jraft-extension/bdb-log-storage-impl/src/test/java/com/alipay/sofa/jraft/storage/impl/BaseLogStorageTest.java
@@ -1,0 +1,240 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alipay.sofa.jraft.storage.impl;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import com.alipay.sofa.jraft.JRaftUtils;
+import com.alipay.sofa.jraft.conf.ConfigurationEntry;
+import com.alipay.sofa.jraft.conf.ConfigurationManager;
+import com.alipay.sofa.jraft.entity.EnumOutter;
+import com.alipay.sofa.jraft.entity.LogEntry;
+import com.alipay.sofa.jraft.entity.LogId;
+import com.alipay.sofa.jraft.entity.codec.LogEntryCodecFactory;
+import com.alipay.sofa.jraft.entity.codec.v2.LogEntryV2CodecFactory;
+import com.alipay.sofa.jraft.option.LogStorageOptions;
+import com.alipay.sofa.jraft.storage.BaseStorageTest;
+import com.alipay.sofa.jraft.storage.LogStorage;
+import com.alipay.sofa.jraft.test.TestUtils;
+import com.alipay.sofa.jraft.util.Utils;
+
+public abstract class BaseLogStorageTest extends BaseStorageTest {
+    protected LogStorage         logStorage;
+    private ConfigurationManager confManager;
+    private LogEntryCodecFactory logEntryCodecFactory;
+
+    @Override
+    @Before
+    public void setup() throws Exception {
+        super.setup();
+        this.confManager = new ConfigurationManager();
+        this.logEntryCodecFactory = LogEntryV2CodecFactory.getInstance();
+        this.logStorage = newLogStorage();
+
+        final LogStorageOptions opts = newLogStorageOptions();
+
+        this.logStorage.init(opts);
+    }
+
+    protected abstract LogStorage newLogStorage();
+
+    protected LogStorageOptions newLogStorageOptions() {
+        final LogStorageOptions opts = new LogStorageOptions();
+        opts.setConfigurationManager(this.confManager);
+        opts.setLogEntryCodecFactory(this.logEntryCodecFactory);
+        return opts;
+    }
+
+    @Override
+    @After
+    public void teardown() throws Exception {
+        this.logStorage.shutdown();
+        super.teardown();
+    }
+
+    @Test
+    public void testEmptyState() {
+        assertEquals(1, this.logStorage.getFirstLogIndex());
+        assertEquals(0, this.logStorage.getLastLogIndex());
+        assertNull(this.logStorage.getEntry(100));
+        assertEquals(0, this.logStorage.getTerm(100));
+    }
+
+    @Test
+    public void testAddOneEntryState() {
+        final LogEntry entry1 = TestUtils.mockEntry(100, 1);
+        assertTrue(this.logStorage.appendEntry(entry1));
+
+        assertEquals(100, this.logStorage.getFirstLogIndex());
+        assertEquals(100, this.logStorage.getLastLogIndex());
+        Assert.assertEquals(entry1, this.logStorage.getEntry(100));
+        assertEquals(1, this.logStorage.getTerm(100));
+
+        final LogEntry entry2 = TestUtils.mockEntry(200, 2);
+        assertTrue(this.logStorage.appendEntry(entry2));
+
+        assertEquals(100, this.logStorage.getFirstLogIndex());
+        assertEquals(200, this.logStorage.getLastLogIndex());
+        Assert.assertEquals(entry1, this.logStorage.getEntry(100));
+        Assert.assertEquals(entry2, this.logStorage.getEntry(200));
+        assertEquals(1, this.logStorage.getTerm(100));
+        assertEquals(2, this.logStorage.getTerm(200));
+    }
+
+    @Test
+    public void testLoadWithConfigManager() {
+        assertTrue(this.confManager.getLastConfiguration().isEmpty());
+
+        final LogEntry confEntry1 = new LogEntry(EnumOutter.EntryType.ENTRY_TYPE_CONFIGURATION);
+        confEntry1.setId(new LogId(99, 1));
+        confEntry1.setPeers(JRaftUtils.getConfiguration("localhost:8081,localhost:8082").listPeers());
+
+        final LogEntry confEntry2 = new LogEntry(EnumOutter.EntryType.ENTRY_TYPE_CONFIGURATION);
+        confEntry2.setId(new LogId(100, 2));
+        confEntry2.setPeers(JRaftUtils.getConfiguration("localhost:8081,localhost:8082,localhost:8083").listPeers());
+
+        assertTrue(this.logStorage.appendEntry(confEntry1));
+        assertEquals(1, this.logStorage.appendEntries(Arrays.asList(confEntry2)));
+
+        // reload log storage.
+        this.logStorage.shutdown();
+        this.logStorage = newLogStorage();
+        this.logStorage.init(newLogStorageOptions());
+
+        ConfigurationEntry conf = this.confManager.getLastConfiguration();
+        assertNotNull(conf);
+        assertFalse(conf.isEmpty());
+        assertEquals("localhost:8081,localhost:8082,localhost:8083", conf.getConf().toString());
+        conf = this.confManager.get(99);
+        assertNotNull(conf);
+        assertFalse(conf.isEmpty());
+        assertEquals("localhost:8081,localhost:8082", conf.getConf().toString());
+    }
+
+    @Test
+    public void testAddManyEntries() {
+        final List<LogEntry> entries = TestUtils.mockEntries();
+
+        assertEquals(10, this.logStorage.appendEntries(entries));
+
+        assertEquals(0, this.logStorage.getFirstLogIndex());
+        assertEquals(9, this.logStorage.getLastLogIndex());
+        for (int i = 0; i < 10; i++) {
+            assertEquals(i, this.logStorage.getTerm(i));
+            final LogEntry entry = this.logStorage.getEntry(i);
+            assertNotNull(entry);
+            assertEquals(entries.get(i), entry);
+        }
+    }
+
+    @Test
+    public void testReset() {
+        testAddManyEntries();
+        this.logStorage.reset(5);
+        assertEquals(5, this.logStorage.getFirstLogIndex());
+        assertEquals(5, this.logStorage.getLastLogIndex());
+        assertEquals(5, this.logStorage.getTerm(5));
+    }
+
+    @Test
+    public void testTruncatePrefix() {
+        final List<LogEntry> entries = TestUtils.mockEntries();
+
+        assertEquals(10, this.logStorage.appendEntries(entries));
+        this.logStorage.truncatePrefix(5);
+        assertEquals(5, this.logStorage.getFirstLogIndex());
+        assertEquals(9, this.logStorage.getLastLogIndex());
+        for (int i = 0; i < 10; i++) {
+            if (i < 5) {
+                assertNull(this.logStorage.getEntry(i));
+            } else {
+                Assert.assertEquals(entries.get(i), this.logStorage.getEntry(i));
+            }
+        }
+    }
+
+    @Test
+    public void testAppendMantyLargeEntries() {
+        final long start = Utils.monotonicMs();
+        final int totalLogs = 100000;
+        final int logSize = 16 * 1024;
+        final int batch = 100;
+
+        appendLargeEntries(totalLogs, logSize, batch);
+
+        System.out.println("Inserted " + totalLogs + " large logs, cost " + (Utils.monotonicMs() - start) + " ms.");
+
+        for (int i = 0; i < totalLogs; i++) {
+            final LogEntry log = this.logStorage.getEntry(i);
+            assertNotNull(log);
+            assertEquals(i, log.getId().getIndex());
+            assertEquals(i, log.getId().getTerm());
+            assertEquals(logSize, log.getData().remaining());
+        }
+
+        this.logStorage.shutdown();
+        this.logStorage.init(newLogStorageOptions());
+
+        for (int i = 0; i < totalLogs; i++) {
+            final LogEntry log = this.logStorage.getEntry(i);
+            assertNotNull(log);
+            assertEquals(i, log.getId().getIndex());
+            assertEquals(i, log.getId().getTerm());
+            assertEquals(logSize, log.getData().remaining());
+        }
+    }
+
+    private void appendLargeEntries(final int totalLogs, final int logSize, final int batch) {
+        for (int i = 0; i < totalLogs; i += batch) {
+            final List<LogEntry> entries = new ArrayList<>(batch);
+            for (int j = i; j < i + batch; j++) {
+                entries.add(TestUtils.mockEntry(j, j, logSize));
+            }
+            assertEquals(batch, this.logStorage.appendEntries(entries));
+        }
+    }
+
+    @Test
+    public void testTruncateSuffix() {
+        final List<LogEntry> entries = TestUtils.mockEntries();
+
+        assertEquals(10, this.logStorage.appendEntries(entries));
+        this.logStorage.truncateSuffix(5);
+        assertEquals(0, this.logStorage.getFirstLogIndex());
+        assertEquals(5, this.logStorage.getLastLogIndex());
+        for (int i = 0; i < 10; i++) {
+            if (i <= 5) {
+                Assert.assertEquals(entries.get(i), this.logStorage.getEntry(i));
+            } else {
+                assertNull(this.logStorage.getEntry(i));
+            }
+        }
+    }
+}

--- a/jraft-extension/bdb-log-storage-impl/src/test/java/com/alipay/sofa/jraft/test/TestUtils.java
+++ b/jraft-extension/bdb-log-storage-impl/src/test/java/com/alipay/sofa/jraft/test/TestUtils.java
@@ -1,0 +1,161 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alipay.sofa.jraft.test;
+
+import java.lang.management.ManagementFactory;
+import java.lang.management.ThreadInfo;
+import java.lang.management.ThreadMXBean;
+import java.net.Inet4Address;
+import java.net.InetAddress;
+import java.net.NetworkInterface;
+import java.net.SocketException;
+import java.nio.ByteBuffer;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.Enumeration;
+import java.util.List;
+import java.util.concurrent.ThreadLocalRandom;
+import com.alipay.sofa.jraft.JRaftUtils;
+import com.alipay.sofa.jraft.conf.ConfigurationEntry;
+import com.alipay.sofa.jraft.entity.EnumOutter;
+import com.alipay.sofa.jraft.entity.LogEntry;
+import com.alipay.sofa.jraft.entity.LogId;
+import com.alipay.sofa.jraft.entity.PeerId;
+import com.alipay.sofa.jraft.rpc.RpcRequests;
+import com.alipay.sofa.jraft.util.Endpoint;
+
+/**
+ * Test helper
+ *
+ * @author boyan (boyan@alibaba-inc.com)
+ *
+ *         2018-Apr-11 10:16:07 AM
+ */
+public class TestUtils {
+
+    public static ConfigurationEntry getConfEntry(final String confStr, final String oldConfStr) {
+        ConfigurationEntry entry = new ConfigurationEntry();
+        entry.setConf(JRaftUtils.getConfiguration(confStr));
+        entry.setOldConf(JRaftUtils.getConfiguration(oldConfStr));
+        return entry;
+    }
+
+    public static void dumpThreads() {
+        try {
+            ThreadMXBean bean = ManagementFactory.getThreadMXBean();
+            ThreadInfo[] infos = bean.dumpAllThreads(true, true);
+            for (ThreadInfo info : infos) {
+                System.out.println(info);
+            }
+        } catch (Throwable t) {
+            t.printStackTrace(); // NOPMD
+        }
+    }
+
+    public static String mkTempDir() {
+        return Paths.get(System.getProperty("java.io.tmpdir", "/tmp"), "jraft_test_" + System.nanoTime()).toString();
+    }
+
+    public static LogEntry mockEntry(final int index, final int term) {
+        return mockEntry(index, term, 0);
+    }
+
+    public static LogEntry mockEntry(final int index, final int term, final int dataSize) {
+        LogEntry entry = new LogEntry(EnumOutter.EntryType.ENTRY_TYPE_NO_OP);
+        entry.setId(new LogId(index, term));
+        if (dataSize > 0) {
+            byte[] bs = new byte[dataSize];
+            ThreadLocalRandom.current().nextBytes(bs);
+            entry.setData(ByteBuffer.wrap(bs));
+        }
+        return entry;
+    }
+
+    public static List<LogEntry> mockEntries() {
+        return mockEntries(10);
+    }
+
+    public static String getMyIp() {
+        String ip = null;
+        try {
+            Enumeration<NetworkInterface> interfaces = NetworkInterface.getNetworkInterfaces();
+            while (interfaces.hasMoreElements()) {
+                NetworkInterface iface = interfaces.nextElement();
+                // filters out 127.0.0.1 and inactive interfaces
+                if (iface.isLoopback() || !iface.isUp()) {
+                    continue;
+                }
+
+                Enumeration<InetAddress> addresses = iface.getInetAddresses();
+                while (addresses.hasMoreElements()) {
+                    InetAddress addr = addresses.nextElement();
+                    if (addr instanceof Inet4Address) {
+                        ip = addr.getHostAddress();
+                        break;
+                    }
+                }
+            }
+            return ip;
+        } catch (SocketException e) {
+            return "localhost";
+        }
+    }
+
+    public static List<LogEntry> mockEntries(final int n) {
+        List<LogEntry> entries = new ArrayList<>();
+        for (int i = 0; i < n; i++) {
+            LogEntry entry = mockEntry(i, i);
+            if (i > 0) {
+                entry.setData(ByteBuffer.wrap(String.valueOf(i).getBytes()));
+            }
+            entries.add(entry);
+        }
+        return entries;
+    }
+
+    public static RpcRequests.PingRequest createPingRequest() {
+        RpcRequests.PingRequest reqObject = RpcRequests.PingRequest.newBuilder()
+            .setSendTimestamp(System.currentTimeMillis()).build();
+        return reqObject;
+    }
+
+    public static final int INIT_PORT = 5003;
+
+    public static List<PeerId> generatePeers(final int n) {
+        List<PeerId> ret = new ArrayList<>();
+        for (int i = 0; i < n; i++) {
+            ret.add(new PeerId(getMyIp(), INIT_PORT + i));
+        }
+        return ret;
+    }
+
+    public static List<PeerId> generatePriorityPeers(final int n, final List<Integer> priorities) {
+        List<PeerId> ret = new ArrayList<>();
+        for (int i = 0; i < n; i++) {
+            Endpoint endpoint = new Endpoint(getMyIp(), INIT_PORT + i);
+            PeerId peerId = new PeerId(endpoint, 0, priorities.get(i));
+            ret.add(peerId);
+        }
+        return ret;
+    }
+
+    public static byte[] getRandomBytes() {
+        final byte[] requestContext = new byte[ThreadLocalRandom.current().nextInt(10) + 1];
+        ThreadLocalRandom.current().nextBytes(requestContext);
+        return requestContext;
+    }
+}

--- a/jraft-extension/pom.xml
+++ b/jraft-extension/pom.xml
@@ -12,6 +12,7 @@
     <name>jraft-extension ${project.version}</name>
     <modules>
         <module>rpc-grpc-impl</module>
+        <module>bdb-log-storage-impl</module>
     </modules>
 
 </project>


### PR DESCRIPTION
### Motivation:
对于国产化平台，使用RocksDB存储日志，需要编译各个环境的依赖。
因此采用基于java实现的BDB存储日志，对于国产化平台的适配更方便、容易

### Modification:
1、基于BDB 实现了 LogStorage 接口
2、提供BDBLogStorageJRaftServiceFactory 重写 createLogStorage
3、通过单元测试

参考了RocksDBLogStorage


### Result:
只需要在启动前设置ServiceFactory即可，如： nodeOptions.setServiceFactory(new BDBLogStorageJRaftServiceFactory());
