### PR TITLE
Feature/backpressure

### DIFF
--- a/jraft-core/src/main/java/com/alipay/sofa/jraft/core/FSMCallerImpl.java
+++ b/jraft-core/src/main/java/com/alipay/sofa/jraft/core/FSMCallerImpl.java
@@ -36,7 +36,6 @@ import com.alipay.sofa.jraft.closure.TaskClosure;
 import com.alipay.sofa.jraft.conf.Configuration;
 import com.alipay.sofa.jraft.conf.ConfigurationEntry;
 import com.alipay.sofa.jraft.entity.EnumOutter;
-import com.alipay.sofa.jraft.entity.EnumOutter.ErrorType;
 import com.alipay.sofa.jraft.entity.LeaderChangeContext;
 import com.alipay.sofa.jraft.entity.LogEntry;
 import com.alipay.sofa.jraft.entity.LogId;
@@ -232,11 +231,7 @@ public class FSMCallerImpl implements FSMCaller {
             LOG.warn("FSMCaller is stopped, can not apply new task.");
             return false;
         }
-        if (!this.taskQueue.tryPublishEvent(tpl)) {
-            setError(new RaftException(ErrorType.ERROR_TYPE_STATE_MACHINE, new Status(RaftError.EBUSY,
-                "FSMCaller is overload.")));
-            return false;
-        }
+        this.taskQueue.publishEvent(tpl);
         return true;
     }
 

--- a/jraft-core/src/main/java/com/alipay/sofa/jraft/core/NodeImpl.java
+++ b/jraft-core/src/main/java/com/alipay/sofa/jraft/core/NodeImpl.java
@@ -1972,7 +1972,7 @@ public class NodeImpl implements Node, RaftServerService {
             }
 
             // fast checking if log manager is overloaded
-            if (!this.logManager.hasAvailableCapacityToAppendEntries(entriesCount)) {
+            if (!this.logManager.hasAvailableCapacityToAppendEntries(1)) {
                 LOG.warn("Node {} received AppendEntriesRequest but log manager is busy.", getNodeId());
                 return RpcFactoryHelper //
                     .responseFactory() //

--- a/jraft-core/src/main/java/com/alipay/sofa/jraft/core/NodeImpl.java
+++ b/jraft-core/src/main/java/com/alipay/sofa/jraft/core/NodeImpl.java
@@ -1623,12 +1623,13 @@ public class NodeImpl implements Node, RaftServerService {
           case NonBlocking:
           default:
             if (!this.applyQueue.tryPublishEvent(translator)) {
+              String errorMsg = "Node is busy, has too many tasks, bufferSize: "+ this.applyQueue.getBufferSize()+" , remainingCapacity: "+ this.applyQueue.remainingCapacity();
               Utils.runClosureInThread(task.getDone(),
-                  new Status(RaftError.EBUSY, "Node is busy, has too many tasks."));
+                  new Status(RaftError.EBUSY, errorMsg));
               LOG.warn("Node {} applyQueue is overload.", getNodeId());
               this.metrics.recordTimes("apply-task-overload-times", 1);
               if(task.getDone() == null) {
-                throw new OverloadException("Node is busy, has too many tasks, bufferSize: "+ this.applyQueue.getBufferSize()+" , remainingCapacity: "+ this.applyQueue.remainingCapacity());
+                throw new OverloadException(errorMsg);
               }
             }
             break;

--- a/jraft-core/src/main/java/com/alipay/sofa/jraft/core/NodeImpl.java
+++ b/jraft-core/src/main/java/com/alipay/sofa/jraft/core/NodeImpl.java
@@ -2025,9 +2025,14 @@ public class NodeImpl implements Node, RaftServerService {
             if (doUnlock) {
                 this.writeLock.unlock();
             }
-            this.metrics.recordLatency("handle-append-entries", Utils.monotonicMs() - startMs);
+            final long processLatency = Utils.monotonicMs() - startMs;
+            if (entriesCount == 0) {
+                this.metrics.recordLatency("handle-heartbeat-requests", processLatency);
+            } else {
+                this.metrics.recordLatency("handle-append-entries", processLatency);
+            }
             if (success) {
-                // Don't record heartbeat requests.
+                // Don't stats heartbeat requests.
                 this.metrics.recordSize("handle-append-entries-count", entriesCount);
             }
         }

--- a/jraft-core/src/main/java/com/alipay/sofa/jraft/core/NodeImpl.java
+++ b/jraft-core/src/main/java/com/alipay/sofa/jraft/core/NodeImpl.java
@@ -1623,7 +1623,7 @@ public class NodeImpl implements Node, RaftServerService {
           case NonBlocking:
           default:
             if (!this.applyQueue.tryPublishEvent(translator)) {
-              String errorMsg = "Node is busy, has too many tasks, bufferSize: "+ this.applyQueue.getBufferSize()+" , remainingCapacity: "+ this.applyQueue.remainingCapacity();
+              String errorMsg = "Node is busy, has too many tasks, queue is full and bufferSize="+ this.applyQueue.getBufferSize();
               Utils.runClosureInThread(task.getDone(),
                   new Status(RaftError.EBUSY, errorMsg));
               LOG.warn("Node {} applyQueue is overload.", getNodeId());

--- a/jraft-core/src/main/java/com/alipay/sofa/jraft/core/NodeImpl.java
+++ b/jraft-core/src/main/java/com/alipay/sofa/jraft/core/NodeImpl.java
@@ -66,6 +66,7 @@ import com.alipay.sofa.jraft.entity.Task;
 import com.alipay.sofa.jraft.entity.UserLog;
 import com.alipay.sofa.jraft.error.LogIndexOutOfBoundsException;
 import com.alipay.sofa.jraft.error.LogNotFoundException;
+import com.alipay.sofa.jraft.error.OverloadException;
 import com.alipay.sofa.jraft.error.RaftError;
 import com.alipay.sofa.jraft.error.RaftException;
 import com.alipay.sofa.jraft.option.BallotBoxOptions;
@@ -115,7 +116,6 @@ import com.alipay.sofa.jraft.util.Requires;
 import com.alipay.sofa.jraft.util.RpcFactoryHelper;
 import com.alipay.sofa.jraft.util.SignalHelper;
 import com.alipay.sofa.jraft.util.SystemPropertyUtil;
-import com.alipay.sofa.jraft.util.ThreadHelper;
 import com.alipay.sofa.jraft.util.ThreadId;
 import com.alipay.sofa.jraft.util.Utils;
 import com.alipay.sofa.jraft.util.concurrent.LongHeldDetectingReadWriteLock;
@@ -158,9 +158,6 @@ public class NodeImpl implements Node, RaftServerService {
 
     public final static RaftTimerFactory                                   TIMER_FACTORY            = JRaftUtils
                                                                                                         .raftTimerFactory();
-
-    // Max retry times when applying tasks.
-    private static final int                                               MAX_APPLY_RETRY_TIMES    = 3;
 
     public static final AtomicInteger                                      GLOBAL_NUM_NODES         = new AtomicInteger(
                                                                                                         0);
@@ -1611,33 +1608,30 @@ public class NodeImpl implements Node, RaftServerService {
 
         final LogEntry entry = new LogEntry();
         entry.setData(task.getData());
-        int retryTimes = 0;
-        try {
-            final EventTranslator<LogEntryAndClosure> translator = (event, sequence) -> {
-                event.reset();
-                event.done = task.getDone();
-                event.entry = entry;
-                event.expectedTerm = task.getExpectedTerm();
-            };
-            while (true) {
-                if (this.applyQueue.tryPublishEvent(translator)) {
-                    break;
-                } else {
-                    retryTimes++;
-                    if (retryTimes > MAX_APPLY_RETRY_TIMES) {
-                        Utils.runClosureInThread(task.getDone(),
-                            new Status(RaftError.EBUSY, "Node is busy, has too many tasks."));
-                        LOG.warn("Node {} applyQueue is overload.", getNodeId());
-                        this.metrics.recordTimes("apply-task-overload-times", 1);
-                        return;
-                    }
-                    ThreadHelper.onSpinWait();
-                }
-            }
 
-        } catch (final Exception e) {
-            LOG.error("Fail to apply task.", e);
-            Utils.runClosureInThread(task.getDone(), new Status(RaftError.EPERM, "Node is down."));
+        final EventTranslator<LogEntryAndClosure> translator = (event, sequence) -> {
+          event.reset();
+          event.done = task.getDone();
+          event.entry = entry;
+          event.expectedTerm = task.getExpectedTerm();
+        };
+
+        switch(this.options.getApplyTaskMode()) {
+          case Blocking:
+            this.applyQueue.publishEvent(translator);
+            break;
+          case NonBlocking:
+          default:
+            if (!this.applyQueue.tryPublishEvent(translator)) {
+              Utils.runClosureInThread(task.getDone(),
+                  new Status(RaftError.EBUSY, "Node is busy, has too many tasks."));
+              LOG.warn("Node {} applyQueue is overload.", getNodeId());
+              this.metrics.recordTimes("apply-task-overload-times", 1);
+              if(task.getDone() == null) {
+                throw new OverloadException("Node is busy, has too many tasks, bufferSize: "+ this.applyQueue.getBufferSize()+" , remainingCapacity: "+ this.applyQueue.remainingCapacity());
+              }
+            }
+            break;
         }
     }
 

--- a/jraft-core/src/main/java/com/alipay/sofa/jraft/core/ReadOnlyServiceImpl.java
+++ b/jraft-core/src/main/java/com/alipay/sofa/jraft/core/ReadOnlyServiceImpl.java
@@ -336,12 +336,13 @@ public class ReadOnlyServiceImpl implements ReadOnlyService, LastAppliedLogIndex
               case NonBlocking:
                 default:
                   if (!this.readIndexQueue.tryPublishEvent(translator)) {
+                    final String errorMsg = "Node is busy, has too many read-index requests, bufferSize: "+ this.readIndexQueue.getBufferSize()+" , remainingCapacity: "+ this.readIndexQueue.remainingCapacity();
                     Utils.runClosureInThread(closure,
-                        new Status(RaftError.EBUSY, "Node is busy, has too many read-only requests."));
+                        new Status(RaftError.EBUSY, errorMsg));
                     this.nodeMetrics.recordTimes("read-index-overload-times", 1);
                     LOG.warn("Node {} ReadOnlyServiceImpl readIndexQueue is overload.", this.node.getNodeId());
                     if(closure == null) {
-                      throw new OverloadException("Node is busy, has too many read-index requests, bufferSize: "+ this.readIndexQueue.getBufferSize()+" , remainingCapacity: "+ this.readIndexQueue.remainingCapacity());
+                      throw new OverloadException(errorMsg);
                     }
                   }
                   break;

--- a/jraft-core/src/main/java/com/alipay/sofa/jraft/core/ReadOnlyServiceImpl.java
+++ b/jraft-core/src/main/java/com/alipay/sofa/jraft/core/ReadOnlyServiceImpl.java
@@ -38,6 +38,7 @@ import com.alipay.sofa.jraft.Status;
 import com.alipay.sofa.jraft.closure.ReadIndexClosure;
 import com.alipay.sofa.jraft.entity.ReadIndexState;
 import com.alipay.sofa.jraft.entity.ReadIndexStatus;
+import com.alipay.sofa.jraft.error.OverloadException;
 import com.alipay.sofa.jraft.error.RaftError;
 import com.alipay.sofa.jraft.error.RaftException;
 import com.alipay.sofa.jraft.option.RaftOptions;
@@ -51,7 +52,6 @@ import com.alipay.sofa.jraft.util.DisruptorMetricSet;
 import com.alipay.sofa.jraft.util.LogExceptionHandler;
 import com.alipay.sofa.jraft.util.NamedThreadFactory;
 import com.alipay.sofa.jraft.util.OnlyForTest;
-import com.alipay.sofa.jraft.util.ThreadHelper;
 import com.alipay.sofa.jraft.util.Utils;
 import com.google.protobuf.ZeroByteStringHelper;
 import com.lmax.disruptor.BlockingWaitStrategy;
@@ -69,13 +69,12 @@ import com.lmax.disruptor.dsl.ProducerType;
  */
 public class ReadOnlyServiceImpl implements ReadOnlyService, LastAppliedLogIndexListener {
 
-    private static final int                           MAX_ADD_REQUEST_RETRY_TIMES = 3;
     /** Disruptor to run readonly service. */
     private Disruptor<ReadIndexEvent>                  readIndexDisruptor;
     private RingBuffer<ReadIndexEvent>                 readIndexQueue;
     private RaftOptions                                raftOptions;
     private NodeImpl                                   node;
-    private final Lock                                 lock                        = new ReentrantLock();
+    private final Lock                                 lock                = new ReentrantLock();
     private FSMCaller                                  fsmCaller;
     private volatile CountDownLatch                    shutdownLatch;
 
@@ -86,10 +85,10 @@ public class ReadOnlyServiceImpl implements ReadOnlyService, LastAppliedLogIndex
     private volatile RaftException                     error;
 
     // <logIndex, statusList>
-    private final TreeMap<Long, List<ReadIndexStatus>> pendingNotifyStatus         = new TreeMap<>();
+    private final TreeMap<Long, List<ReadIndexStatus>> pendingNotifyStatus = new TreeMap<>();
 
-    private static final Logger                        LOG                         = LoggerFactory
-                                                                                       .getLogger(ReadOnlyServiceImpl.class);
+    private static final Logger                        LOG                 = LoggerFactory
+                                                                               .getLogger(ReadOnlyServiceImpl.class);
 
     private static class ReadIndexEvent {
         Bytes            requestContext;
@@ -329,21 +328,23 @@ public class ReadOnlyServiceImpl implements ReadOnlyService, LastAppliedLogIndex
                 event.requestContext = new Bytes(reqCtx);
                 event.startTime = Utils.monotonicMs();
             };
-            int retryTimes = 0;
-            while (true) {
-                if (this.readIndexQueue.tryPublishEvent(translator)) {
-                    break;
-                } else {
-                    retryTimes++;
-                    if (retryTimes > MAX_ADD_REQUEST_RETRY_TIMES) {
-                        Utils.runClosureInThread(closure,
-                            new Status(RaftError.EBUSY, "Node is busy, has too many read-only requests."));
-                        this.nodeMetrics.recordTimes("read-index-overload-times", 1);
-                        LOG.warn("Node {} ReadOnlyServiceImpl readIndexQueue is overload.", this.node.getNodeId());
-                        return;
+
+            switch(this.node.getOptions().getApplyTaskMode()) {
+              case Blocking:
+                this.readIndexQueue.publishEvent(translator);
+                break;
+              case NonBlocking:
+                default:
+                  if (!this.readIndexQueue.tryPublishEvent(translator)) {
+                    Utils.runClosureInThread(closure,
+                        new Status(RaftError.EBUSY, "Node is busy, has too many read-only requests."));
+                    this.nodeMetrics.recordTimes("read-index-overload-times", 1);
+                    LOG.warn("Node {} ReadOnlyServiceImpl readIndexQueue is overload.", this.node.getNodeId());
+                    if(closure == null) {
+                      throw new OverloadException("Node is busy, has too many read-index requests, bufferSize: "+ this.readIndexQueue.getBufferSize()+" , remainingCapacity: "+ this.readIndexQueue.remainingCapacity());
                     }
-                    ThreadHelper.onSpinWait();
-                }
+                  }
+                  break;
             }
         } catch (final Exception e) {
             Utils.runClosureInThread(closure, new Status(RaftError.EPERM, "Node is down."));
@@ -415,7 +416,7 @@ public class ReadOnlyServiceImpl implements ReadOnlyService, LastAppliedLogIndex
 
     @OnlyForTest
     RaftOptions getRaftOptions() {
-        return raftOptions;
+        return this.raftOptions;
     }
 
     private void reportError(final ReadIndexStatus status, final Status st) {

--- a/jraft-core/src/main/java/com/alipay/sofa/jraft/core/ReadOnlyServiceImpl.java
+++ b/jraft-core/src/main/java/com/alipay/sofa/jraft/core/ReadOnlyServiceImpl.java
@@ -336,7 +336,7 @@ public class ReadOnlyServiceImpl implements ReadOnlyService, LastAppliedLogIndex
               case NonBlocking:
                 default:
                   if (!this.readIndexQueue.tryPublishEvent(translator)) {
-                    final String errorMsg = "Node is busy, has too many read-index requests, bufferSize: "+ this.readIndexQueue.getBufferSize()+" , remainingCapacity: "+ this.readIndexQueue.remainingCapacity();
+                    final String errorMsg = "Node is busy, has too many read-index requests, queue is full and bufferSize="+ this.readIndexQueue.getBufferSize();
                     Utils.runClosureInThread(closure,
                         new Status(RaftError.EBUSY, errorMsg));
                     this.nodeMetrics.recordTimes("read-index-overload-times", 1);

--- a/jraft-core/src/main/java/com/alipay/sofa/jraft/error/OverloadException.java
+++ b/jraft-core/src/main/java/com/alipay/sofa/jraft/error/OverloadException.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alipay.sofa.jraft.error;
+
+/**
+ * Task is overload.
+ * @author boyan(boyan@antfin.com)
+ *
+ */
+public class OverloadException extends JRaftException {
+
+    /**
+     *
+     */
+    private static final long serialVersionUID = -5505054326197103575L;
+
+    public OverloadException() {
+        super();
+    }
+
+    public OverloadException(final String message, final Throwable cause, final boolean enableSuppression,
+                             final boolean writableStackTrace) {
+        super(message, cause, enableSuppression, writableStackTrace);
+    }
+
+    public OverloadException(final String message, final Throwable cause) {
+        super(message, cause);
+    }
+
+    public OverloadException(final String message) {
+        super(message);
+    }
+
+    public OverloadException(final Throwable cause) {
+        super(cause);
+    }
+
+}

--- a/jraft-core/src/main/java/com/alipay/sofa/jraft/error/OverloadException.java
+++ b/jraft-core/src/main/java/com/alipay/sofa/jraft/error/OverloadException.java
@@ -17,7 +17,7 @@
 package com.alipay.sofa.jraft.error;
 
 /**
- * Task is overload.
+ * Threw when Node is overloaded.
  * @author boyan(boyan@antfin.com)
  *
  */

--- a/jraft-core/src/main/java/com/alipay/sofa/jraft/option/ApplyTaskMode.java
+++ b/jraft-core/src/main/java/com/alipay/sofa/jraft/option/ApplyTaskMode.java
@@ -1,0 +1,26 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alipay.sofa.jraft.option;
+
+/**
+ * Apply task in blocking or non-blocking mode.
+ * @author boyan(boyan@antfin.com)
+ *
+ */
+public enum ApplyTaskMode {
+    Blocking, NonBlocking
+}

--- a/jraft-core/src/main/java/com/alipay/sofa/jraft/option/NodeOptions.java
+++ b/jraft-core/src/main/java/com/alipay/sofa/jraft/option/NodeOptions.java
@@ -452,7 +452,7 @@ public class NodeOptions extends RpcOptions implements Copiable<NodeOptions> {
                + this.raftRpcThreadPoolSize + ", enableMetrics=" + this.enableMetrics + ", snapshotThrottle="
                + this.snapshotThrottle + ", sharedElectionTimer=" + this.sharedElectionTimer + ", sharedVoteTimer="
                + this.sharedVoteTimer + ", sharedStepDownTimer=" + this.sharedStepDownTimer + ", sharedSnapshotTimer="
-               + this.sharedSnapshotTimer + ", serviceFactory=" + this.serviceFactory + ", raftOptions="
-               + this.raftOptions + "} " + super.toString();
+               + this.sharedSnapshotTimer + ", serviceFactory=" + this.serviceFactory + ", applyTaskMode="
+               + this.applyTaskMode + ", raftOptions=" + this.raftOptions + "} " + super.toString();
     }
 }

--- a/jraft-core/src/main/java/com/alipay/sofa/jraft/option/NodeOptions.java
+++ b/jraft-core/src/main/java/com/alipay/sofa/jraft/option/NodeOptions.java
@@ -168,6 +168,19 @@ public class NodeOptions extends RpcOptions implements Copiable<NodeOptions> {
      */
     private JRaftServiceFactory             serviceFactory         = defaultServiceFactory;
 
+    /**
+     * Apply task in blocking or non-blocking mode, ApplyTaskMode.NonBlocking by default.
+     */
+    private ApplyTaskMode                   applyTaskMode          = ApplyTaskMode.NonBlocking;
+
+    public ApplyTaskMode getApplyTaskMode() {
+        return this.applyTaskMode;
+    }
+
+    public void setApplyTaskMode(final ApplyTaskMode applyTaskMode) {
+        this.applyTaskMode = applyTaskMode;
+    }
+
     public JRaftServiceFactory getServiceFactory() {
         return this.serviceFactory;
     }
@@ -214,10 +227,10 @@ public class NodeOptions extends RpcOptions implements Copiable<NodeOptions> {
     }
 
     public boolean isSharedTimerPool() {
-        return sharedTimerPool;
+        return this.sharedTimerPool;
     }
 
-    public void setSharedTimerPool(boolean sharedTimerPool) {
+    public void setSharedTimerPool(final boolean sharedTimerPool) {
         this.sharedTimerPool = sharedTimerPool;
     }
 
@@ -250,18 +263,18 @@ public class NodeOptions extends RpcOptions implements Copiable<NodeOptions> {
     }
 
     public int getElectionPriority() {
-        return electionPriority;
+        return this.electionPriority;
     }
 
-    public void setElectionPriority(int electionPriority) {
+    public void setElectionPriority(final int electionPriority) {
         this.electionPriority = electionPriority;
     }
 
     public int getDecayPriorityGap() {
-        return decayPriorityGap;
+        return this.decayPriorityGap;
     }
 
-    public void setDecayPriorityGap(int decayPriorityGap) {
+    public void setDecayPriorityGap(final int decayPriorityGap) {
         this.decayPriorityGap = decayPriorityGap;
     }
 
@@ -298,10 +311,10 @@ public class NodeOptions extends RpcOptions implements Copiable<NodeOptions> {
     }
 
     public int getSnapshotLogIndexMargin() {
-        return snapshotLogIndexMargin;
+        return this.snapshotLogIndexMargin;
     }
 
-    public void setSnapshotLogIndexMargin(int snapshotLogIndexMargin) {
+    public void setSnapshotLogIndexMargin(final int snapshotLogIndexMargin) {
         this.snapshotLogIndexMargin = snapshotLogIndexMargin;
     }
 
@@ -370,34 +383,34 @@ public class NodeOptions extends RpcOptions implements Copiable<NodeOptions> {
     }
 
     public boolean isSharedElectionTimer() {
-        return sharedElectionTimer;
+        return this.sharedElectionTimer;
     }
 
-    public void setSharedElectionTimer(boolean sharedElectionTimer) {
+    public void setSharedElectionTimer(final boolean sharedElectionTimer) {
         this.sharedElectionTimer = sharedElectionTimer;
     }
 
     public boolean isSharedVoteTimer() {
-        return sharedVoteTimer;
+        return this.sharedVoteTimer;
     }
 
-    public void setSharedVoteTimer(boolean sharedVoteTimer) {
+    public void setSharedVoteTimer(final boolean sharedVoteTimer) {
         this.sharedVoteTimer = sharedVoteTimer;
     }
 
     public boolean isSharedStepDownTimer() {
-        return sharedStepDownTimer;
+        return this.sharedStepDownTimer;
     }
 
-    public void setSharedStepDownTimer(boolean sharedStepDownTimer) {
+    public void setSharedStepDownTimer(final boolean sharedStepDownTimer) {
         this.sharedStepDownTimer = sharedStepDownTimer;
     }
 
     public boolean isSharedSnapshotTimer() {
-        return sharedSnapshotTimer;
+        return this.sharedSnapshotTimer;
     }
 
-    public void setSharedSnapshotTimer(boolean sharedSnapshotTimer) {
+    public void setSharedSnapshotTimer(final boolean sharedSnapshotTimer) {
         this.sharedSnapshotTimer = sharedSnapshotTimer;
     }
 
@@ -427,17 +440,19 @@ public class NodeOptions extends RpcOptions implements Copiable<NodeOptions> {
 
     @Override
     public String toString() {
-        return "NodeOptions{" + "electionTimeoutMs=" + electionTimeoutMs + ", electionPriority=" + electionPriority
-               + ", decayPriorityGap=" + decayPriorityGap + ", leaderLeaseTimeRatio=" + leaderLeaseTimeRatio
-               + ", snapshotIntervalSecs=" + snapshotIntervalSecs + ", snapshotLogIndexMargin="
-               + snapshotLogIndexMargin + ", catchupMargin=" + catchupMargin + ", initialConf=" + initialConf
-               + ", fsm=" + fsm + ", logUri='" + logUri + '\'' + ", raftMetaUri='" + raftMetaUri + '\''
-               + ", snapshotUri='" + snapshotUri + '\'' + ", filterBeforeCopyRemote=" + filterBeforeCopyRemote
-               + ", disableCli=" + disableCli + ", sharedTimerPool=" + sharedTimerPool + ", timerPoolSize="
-               + timerPoolSize + ", cliRpcThreadPoolSize=" + cliRpcThreadPoolSize + ", raftRpcThreadPoolSize="
-               + raftRpcThreadPoolSize + ", enableMetrics=" + enableMetrics + ", snapshotThrottle=" + snapshotThrottle
-               + ", sharedElectionTimer=" + sharedElectionTimer + ", sharedVoteTimer=" + sharedVoteTimer
-               + ", sharedStepDownTimer=" + sharedStepDownTimer + ", sharedSnapshotTimer=" + sharedSnapshotTimer
-               + ", serviceFactory=" + serviceFactory + ", raftOptions=" + raftOptions + "} " + super.toString();
+        return "NodeOptions{" + "electionTimeoutMs=" + this.electionTimeoutMs + ", electionPriority="
+               + this.electionPriority + ", decayPriorityGap=" + this.decayPriorityGap + ", leaderLeaseTimeRatio="
+               + this.leaderLeaseTimeRatio + ", snapshotIntervalSecs=" + this.snapshotIntervalSecs
+               + ", snapshotLogIndexMargin=" + this.snapshotLogIndexMargin + ", catchupMargin=" + this.catchupMargin
+               + ", initialConf=" + this.initialConf + ", fsm=" + this.fsm + ", logUri='" + this.logUri + '\''
+               + ", raftMetaUri='" + this.raftMetaUri + '\'' + ", snapshotUri='" + this.snapshotUri + '\''
+               + ", filterBeforeCopyRemote=" + this.filterBeforeCopyRemote + ", disableCli=" + this.disableCli
+               + ", sharedTimerPool=" + this.sharedTimerPool + ", timerPoolSize=" + this.timerPoolSize
+               + ", cliRpcThreadPoolSize=" + this.cliRpcThreadPoolSize + ", raftRpcThreadPoolSize="
+               + this.raftRpcThreadPoolSize + ", enableMetrics=" + this.enableMetrics + ", snapshotThrottle="
+               + this.snapshotThrottle + ", sharedElectionTimer=" + this.sharedElectionTimer + ", sharedVoteTimer="
+               + this.sharedVoteTimer + ", sharedStepDownTimer=" + this.sharedStepDownTimer + ", sharedSnapshotTimer="
+               + this.sharedSnapshotTimer + ", serviceFactory=" + this.serviceFactory + ", raftOptions="
+               + this.raftOptions + "} " + super.toString();
     }
 }

--- a/jraft-core/src/main/java/com/alipay/sofa/jraft/storage/LogManager.java
+++ b/jraft-core/src/main/java/com/alipay/sofa/jraft/storage/LogManager.java
@@ -117,6 +117,14 @@ public interface LogManager extends Lifecycle<LogManagerOptions>, Describer {
     void join() throws InterruptedException;
 
     /**
+     * Given specified <tt>requiredCapacity</tt> determines if that amount of space
+     * is available to append these entries. Returns true when available.
+     * @param requiredCapacity
+     * @return Returns true when available.
+     */
+    boolean hasAvailableCapacityToAppendEntries(final int requiredCapacity);
+
+    /**
      * Append log entry vector and wait until it's stable (NOT COMMITTED!)
      *
      * @param entries log entries
@@ -211,7 +219,7 @@ public interface LogManager extends Lifecycle<LogManagerOptions>, Describer {
     /**
      * Wait until there are more logs since |last_log_index| and |on_new_log|
      * would be called after there are new logs or error occurs, return the waiter id.
-     * 
+     *
      * @param expectedLastLogIndex  expected last index of log
      * @param cb                    callback
      * @param arg                   the waiter pass-in argument

--- a/jraft-core/src/main/java/com/alipay/sofa/jraft/storage/impl/LogManagerImpl.java
+++ b/jraft-core/src/main/java/com/alipay/sofa/jraft/storage/impl/LogManagerImpl.java
@@ -57,7 +57,6 @@ import com.alipay.sofa.jraft.util.LogExceptionHandler;
 import com.alipay.sofa.jraft.util.NamedThreadFactory;
 import com.alipay.sofa.jraft.util.Requires;
 import com.alipay.sofa.jraft.util.SegmentList;
-import com.alipay.sofa.jraft.util.ThreadHelper;
 import com.alipay.sofa.jraft.util.Utils;
 import com.lmax.disruptor.EventFactory;
 import com.lmax.disruptor.EventHandler;
@@ -75,33 +74,32 @@ import com.lmax.disruptor.dsl.ProducerType;
  * 2018-Apr-04 4:42:20 PM
  */
 public class LogManagerImpl implements LogManager {
-    private static final int                                 APPEND_LOG_RETRY_TIMES = 50;
 
-    private static final Logger                              LOG                    = LoggerFactory
-                                                                                        .getLogger(LogManagerImpl.class);
+    private static final Logger                              LOG                   = LoggerFactory
+                                                                                       .getLogger(LogManagerImpl.class);
 
     private LogStorage                                       logStorage;
     private ConfigurationManager                             configManager;
     private FSMCaller                                        fsmCaller;
-    private final ReadWriteLock                              lock                   = new ReentrantReadWriteLock();
-    private final Lock                                       writeLock              = this.lock.writeLock();
-    private final Lock                                       readLock               = this.lock.readLock();
+    private final ReadWriteLock                              lock                  = new ReentrantReadWriteLock();
+    private final Lock                                       writeLock             = this.lock.writeLock();
+    private final Lock                                       readLock              = this.lock.readLock();
     private volatile boolean                                 stopped;
     private volatile boolean                                 hasError;
     private long                                             nextWaitId;
-    private LogId                                            diskId                 = new LogId(0, 0);
-    private LogId                                            appliedId              = new LogId(0, 0);
-    private final SegmentList<LogEntry>                      logsInMemory           = new SegmentList<>(true);
+    private LogId                                            diskId                = new LogId(0, 0);
+    private LogId                                            appliedId             = new LogId(0, 0);
+    private final SegmentList<LogEntry>                      logsInMemory          = new SegmentList<>(true);
     private volatile long                                    firstLogIndex;
     private volatile long                                    lastLogIndex;
-    private volatile LogId                                   lastSnapshotId         = new LogId(0, 0);
-    private final Map<Long, WaitMeta>                        waitMap                = new HashMap<>();
+    private volatile LogId                                   lastSnapshotId        = new LogId(0, 0);
+    private final Map<Long, WaitMeta>                        waitMap               = new HashMap<>();
     private Disruptor<StableClosureEvent>                    disruptor;
     private RingBuffer<StableClosureEvent>                   diskQueue;
     private RaftOptions                                      raftOptions;
     private volatile CountDownLatch                          shutDownLatch;
     private NodeMetrics                                      nodeMetrics;
-    private final CopyOnWriteArrayList<LastLogIndexListener> lastLogIndexListeners  = new CopyOnWriteArrayList<>();
+    private final CopyOnWriteArrayList<LastLogIndexListener> lastLogIndexListeners = new CopyOnWriteArrayList<>();
 
     private enum EventType {
         OTHER, // other event type.
@@ -287,6 +285,8 @@ public class LogManagerImpl implements LogManager {
 
     @Override
     public void appendEntries(final List<LogEntry> entries, final StableClosure done) {
+        assert(done != null);
+
         Requires.requireNonNull(done, "done");
         if (this.hasError) {
             entries.clear();
@@ -296,7 +296,7 @@ public class LogManagerImpl implements LogManager {
         boolean doUnlock = true;
         this.writeLock.lock();
         try {
-            if (!entries.isEmpty() && !checkAndResolveConflict(entries, done)) {
+            if (!entries.isEmpty() && !checkAndResolveConflict(entries, done, this.writeLock)) {
                 // If checkAndResolveConflict returns false, the done will be called in it.
                 entries.clear();
                 return;
@@ -323,28 +323,19 @@ public class LogManagerImpl implements LogManager {
             }
             done.setEntries(entries);
 
-            int retryTimes = 0;
             final EventTranslator<StableClosureEvent> translator = (event, sequence) -> {
                 event.reset();
                 event.type = EventType.OTHER;
                 event.done = done;
             };
-            while (true) {
-                if (tryOfferEvent(done, translator)) {
-                    break;
-                } else {
-                    retryTimes++;
-                    if (retryTimes > APPEND_LOG_RETRY_TIMES) {
-                        reportError(RaftError.EBUSY.getNumber(), "LogManager is busy, disk queue overload.");
-                        return;
-                    }
-                    ThreadHelper.onSpinWait();
-                }
-            }
+
             doUnlock = false;
             if (!wakeupAllWaiter(this.writeLock)) {
                 notifyLastLogIndexListeners();
             }
+
+            // publish event out of lock
+            this.diskQueue.publishEvent(translator);
         } finally {
             if (doUnlock) {
                 this.writeLock.unlock();
@@ -352,27 +343,23 @@ public class LogManagerImpl implements LogManager {
         }
     }
 
+    /**
+     * Adds event to disk queue, NEVER call it in lock.
+     * @param done
+     * @param type
+     */
     private void offerEvent(final StableClosure done, final EventType type) {
+        assert(done != null);
+
         if (this.stopped) {
             Utils.runClosureInThread(done, new Status(RaftError.ESTOP, "Log manager is stopped."));
             return;
         }
-        if (!this.diskQueue.tryPublishEvent((event, sequence) -> {
+       this.diskQueue.publishEvent((event, sequence) -> {
             event.reset();
             event.type = type;
             event.done = done;
-        })) {
-            reportError(RaftError.EBUSY.getNumber(), "Log manager is overload.");
-            Utils.runClosureInThread(done, new Status(RaftError.EBUSY, "Log manager is overload."));
-        }
-    }
-
-    private boolean tryOfferEvent(final StableClosure done, final EventTranslator<StableClosureEvent> translator) {
-        if (this.stopped) {
-            Utils.runClosureInThread(done, new Status(RaftError.ESTOP, "Log manager is stopped."));
-            return true;
-        }
-        return this.diskQueue.tryPublishEvent(translator);
+        });
     }
 
     private void notifyLastLogIndexListeners() {
@@ -603,6 +590,7 @@ public class LogManagerImpl implements LogManager {
     @Override
     public void setSnapshot(final SnapshotMeta meta) {
         LOG.debug("set snapshot: {}.", meta);
+        boolean doUnlock = true;
         this.writeLock.lock();
         try {
             if (meta.getLastIncludedIndex() <= this.lastSnapshotId.getIndex()) {
@@ -635,7 +623,9 @@ public class LogManagerImpl implements LogManager {
             if (term == 0) {
                 // last_included_index is larger than last_index
                 // FIXME: what if last_included_index is less than first_index?
-                truncatePrefix(meta.getLastIncludedIndex() + 1);
+                doUnlock = false;
+                //unlock in truncatePrefix
+                truncatePrefix(meta.getLastIncludedIndex() + 1, this.writeLock);
             } else if (term == meta.getLastIncludedTerm()) {
                 // Truncating log to the index of the last snapshot.
                 // We don't truncate log before the last snapshot immediately since
@@ -643,7 +633,9 @@ public class LogManagerImpl implements LogManager {
                 // followers
                 // TODO if there are still be need?
                 if (savedLastSnapshotIndex > 0) {
-                    truncatePrefix(savedLastSnapshotIndex + 1);
+                    doUnlock = false;
+                    //unlock in truncatePrefix
+                    truncatePrefix(savedLastSnapshotIndex + 1, this.writeLock);
                 }
             } else {
                 if (!reset(meta.getLastIncludedIndex() + 1)) {
@@ -651,7 +643,9 @@ public class LogManagerImpl implements LogManager {
                 }
             }
         } finally {
-            this.writeLock.unlock();
+            if (doUnlock) {
+                this.writeLock.unlock();
+            }
         }
 
     }
@@ -688,13 +682,18 @@ public class LogManagerImpl implements LogManager {
 
     @Override
     public void clearBufferedLogs() {
+        boolean doUnlock = true;
         this.writeLock.lock();
         try {
             if (this.lastSnapshotId.getIndex() != 0) {
-                truncatePrefix(this.lastSnapshotId.getIndex() + 1);
+                doUnlock = false;
+                //unlock in truncatePrefix
+                truncatePrefix(this.lastSnapshotId.getIndex() + 1, this.writeLock);
             }
         } finally {
-            this.writeLock.unlock();
+            if (doUnlock) {
+                this.writeLock.unlock();
+            }
         }
     }
 
@@ -828,11 +827,11 @@ public class LogManagerImpl implements LogManager {
                     return this.lastLogIndex;
                 }
                 c = new LastLogIdClosure();
-                offerEvent(c, EventType.LAST_LOG_ID);
             }
         } finally {
             this.readLock.unlock();
         }
+        offerEvent(c, EventType.LAST_LOG_ID);
         try {
             c.await();
         } catch (final InterruptedException e) {
@@ -876,11 +875,11 @@ public class LogManagerImpl implements LogManager {
                     return this.lastSnapshotId;
                 }
                 c = new LastLogIdClosure();
-                offerEvent(c, EventType.LAST_LOG_ID);
             }
         } finally {
             this.readLock.unlock();
         }
+        offerEvent(c, EventType.LAST_LOG_ID);
         try {
             c.await();
         } catch (final InterruptedException e) {
@@ -936,7 +935,7 @@ public class LogManagerImpl implements LogManager {
         }
     }
 
-    private boolean truncatePrefix(final long firstIndexKept) {
+    private boolean truncatePrefix(final long firstIndexKept, final Lock lock) {
 
         this.logsInMemory.removeFromFirstWhen(entry -> entry.getId().getIndex() < firstIndexKept);
 
@@ -951,6 +950,7 @@ public class LogManagerImpl implements LogManager {
         }
         LOG.debug("Truncate prefix, firstIndexKept is :{}", firstIndexKept);
         this.configManager.truncatePrefix(firstIndexKept);
+        lock.unlock();
         final TruncatePrefixClosure c = new TruncatePrefixClosure(firstIndexKept);
         offerEvent(c, EventType.TRUNCATE_PREFIX);
         return true;
@@ -964,15 +964,16 @@ public class LogManagerImpl implements LogManager {
             this.lastLogIndex = nextLogIndex - 1;
             this.configManager.truncatePrefix(this.firstLogIndex);
             this.configManager.truncateSuffix(this.lastLogIndex);
-            final ResetClosure c = new ResetClosure(nextLogIndex);
-            offerEvent(c, EventType.RESET);
             return true;
         } finally {
             this.writeLock.unlock();
+            final ResetClosure c = new ResetClosure(nextLogIndex);
+            offerEvent(c, EventType.RESET);
         }
+
     }
 
-    private void unsafeTruncateSuffix(final long lastIndexKept) {
+    private void unsafeTruncateSuffix(final long lastIndexKept, final Lock lock) {
         if (lastIndexKept < this.appliedId.getIndex()) {
             LOG.error("FATAL ERROR: Can't truncate logs before appliedId={}, lastIndexKept={}", this.appliedId,
                 lastIndexKept);
@@ -986,12 +987,14 @@ public class LogManagerImpl implements LogManager {
         Requires.requireTrue(this.lastLogIndex == 0 || lastTermKept != 0);
         LOG.debug("Truncate suffix :{}", lastIndexKept);
         this.configManager.truncateSuffix(lastIndexKept);
+        lock.unlock();
         final TruncateSuffixClosure c = new TruncateSuffixClosure(lastIndexKept, lastTermKept);
         offerEvent(c, EventType.TRUNCATE_SUFFIX);
+        lock.lock();
     }
 
     @SuppressWarnings("NonAtomicOperationOnVolatileField")
-    private boolean checkAndResolveConflict(final List<LogEntry> entries, final StableClosure done) {
+    private boolean checkAndResolveConflict(final List<LogEntry> entries, final StableClosure done, final Lock lock) {
         final LogEntry firstLogEntry = ArrayDeque.peekFirst(entries);
         if (firstLogEntry.getId().getIndex() == 0) {
             // Node is currently the leader and |entries| are from the user who
@@ -1039,7 +1042,7 @@ public class LogManagerImpl implements LogManager {
                     if (entries.get(conflictingIndex).getId().getIndex() <= this.lastLogIndex) {
                         // Truncate all the conflicting entries to make local logs
                         // consensus with the leader.
-                        unsafeTruncateSuffix(entries.get(conflictingIndex).getId().getIndex() - 1);
+                        unsafeTruncateSuffix(entries.get(conflictingIndex).getId().getIndex() - 1, lock);
                     }
                     this.lastLogIndex = lastLogEntry.getId().getIndex();
                 } // else this is a duplicated AppendEntriesRequest, we have

--- a/jraft-core/src/main/java/com/alipay/sofa/jraft/storage/impl/LogManagerImpl.java
+++ b/jraft-core/src/main/java/com/alipay/sofa/jraft/storage/impl/LogManagerImpl.java
@@ -212,6 +212,13 @@ public class LogManagerImpl implements LogManager {
         return true;
     }
 
+    public boolean hasAvailableCapacityToAppendEntries(final int requiredCapacity) {
+        if (this.stopped) {
+            return false;
+        }
+        return this.diskQueue.hasAvailableCapacity(requiredCapacity);
+    }
+
     private void stopDiskThread() {
         this.shutDownLatch = new CountDownLatch(1);
         Utils.runInThread(() -> this.diskQueue.publishEvent((event, sequence) -> {

--- a/jraft-core/src/main/java/com/alipay/sofa/jraft/util/Utils.java
+++ b/jraft-core/src/main/java/com/alipay/sofa/jraft/util/Utils.java
@@ -145,6 +145,17 @@ public final class Utils {
     }
 
     /**
+     * Run closure in current thread.
+     * @param done
+     * @param status
+     */
+    public static void runClosure(final Closure done, final Status status) {
+        if (done != null) {
+            done.run(status);
+        }
+    }
+
+    /**
      * Run closure with OK status in thread pool.
      */
     public static Future<?> runClosureInThread(final Closure done) {
@@ -442,7 +453,7 @@ public final class Utils {
      * @param addr ip address
      * @return boolean
      */
-    public static boolean isIPv6(String addr) {
+    public static boolean isIPv6(final String addr) {
         try {
             return InetAddress.getByName(addr).getAddress().length == IPV6_ADDRESS_LENGTH;
         } catch (Exception e) {
@@ -462,7 +473,7 @@ public final class Utils {
      * </pre>
      *
      */
-    public static String[] parsePeerId(String s) {
+    public static String[] parsePeerId(final String s) {
         if (s.startsWith(IPV6_START_MARK) && StringUtils.containsIgnoreCase(s, IPV6_END_MARK)) {
             String ipv6Addr;
             if (s.endsWith(IPV6_END_MARK)) {

--- a/jraft-core/src/test/java/com/alipay/sofa/jraft/core/ReadOnlyServiceTest.java
+++ b/jraft-core/src/test/java/com/alipay/sofa/jraft/core/ReadOnlyServiceTest.java
@@ -36,6 +36,7 @@ import com.alipay.sofa.jraft.closure.ReadIndexClosure;
 import com.alipay.sofa.jraft.entity.PeerId;
 import com.alipay.sofa.jraft.entity.ReadIndexState;
 import com.alipay.sofa.jraft.entity.ReadIndexStatus;
+import com.alipay.sofa.jraft.option.NodeOptions;
 import com.alipay.sofa.jraft.option.RaftOptions;
 import com.alipay.sofa.jraft.option.ReadOnlyServiceOptions;
 import com.alipay.sofa.jraft.rpc.RpcRequests.ReadIndexRequest;
@@ -70,6 +71,7 @@ public class ReadOnlyServiceTest {
         opts.setNode(this.node);
         opts.setRaftOptions(new RaftOptions());
         Mockito.when(this.node.getNodeMetrics()).thenReturn(new NodeMetrics(false));
+        Mockito.when(this.node.getOptions()).thenReturn(new NodeOptions());
         Mockito.when(this.node.getGroupId()).thenReturn("test");
         Mockito.when(this.node.getServerId()).thenReturn(new PeerId("localhost:8081", 0));
         assertTrue(this.readOnlyServiceImpl.init(opts));
@@ -270,7 +272,7 @@ public class ReadOnlyServiceTest {
     @Test
     public void testOverMaxReadIndexLag() throws Exception {
         Mockito.when(this.fsmCaller.getLastAppliedIndex()).thenReturn(1L);
-        readOnlyServiceImpl.getRaftOptions().setMaxReadIndexLag(50);
+        this.readOnlyServiceImpl.getRaftOptions().setMaxReadIndexLag(50);
 
         final byte[] requestContext = TestUtils.getRandomBytes();
         final CountDownLatch latch = new CountDownLatch(1);

--- a/jraft-core/src/test/java/com/alipay/sofa/jraft/storage/impl/LogManagerTest.java
+++ b/jraft-core/src/test/java/com/alipay/sofa/jraft/storage/impl/LogManagerTest.java
@@ -105,6 +105,13 @@ public class LogManagerTest extends BaseStorageTest {
     }
 
     @Test
+    public void testHasAvailableCapacityToAppendEntries() {
+        assertTrue(this.logManager.hasAvailableCapacityToAppendEntries(1));
+        assertTrue(this.logManager.hasAvailableCapacityToAppendEntries(10));
+        assertFalse(this.logManager.hasAvailableCapacityToAppendEntries(1000000));
+    }
+
+    @Test
     public void testAppendOneEntry() throws Exception {
         final CountDownLatch latch = new CountDownLatch(1);
         final LogEntry entry = TestUtils.mockEntry(1, 1);


### PR DESCRIPTION
### Motivation:
Right now when the raft node is overloaded, it will trap into error state and can't service any more until restart it by manual. It's not acceptable in many cases.In this PR, i try to improve the backpressure mechanism.

It introduces `ApplyTaskMode` for `Node#apply(task)` and `Node#readIndex(task)`  which determins submmitting tasks to node in blocking or non-blocking mode,  `ApplyTaskMode.NonBlocking` by default. In blocking mode, it will block the invocation to these two methods when node is overloaded, and throws `OverloadException` immediately in non-blocking mode instead.

The PR also Improves disruptor usage in jraft to prevent deadlocking such as #138 #720 etc.

### Modification:

Describe the idea and modifications you've done.

### Result:

Fixes #754 #720 
