### PR TITLE
optimize: support jdk9+ compile code

### DIFF
--- a/jraft-core/src/main/java/com/alipay/sofa/jraft/core/Replicator.java
+++ b/jraft-core/src/main/java/com/alipay/sofa/jraft/core/Replicator.java
@@ -16,6 +16,9 @@
  */
 package com.alipay.sofa.jraft.core;
 
+import static com.codahale.metrics.MetricRegistry.name;
+
+
 import java.nio.ByteBuffer;
 import java.util.ArrayDeque;
 import java.util.HashMap;
@@ -54,6 +57,7 @@ import com.alipay.sofa.jraft.rpc.RpcResponseClosure;
 import com.alipay.sofa.jraft.rpc.RpcResponseClosureAdapter;
 import com.alipay.sofa.jraft.rpc.RpcUtils;
 import com.alipay.sofa.jraft.storage.snapshot.SnapshotReader;
+import com.alipay.sofa.jraft.util.BufferUtils;
 import com.alipay.sofa.jraft.util.ByteBufferCollector;
 import com.alipay.sofa.jraft.util.OnlyForTest;
 import com.alipay.sofa.jraft.util.Recyclable;
@@ -71,8 +75,6 @@ import com.codahale.metrics.MetricSet;
 import com.google.protobuf.ByteString;
 import com.google.protobuf.Message;
 import com.google.protobuf.ZeroByteStringHelper;
-
-import static com.codahale.metrics.MetricRegistry.name;
 
 /**
  * Replicator for replicating log entry from leader to followers.
@@ -1645,7 +1647,7 @@ public class Replicator implements ThreadId.OnError {
                     dataBuf.put(b);
                 }
                 final ByteBuffer buf = dataBuf.getBuffer();
-                buf.flip();
+                BufferUtils.flip(buf);
                 rb.setData(ZeroByteStringHelper.wrap(buf));
             }
         } finally {

--- a/jraft-core/src/main/java/com/alipay/sofa/jraft/core/Replicator.java
+++ b/jraft-core/src/main/java/com/alipay/sofa/jraft/core/Replicator.java
@@ -16,9 +16,6 @@
  */
 package com.alipay.sofa.jraft.core;
 
-import static com.codahale.metrics.MetricRegistry.name;
-
-
 import java.nio.ByteBuffer;
 import java.util.ArrayDeque;
 import java.util.HashMap;
@@ -75,6 +72,8 @@ import com.codahale.metrics.MetricSet;
 import com.google.protobuf.ByteString;
 import com.google.protobuf.Message;
 import com.google.protobuf.ZeroByteStringHelper;
+
+import static com.codahale.metrics.MetricRegistry.name;
 
 /**
  * Replicator for replicating log entry from leader to followers.

--- a/jraft-core/src/main/java/com/alipay/sofa/jraft/entity/UserLog.java
+++ b/jraft-core/src/main/java/com/alipay/sofa/jraft/entity/UserLog.java
@@ -17,6 +17,7 @@
 package com.alipay.sofa.jraft.entity;
 
 import java.nio.ByteBuffer;
+import com.alipay.sofa.jraft.util.BufferUtils;
 
 /**
  * User log entry.
@@ -55,7 +56,7 @@ public class UserLog {
     }
 
     public void reset() {
-        this.data.clear();
+        BufferUtils.clear(this.data);
         this.index = 0;
     }
 

--- a/jraft-core/src/main/java/com/alipay/sofa/jraft/entity/codec/v1/V1Decoder.java
+++ b/jraft-core/src/main/java/com/alipay/sofa/jraft/entity/codec/v1/V1Decoder.java
@@ -27,6 +27,7 @@ import com.alipay.sofa.jraft.entity.PeerId;
 import com.alipay.sofa.jraft.entity.codec.LogEntryDecoder;
 import com.alipay.sofa.jraft.util.AsciiStringUtil;
 import com.alipay.sofa.jraft.util.Bits;
+import com.alipay.sofa.jraft.util.BufferUtils;
 
 /**
  * V1 log entry decoder
@@ -108,7 +109,7 @@ public final class V1Decoder implements LogEntryDecoder {
             final int len = content.length - pos;
             ByteBuffer data = ByteBuffer.allocate(len);
             data.put(content, pos, len);
-            data.flip();
+            BufferUtils.flip(data);
             log.setData(data);
         }
     }

--- a/jraft-core/src/main/java/com/alipay/sofa/jraft/storage/FileService.java
+++ b/jraft-core/src/main/java/com/alipay/sofa/jraft/storage/FileService.java
@@ -22,8 +22,6 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.atomic.AtomicLong;
 
-import io.netty.util.internal.ThreadLocalRandom;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -33,6 +31,7 @@ import com.alipay.sofa.jraft.rpc.RpcRequestClosure;
 import com.alipay.sofa.jraft.rpc.RpcRequests.GetFileRequest;
 import com.alipay.sofa.jraft.rpc.RpcRequests.GetFileResponse;
 import com.alipay.sofa.jraft.storage.io.FileReader;
+import com.alipay.sofa.jraft.util.BufferUtils;
 import com.alipay.sofa.jraft.util.ByteBufferCollector;
 import com.alipay.sofa.jraft.util.OnlyForTest;
 import com.alipay.sofa.jraft.util.RpcFactoryHelper;
@@ -40,6 +39,8 @@ import com.alipay.sofa.jraft.util.Utils;
 import com.google.protobuf.ByteString;
 import com.google.protobuf.Message;
 import com.google.protobuf.ZeroByteStringHelper;
+
+import io.netty.util.internal.ThreadLocalRandom;
 
 /**
  * File reader service.
@@ -108,7 +109,7 @@ public final class FileService {
             responseBuilder.setReadSize(read);
             responseBuilder.setEof(read == FileReader.EOF);
             final ByteBuffer buf = dataBuffer.getBuffer();
-            buf.flip();
+            BufferUtils.flip(buf);
             if (!buf.hasRemaining()) {
                 // skip empty data
                 responseBuilder.setData(ByteString.EMPTY);

--- a/jraft-core/src/main/java/com/alipay/sofa/jraft/storage/FileService.java
+++ b/jraft-core/src/main/java/com/alipay/sofa/jraft/storage/FileService.java
@@ -22,6 +22,8 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.atomic.AtomicLong;
 
+import io.netty.util.internal.ThreadLocalRandom;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -39,8 +41,6 @@ import com.alipay.sofa.jraft.util.Utils;
 import com.google.protobuf.ByteString;
 import com.google.protobuf.Message;
 import com.google.protobuf.ZeroByteStringHelper;
-
-import io.netty.util.internal.ThreadLocalRandom;
 
 /**
  * File reader service.

--- a/jraft-core/src/main/java/com/alipay/sofa/jraft/storage/snapshot/local/SnapshotFileReader.java
+++ b/jraft-core/src/main/java/com/alipay/sofa/jraft/storage/snapshot/local/SnapshotFileReader.java
@@ -26,6 +26,7 @@ import com.alipay.sofa.jraft.error.RetryAgainException;
 import com.alipay.sofa.jraft.storage.SnapshotThrottle;
 import com.alipay.sofa.jraft.storage.io.LocalDirReader;
 import com.alipay.sofa.jraft.storage.snapshot.Snapshot;
+import com.alipay.sofa.jraft.util.BufferUtils;
 import com.alipay.sofa.jraft.util.ByteBufferCollector;
 
 /**
@@ -65,7 +66,7 @@ public class SnapshotFileReader extends LocalDirReader {
         if (fileName.equals(Snapshot.JRAFT_SNAPSHOT_META_FILE)) {
             final ByteBuffer metaBuf = this.metaTable.saveToByteBufferAsRemote();
             // because bufRef will flip the buffer before using, so we must set the meta buffer position to it's limit.
-            metaBuf.position(metaBuf.limit());
+            BufferUtils.position(metaBuf, metaBuf.limit());
             metaBufferCollector.setBuffer(metaBuf);
             return EOF;
         }

--- a/jraft-core/src/main/java/com/alipay/sofa/jraft/storage/snapshot/remote/CopySession.java
+++ b/jraft-core/src/main/java/com/alipay/sofa/jraft/storage/snapshot/remote/CopySession.java
@@ -43,6 +43,7 @@ import com.alipay.sofa.jraft.rpc.RpcRequests.GetFileResponse;
 import com.alipay.sofa.jraft.rpc.RpcResponseClosureAdapter;
 import com.alipay.sofa.jraft.rpc.RpcUtils;
 import com.alipay.sofa.jraft.storage.SnapshotThrottle;
+import com.alipay.sofa.jraft.util.BufferUtils;
 import com.alipay.sofa.jraft.util.ByteBufferCollector;
 import com.alipay.sofa.jraft.util.Endpoint;
 import com.alipay.sofa.jraft.util.OnlyForTest;
@@ -198,7 +199,7 @@ public class CopySession implements Session {
             if (this.destBuf != null) {
                 final ByteBuffer buf = this.destBuf.getBuffer();
                 if (buf != null) {
-                    buf.flip();
+                    BufferUtils.flip(buf);
                 }
                 this.destBuf = null;
             }

--- a/jraft-core/src/main/java/com/alipay/sofa/jraft/util/BufferUtils.java
+++ b/jraft-core/src/main/java/com/alipay/sofa/jraft/util/BufferUtils.java
@@ -1,0 +1,97 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alipay.sofa.jraft.util;
+
+import java.nio.Buffer;
+
+/**
+ * Explicit cast to {@link Buffer} parent buffer type. It resolves issues with covariant return types in Java 9+ for
+ * {@link java.nio.ByteBuffer} and {@link java.nio.CharBuffer}. Explicit casting resolves the NoSuchMethodErrors (e.g
+ * java.lang.NoSuchMethodError: java.nio.ByteBuffer.flip(I)Ljava/nio/ByteBuffer) when the project is compiled with
+ * newer Java version and run on Java 8.
+ * <p/>
+ * <a href="https://docs.oracle.com/javase/8/docs/api/java/nio/ByteBuffer.html">Java 8</a> doesn't provide override the
+ * following Buffer methods in subclasses:
+ *
+ * <pre>
+ * Buffer clear()
+ * Buffer flip()
+ * Buffer limit(int newLimit)
+ * Buffer mark()
+ * Buffer position(int newPosition)
+ * Buffer reset()
+ * Buffer rewind()
+ * </pre>
+ *
+ * <a href="https://docs.oracle.com/javase/9/docs/api/java/nio/ByteBuffer.html">Java 9</a> introduces the overrides in
+ * child classes (e.g the ByteBuffer), but the return type is the specialized one and not the abstract {@link Buffer}.
+ * So the code compiled with newer Java is not working on Java 8 unless a workaround with explicit casting is used.
+ *
+ * @author funkye
+ */
+public class BufferUtils {
+
+    /**
+     * @param buffer byteBuffer
+     */
+    public static void flip(Buffer buffer) {
+        buffer.flip();
+    }
+
+    /**
+     * @param buffer byteBuffer
+     */
+    public static void clear(Buffer buffer) {
+        buffer.clear();
+    }
+
+    /**
+     * @param buffer byteBuffer
+     */
+    public static void limit(Buffer buffer, int newLimit) {
+        buffer.limit(newLimit);
+    }
+
+    /**
+     * @param buffer byteBuffer
+     */
+    public static void mark(Buffer buffer) {
+        buffer.mark();
+    }
+
+    /**
+     * @param buffer byteBuffer
+     */
+    public static void position(Buffer buffer, int newPosition) {
+        buffer.position(newPosition);
+    }
+
+    /**
+     * @param buffer byteBuffer
+     */
+    public static void rewind(Buffer buffer) {
+        buffer.rewind();
+    }
+
+    /**
+     * @param buffer byteBuffer
+     */
+    public static void reset(Buffer buffer) {
+        buffer.reset();
+    }
+
+}

--- a/jraft-core/src/main/java/com/alipay/sofa/jraft/util/ByteBufferCollector.java
+++ b/jraft-core/src/main/java/com/alipay/sofa/jraft/util/ByteBufferCollector.java
@@ -126,7 +126,7 @@ public final class ByteBufferCollector implements Recyclable {
                 // If the size is too large, we should release it to avoid memory overhead
                 this.buffer = null;
             } else {
-                this.buffer.clear();
+                BufferUtils.clear(this.buffer);
             }
         }
         return recyclers.recycle(this, handle);

--- a/jraft-core/src/main/java/com/alipay/sofa/jraft/util/CrcUtil.java
+++ b/jraft-core/src/main/java/com/alipay/sofa/jraft/util/CrcUtil.java
@@ -73,9 +73,9 @@ public final class CrcUtil {
             return crc64(buf.array(), pos + buf.arrayOffset(), rem);
         }
         final byte[] b = new byte[rem];
-        buf.mark();
+        BufferUtils.mark(buf);
         buf.get(b);
-        buf.reset();
+        BufferUtils.reset(buf);
         return crc64(b);
     }
 

--- a/jraft-core/src/main/java/com/alipay/sofa/jraft/util/Utils.java
+++ b/jraft-core/src/main/java/com/alipay/sofa/jraft/util/Utils.java
@@ -280,7 +280,7 @@ public final class Utils {
     public static ByteBuffer expandByteBufferAtLeast(final ByteBuffer buf, final int minLength) {
         final int newCapacity = minLength > RAFT_DATA_BUF_SIZE ? minLength : RAFT_DATA_BUF_SIZE;
         final ByteBuffer newBuf = ByteBuffer.allocate(buf.capacity() + newCapacity);
-        buf.flip();
+        BufferUtils.flip(buf);
         newBuf.put(buf);
         return newBuf;
     }
@@ -291,7 +291,7 @@ public final class Utils {
     public static ByteBuffer expandByteBufferAtMost(final ByteBuffer buf, final int maxLength) {
         final int newCapacity = maxLength > RAFT_DATA_BUF_SIZE || maxLength <= 0 ? RAFT_DATA_BUF_SIZE : maxLength;
         final ByteBuffer newBuf = ByteBuffer.allocate(buf.capacity() + newCapacity);
-        buf.flip();
+        BufferUtils.flip(buf);
         newBuf.put(buf);
         return newBuf;
     }

--- a/jraft-core/src/main/java/com/alipay/sofa/jraft/util/internal/UnsafeUtf8Util.java
+++ b/jraft-core/src/main/java/com/alipay/sofa/jraft/util/internal/UnsafeUtf8Util.java
@@ -32,6 +32,7 @@ package com.alipay.sofa.jraft.util.internal;
 
 import java.nio.ByteBuffer;
 import java.util.Arrays;
+import com.alipay.sofa.jraft.util.BufferUtils;
 
 import static java.lang.Character.MAX_SURROGATE;
 import static java.lang.Character.MIN_HIGH_SURROGATE;
@@ -274,7 +275,7 @@ public final class UnsafeUtf8Util {
         }
         if (inIx == inLimit) {
             // We're done, it was ASCII encoded.
-            out.position((int) (outIx - address));
+            BufferUtils.position(out, (int) (outIx - address));
             return;
         }
 
@@ -314,7 +315,7 @@ public final class UnsafeUtf8Util {
         }
 
         // All bytes have been encoded.
-        out.position((int) (outIx - address));
+        BufferUtils.position(out, (int) (outIx - address));
     }
 
     /**

--- a/jraft-core/src/test/java/com/alipay/sofa/jraft/entity/LogEntryTest.java
+++ b/jraft-core/src/test/java/com/alipay/sofa/jraft/entity/LogEntryTest.java
@@ -19,10 +19,12 @@ package com.alipay.sofa.jraft.entity;
 import java.nio.ByteBuffer;
 import java.nio.ReadOnlyBufferException;
 import java.util.Arrays;
-import com.alipay.sofa.jraft.entity.codec.v1.LogEntryV1CodecFactory;
+
 import com.alipay.sofa.jraft.util.BufferUtils;
 import org.junit.Assert;
 import org.junit.Test;
+
+import com.alipay.sofa.jraft.entity.codec.v1.LogEntryV1CodecFactory;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;

--- a/jraft-core/src/test/java/com/alipay/sofa/jraft/entity/LogEntryTest.java
+++ b/jraft-core/src/test/java/com/alipay/sofa/jraft/entity/LogEntryTest.java
@@ -19,11 +19,10 @@ package com.alipay.sofa.jraft.entity;
 import java.nio.ByteBuffer;
 import java.nio.ReadOnlyBufferException;
 import java.util.Arrays;
-
+import com.alipay.sofa.jraft.entity.codec.v1.LogEntryV1CodecFactory;
+import com.alipay.sofa.jraft.util.BufferUtils;
 import org.junit.Assert;
 import org.junit.Test;
-
-import com.alipay.sofa.jraft.entity.codec.v1.LogEntryV1CodecFactory;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -153,7 +152,7 @@ public class LogEntryTest {
         assertEquals("hella", new String(bs));
 
         try {
-            readOnly.position(4);
+            BufferUtils.position(readOnly, 4);
             readOnly.put((byte) 1);
             fail();
         } catch (ReadOnlyBufferException e) {

--- a/jraft-core/src/test/java/com/alipay/sofa/jraft/rpc/AppendEntriesBenchmark.java
+++ b/jraft-core/src/test/java/com/alipay/sofa/jraft/rpc/AppendEntriesBenchmark.java
@@ -19,12 +19,8 @@ package com.alipay.sofa.jraft.rpc;
 import java.nio.ByteBuffer;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.TimeUnit;
-import com.alipay.sofa.jraft.util.AdaptiveBufAllocator;
+
 import com.alipay.sofa.jraft.util.BufferUtils;
-import com.alipay.sofa.jraft.util.ByteBufferCollector;
-import com.alipay.sofa.jraft.util.RecyclableByteBufferList;
-import com.alipay.sofa.jraft.util.RecycleUtil;
-import com.google.protobuf.ZeroByteStringHelper;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
 import org.openjdk.jmh.annotations.Mode;
@@ -38,6 +34,11 @@ import org.openjdk.jmh.runner.options.Options;
 import org.openjdk.jmh.runner.options.OptionsBuilder;
 import org.openjdk.jmh.runner.options.TimeValue;
 
+import com.alipay.sofa.jraft.util.AdaptiveBufAllocator;
+import com.alipay.sofa.jraft.util.ByteBufferCollector;
+import com.alipay.sofa.jraft.util.RecyclableByteBufferList;
+import com.alipay.sofa.jraft.util.RecycleUtil;
+import com.google.protobuf.ZeroByteStringHelper;
 
 import static com.alipay.sofa.jraft.rpc.RpcRequests.AppendEntriesRequest;
 

--- a/jraft-core/src/test/java/com/alipay/sofa/jraft/rpc/AppendEntriesBenchmark.java
+++ b/jraft-core/src/test/java/com/alipay/sofa/jraft/rpc/AppendEntriesBenchmark.java
@@ -19,7 +19,12 @@ package com.alipay.sofa.jraft.rpc;
 import java.nio.ByteBuffer;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.TimeUnit;
-
+import com.alipay.sofa.jraft.util.AdaptiveBufAllocator;
+import com.alipay.sofa.jraft.util.BufferUtils;
+import com.alipay.sofa.jraft.util.ByteBufferCollector;
+import com.alipay.sofa.jraft.util.RecyclableByteBufferList;
+import com.alipay.sofa.jraft.util.RecycleUtil;
+import com.google.protobuf.ZeroByteStringHelper;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
 import org.openjdk.jmh.annotations.Mode;
@@ -33,11 +38,6 @@ import org.openjdk.jmh.runner.options.Options;
 import org.openjdk.jmh.runner.options.OptionsBuilder;
 import org.openjdk.jmh.runner.options.TimeValue;
 
-import com.alipay.sofa.jraft.util.AdaptiveBufAllocator;
-import com.alipay.sofa.jraft.util.ByteBufferCollector;
-import com.alipay.sofa.jraft.util.RecyclableByteBufferList;
-import com.alipay.sofa.jraft.util.RecycleUtil;
-import com.google.protobuf.ZeroByteStringHelper;
 
 import static com.alipay.sofa.jraft.rpc.RpcRequests.AppendEntriesRequest;
 
@@ -179,7 +179,7 @@ public class AppendEntriesBenchmark {
             dataBuffer.put(buf.slice());
         }
         final ByteBuffer buf = dataBuffer.getBuffer();
-        buf.flip();
+        BufferUtils.flip(buf);
         rb.setData(ZeroByteStringHelper.wrap(buf));
         return rb.build().toByteArray();
     }
@@ -196,7 +196,7 @@ public class AppendEntriesBenchmark {
                 dataBuffer.put(buf.slice());
             }
             final ByteBuffer buf = dataBuffer.getBuffer();
-            buf.flip();
+            BufferUtils.flip(buf);
             rb.setData(ZeroByteStringHelper.wrap(buf));
             return rb.build().toByteArray();
         } finally {
@@ -217,7 +217,7 @@ public class AppendEntriesBenchmark {
                 dataBuffer.put(buf.slice());
             }
             final ByteBuffer buf = dataBuffer.getBuffer();
-            buf.flip();
+            BufferUtils.flip(buf);
             final int remaining = buf.remaining();
             allocator.record(remaining);
             rb.setData(ZeroByteStringHelper.wrap(buf));

--- a/jraft-core/src/test/java/com/alipay/sofa/jraft/storage/io/LocalFileReaderTest.java
+++ b/jraft-core/src/test/java/com/alipay/sofa/jraft/storage/io/LocalFileReaderTest.java
@@ -16,19 +16,18 @@
  */
 package com.alipay.sofa.jraft.storage.io;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
-
 import java.io.File;
 import java.io.FileNotFoundException;
 import java.nio.ByteBuffer;
-
+import com.alipay.sofa.jraft.storage.BaseStorageTest;
+import com.alipay.sofa.jraft.util.BufferUtils;
+import com.alipay.sofa.jraft.util.ByteBufferCollector;
 import org.apache.commons.io.FileUtils;
 import org.junit.Before;
 import org.junit.Test;
 
-import com.alipay.sofa.jraft.storage.BaseStorageTest;
-import com.alipay.sofa.jraft.util.ByteBufferCollector;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
 
 public class LocalFileReaderTest extends BaseStorageTest {
     private LocalDirReader fileReader;
@@ -59,7 +58,7 @@ public class LocalFileReaderTest extends BaseStorageTest {
         final int read = this.fileReader.readFile(bufRef, "data", 0, 1024);
         assertEquals(-1, read);
         final ByteBuffer buf = bufRef.getBuffer();
-        buf.flip();
+        BufferUtils.flip(buf);
         assertEquals(data.length(), buf.remaining());
         final byte[] bs = new byte[data.length()];
         buf.get(bs);
@@ -96,7 +95,7 @@ public class LocalFileReaderTest extends BaseStorageTest {
         assertEquals(-1, read);
 
         final ByteBuffer buf = bufRef.getBuffer();
-        buf.flip();
+        BufferUtils.flip(buf);
         assertEquals(data.length(), buf.remaining());
         final byte[] bs = new byte[data.length()];
         buf.get(bs);

--- a/jraft-core/src/test/java/com/alipay/sofa/jraft/storage/io/LocalFileReaderTest.java
+++ b/jraft-core/src/test/java/com/alipay/sofa/jraft/storage/io/LocalFileReaderTest.java
@@ -16,18 +16,20 @@
  */
 package com.alipay.sofa.jraft.storage.io;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
 import java.io.File;
 import java.io.FileNotFoundException;
 import java.nio.ByteBuffer;
-import com.alipay.sofa.jraft.storage.BaseStorageTest;
+
 import com.alipay.sofa.jraft.util.BufferUtils;
-import com.alipay.sofa.jraft.util.ByteBufferCollector;
 import org.apache.commons.io.FileUtils;
 import org.junit.Before;
 import org.junit.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
+import com.alipay.sofa.jraft.storage.BaseStorageTest;
+import com.alipay.sofa.jraft.util.ByteBufferCollector;
 
 public class LocalFileReaderTest extends BaseStorageTest {
     private LocalDirReader fileReader;

--- a/jraft-core/src/test/java/com/alipay/sofa/jraft/storage/snapshot/local/SnapshotFileReaderTest.java
+++ b/jraft-core/src/test/java/com/alipay/sofa/jraft/storage/snapshot/local/SnapshotFileReaderTest.java
@@ -18,15 +18,17 @@ package com.alipay.sofa.jraft.storage.snapshot.local;
 
 import java.io.FileNotFoundException;
 import java.nio.ByteBuffer;
+
+import com.alipay.sofa.jraft.util.BufferUtils;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
 import com.alipay.sofa.jraft.entity.LocalFileMetaOutter;
 import com.alipay.sofa.jraft.option.RaftOptions;
 import com.alipay.sofa.jraft.storage.BaseStorageTest;
 import com.alipay.sofa.jraft.storage.snapshot.Snapshot;
-import com.alipay.sofa.jraft.util.BufferUtils;
 import com.alipay.sofa.jraft.util.ByteBufferCollector;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;

--- a/jraft-core/src/test/java/com/alipay/sofa/jraft/storage/snapshot/local/SnapshotFileReaderTest.java
+++ b/jraft-core/src/test/java/com/alipay/sofa/jraft/storage/snapshot/local/SnapshotFileReaderTest.java
@@ -18,16 +18,15 @@ package com.alipay.sofa.jraft.storage.snapshot.local;
 
 import java.io.FileNotFoundException;
 import java.nio.ByteBuffer;
-
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
-
 import com.alipay.sofa.jraft.entity.LocalFileMetaOutter;
 import com.alipay.sofa.jraft.option.RaftOptions;
 import com.alipay.sofa.jraft.storage.BaseStorageTest;
 import com.alipay.sofa.jraft.storage.snapshot.Snapshot;
+import com.alipay.sofa.jraft.util.BufferUtils;
 import com.alipay.sofa.jraft.util.ByteBufferCollector;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
@@ -52,7 +51,7 @@ public class SnapshotFileReaderTest extends BaseStorageTest {
         assertEquals(-1, this.reader.readFile(bufRef, Snapshot.JRAFT_SNAPSHOT_META_FILE, 0, Integer.MAX_VALUE));
 
         final ByteBuffer buf = bufRef.getBuffer();
-        buf.flip();
+        BufferUtils.flip(buf);
         final LocalSnapshotMetaTable newTable = new LocalSnapshotMetaTable(new RaftOptions());
         newTable.loadFromIoBufferAsRemote(buf);
         Assert.assertEquals(meta, newTable.getFileMeta("data"));
@@ -81,7 +80,7 @@ public class SnapshotFileReaderTest extends BaseStorageTest {
         final int read = this.reader.readFile(bufRef, "data", 0, 1024);
         assertEquals(-1, read);
         final ByteBuffer buf = bufRef.getBuffer();
-        buf.flip();
+        BufferUtils.flip(buf);
         assertEquals(data.length(), buf.remaining());
         final byte[] bs = new byte[data.length()];
         buf.get(bs);

--- a/jraft-core/src/test/java/com/alipay/sofa/jraft/util/CrcUtilTest.java
+++ b/jraft-core/src/test/java/com/alipay/sofa/jraft/util/CrcUtilTest.java
@@ -37,7 +37,7 @@ public class CrcUtilTest {
 
         buf = ByteBuffer.allocateDirect(bs.length);
         buf.put(bs);
-        buf.flip();
+        BufferUtils.flip(buf);
         assertEquals(c, CrcUtil.crc64(buf));
     }
 }

--- a/jraft-rheakv/rheakv-core/src/main/java/com/alipay/sofa/jraft/rhea/serialization/impl/protostuff/io/NioBufInput.java
+++ b/jraft-rheakv/rheakv-core/src/main/java/com/alipay/sofa/jraft/rhea/serialization/impl/protostuff/io/NioBufInput.java
@@ -20,9 +20,6 @@ import java.io.IOException;
 import java.lang.reflect.Method;
 import java.nio.ByteBuffer;
 import com.alipay.sofa.jraft.util.BufferUtils;
-import com.alipay.sofa.jraft.util.internal.ThrowUtil;
-import com.alipay.sofa.jraft.util.internal.UnsafeUtf8Util;
-import com.alipay.sofa.jraft.util.internal.UnsafeUtil;
 import io.protostuff.ByteBufferInput;
 import io.protostuff.ByteString;
 import io.protostuff.Input;
@@ -31,6 +28,11 @@ import io.protostuff.ProtobufException;
 import io.protostuff.Schema;
 import io.protostuff.StringSerializer;
 import io.protostuff.UninitializedMessageException;
+
+import com.alipay.sofa.jraft.util.internal.ThrowUtil;
+import com.alipay.sofa.jraft.util.internal.UnsafeUtf8Util;
+import com.alipay.sofa.jraft.util.internal.UnsafeUtil;
+
 
 import static io.protostuff.WireFormat.WIRETYPE_END_GROUP;
 import static io.protostuff.WireFormat.WIRETYPE_FIXED32;

--- a/jraft-rheakv/rheakv-core/src/main/java/com/alipay/sofa/jraft/rhea/serialization/impl/protostuff/io/NioBufInput.java
+++ b/jraft-rheakv/rheakv-core/src/main/java/com/alipay/sofa/jraft/rhea/serialization/impl/protostuff/io/NioBufInput.java
@@ -19,7 +19,10 @@ package com.alipay.sofa.jraft.rhea.serialization.impl.protostuff.io;
 import java.io.IOException;
 import java.lang.reflect.Method;
 import java.nio.ByteBuffer;
-
+import com.alipay.sofa.jraft.util.BufferUtils;
+import com.alipay.sofa.jraft.util.internal.ThrowUtil;
+import com.alipay.sofa.jraft.util.internal.UnsafeUtf8Util;
+import com.alipay.sofa.jraft.util.internal.UnsafeUtil;
 import io.protostuff.ByteBufferInput;
 import io.protostuff.ByteString;
 import io.protostuff.Input;
@@ -28,10 +31,6 @@ import io.protostuff.ProtobufException;
 import io.protostuff.Schema;
 import io.protostuff.StringSerializer;
 import io.protostuff.UninitializedMessageException;
-
-import com.alipay.sofa.jraft.util.internal.ThrowUtil;
-import com.alipay.sofa.jraft.util.internal.UnsafeUtf8Util;
-import com.alipay.sofa.jraft.util.internal.UnsafeUtil;
 
 import static io.protostuff.WireFormat.WIRETYPE_END_GROUP;
 import static io.protostuff.WireFormat.WIRETYPE_FIXED32;
@@ -153,7 +152,7 @@ class NioBufInput implements Input {
                 if (size < 0) {
                     throw ProtocolException.negativeSize();
                 }
-                nioBuffer.position(nioBuffer.position() + size);
+                BufferUtils.position(nioBuffer, nioBuffer.position() + size);
                 // offset += size;
                 return true;
             case WIRETYPE_START_GROUP:
@@ -391,15 +390,15 @@ class NioBufInput implements Input {
         String result;
         if (nioBuffer.hasArray()) {
             if (UnsafeUtil.hasUnsafe()) {
-                nioBuffer.position(position + length);
+                BufferUtils.position(nioBuffer, position + length);
                 result = UnsafeUtf8Util.decodeUtf8(nioBuffer.array(), nioBuffer.arrayOffset() + position, length);
             } else {
-                nioBuffer.position(position + length);
+                BufferUtils.position(nioBuffer, position + length);
                 result = StringSerializer.STRING.deser(nioBuffer.array(), nioBuffer.arrayOffset() + position, length);
             }
         } else {
             if (UnsafeUtil.hasUnsafe()) {
-                nioBuffer.position(position + length);
+                BufferUtils.position(nioBuffer, position + length);
                 result = UnsafeUtf8Util.decodeUtf8Direct(nioBuffer, position, length);
             } else {
                 final byte[] tmp = new byte[length];
@@ -487,7 +486,7 @@ class NioBufInput implements Input {
         // restore old limit
         // this.limit = oldLimit;
 
-        nioBuffer.position(nioBuffer.position() + length);
+        BufferUtils.position(nioBuffer, nioBuffer.position() + length);
         return value;
     }
 

--- a/jraft-rheakv/rheakv-core/src/main/java/com/alipay/sofa/jraft/rhea/serialization/impl/protostuff/io/NioBufInput.java
+++ b/jraft-rheakv/rheakv-core/src/main/java/com/alipay/sofa/jraft/rhea/serialization/impl/protostuff/io/NioBufInput.java
@@ -33,7 +33,6 @@ import com.alipay.sofa.jraft.util.internal.ThrowUtil;
 import com.alipay.sofa.jraft.util.internal.UnsafeUtf8Util;
 import com.alipay.sofa.jraft.util.internal.UnsafeUtil;
 
-
 import static io.protostuff.WireFormat.WIRETYPE_END_GROUP;
 import static io.protostuff.WireFormat.WIRETYPE_FIXED32;
 import static io.protostuff.WireFormat.WIRETYPE_FIXED64;

--- a/jraft-rheakv/rheakv-core/src/main/java/com/alipay/sofa/jraft/rhea/serialization/impl/protostuff/io/NioBufOutput.java
+++ b/jraft-rheakv/rheakv-core/src/main/java/com/alipay/sofa/jraft/rhea/serialization/impl/protostuff/io/NioBufOutput.java
@@ -18,17 +18,18 @@ package com.alipay.sofa.jraft.rhea.serialization.impl.protostuff.io;
 
 import java.io.IOException;
 import java.nio.ByteBuffer;
-import com.alipay.sofa.jraft.rhea.serialization.io.OutputBuf;
-import com.alipay.sofa.jraft.rhea.util.VarInts;
+
 import com.alipay.sofa.jraft.util.BufferUtils;
-import com.alipay.sofa.jraft.util.internal.ReferenceFieldUpdater;
-import com.alipay.sofa.jraft.util.internal.UnsafeUtf8Util;
-import com.alipay.sofa.jraft.util.internal.Updaters;
 import io.protostuff.ByteString;
 import io.protostuff.IntSerializer;
 import io.protostuff.Output;
 import io.protostuff.Schema;
 
+import com.alipay.sofa.jraft.rhea.serialization.io.OutputBuf;
+import com.alipay.sofa.jraft.rhea.util.VarInts;
+import com.alipay.sofa.jraft.util.internal.ReferenceFieldUpdater;
+import com.alipay.sofa.jraft.util.internal.UnsafeUtf8Util;
+import com.alipay.sofa.jraft.util.internal.Updaters;
 import static io.protostuff.ProtobufOutput.encodeZigZag32;
 import static io.protostuff.ProtobufOutput.encodeZigZag64;
 import static io.protostuff.WireFormat.WIRETYPE_END_GROUP;

--- a/jraft-rheakv/rheakv-core/src/main/java/com/alipay/sofa/jraft/rhea/serialization/impl/protostuff/io/NioBufOutput.java
+++ b/jraft-rheakv/rheakv-core/src/main/java/com/alipay/sofa/jraft/rhea/serialization/impl/protostuff/io/NioBufOutput.java
@@ -18,17 +18,17 @@ package com.alipay.sofa.jraft.rhea.serialization.impl.protostuff.io;
 
 import java.io.IOException;
 import java.nio.ByteBuffer;
-
+import com.alipay.sofa.jraft.rhea.serialization.io.OutputBuf;
+import com.alipay.sofa.jraft.rhea.util.VarInts;
+import com.alipay.sofa.jraft.util.BufferUtils;
+import com.alipay.sofa.jraft.util.internal.ReferenceFieldUpdater;
+import com.alipay.sofa.jraft.util.internal.UnsafeUtf8Util;
+import com.alipay.sofa.jraft.util.internal.Updaters;
 import io.protostuff.ByteString;
 import io.protostuff.IntSerializer;
 import io.protostuff.Output;
 import io.protostuff.Schema;
 
-import com.alipay.sofa.jraft.rhea.serialization.io.OutputBuf;
-import com.alipay.sofa.jraft.rhea.util.VarInts;
-import com.alipay.sofa.jraft.util.internal.ReferenceFieldUpdater;
-import com.alipay.sofa.jraft.util.internal.UnsafeUtf8Util;
-import com.alipay.sofa.jraft.util.internal.Updaters;
 import static io.protostuff.ProtobufOutput.encodeZigZag32;
 import static io.protostuff.ProtobufOutput.encodeZigZag64;
 import static io.protostuff.WireFormat.WIRETYPE_END_GROUP;
@@ -168,7 +168,7 @@ class NioBufOutput implements Output {
             // Save the current position and increment past the length field. We'll come back
             // and write the length field after the encoding is complete.
             int stringStartPos = position + maxLengthVarIntSize;
-            nioBuffer.position(stringStartPos);
+            BufferUtils.position(nioBuffer, stringStartPos);
 
             int length;
             // Encode the string.
@@ -181,9 +181,9 @@ class NioBufOutput implements Output {
                 int outIndex = UnsafeUtf8Util.encodeUtf8(value, nioBuffer.array(), offset, nioBuffer.remaining());
                 length = outIndex - offset;
             }
-            nioBuffer.position(position);
+            BufferUtils.position(nioBuffer, position);
             writeVarInt32(length);
-            nioBuffer.position(stringStartPos + length);
+            BufferUtils.position(nioBuffer, stringStartPos + length);
         } else {
             // Calculate and write the encoded length.
             int length = UnsafeUtf8Util.encodedLength(value);
@@ -198,7 +198,7 @@ class NioBufOutput implements Output {
                 int pos = nioBuffer.position();
                 UnsafeUtf8Util.encodeUtf8(value, nioBuffer.array(), nioBuffer.arrayOffset() + pos,
                     nioBuffer.remaining());
-                nioBuffer.position(pos + length);
+                BufferUtils.position(nioBuffer, pos + length);
             }
         }
     }

--- a/jraft-rheakv/rheakv-core/src/main/java/com/alipay/sofa/jraft/rhea/serialization/impl/protostuff/io/UnsafeNioBufInput.java
+++ b/jraft-rheakv/rheakv-core/src/main/java/com/alipay/sofa/jraft/rhea/serialization/impl/protostuff/io/UnsafeNioBufInput.java
@@ -19,7 +19,11 @@ package com.alipay.sofa.jraft.rhea.serialization.impl.protostuff.io;
 import java.io.IOException;
 import java.lang.reflect.Method;
 import java.nio.ByteBuffer;
-
+import com.alipay.sofa.jraft.rhea.util.internal.UnsafeDirectBufferUtil;
+import com.alipay.sofa.jraft.util.BufferUtils;
+import com.alipay.sofa.jraft.util.internal.ThrowUtil;
+import com.alipay.sofa.jraft.util.internal.UnsafeUtf8Util;
+import com.alipay.sofa.jraft.util.internal.UnsafeUtil;
 import io.protostuff.ByteBufferInput;
 import io.protostuff.ByteString;
 import io.protostuff.Input;
@@ -27,11 +31,6 @@ import io.protostuff.Output;
 import io.protostuff.ProtobufException;
 import io.protostuff.Schema;
 import io.protostuff.UninitializedMessageException;
-
-import com.alipay.sofa.jraft.util.internal.ThrowUtil;
-import com.alipay.sofa.jraft.rhea.util.internal.UnsafeDirectBufferUtil;
-import com.alipay.sofa.jraft.util.internal.UnsafeUtf8Util;
-import com.alipay.sofa.jraft.util.internal.UnsafeUtil;
 
 import static io.protostuff.WireFormat.WIRETYPE_END_GROUP;
 import static io.protostuff.WireFormat.WIRETYPE_FIXED32;
@@ -160,7 +159,7 @@ class UnsafeNioBufInput implements Input {
                 if (size < 0) {
                     throw ProtocolException.negativeSize();
                 }
-                nioBuffer.position(nioBuffer.position() + size);
+                BufferUtils.position(nioBuffer, nioBuffer.position() + size);
                 // offset += size;
                 return true;
             case WIRETYPE_START_GROUP:
@@ -325,7 +324,7 @@ class UnsafeNioBufInput implements Input {
         checkIfPackedField();
         int position = nioBuffer.position();
         boolean result = UnsafeDirectBufferUtil.getByte(address(position)) != 0;
-        nioBuffer.position(position + 1);
+        BufferUtils.position(nioBuffer, position + 1);
         return result;
     }
 
@@ -399,7 +398,7 @@ class UnsafeNioBufInput implements Input {
 
         int position = nioBuffer.position();
         String result = UnsafeUtf8Util.decodeUtf8Direct(nioBuffer, position, length);
-        nioBuffer.position(position + length);
+        BufferUtils.position(nioBuffer, position + length);
         return result;
     }
 
@@ -442,7 +441,7 @@ class UnsafeNioBufInput implements Input {
         final byte[] copy = new byte[length];
         int position = nioBuffer.position();
         UnsafeDirectBufferUtil.getBytes(address(position), copy, 0, length);
-        nioBuffer.position(position + length);
+        BufferUtils.position(nioBuffer, position + length);
         return copy;
     }
 
@@ -474,7 +473,7 @@ class UnsafeNioBufInput implements Input {
         }
         nestedInput.checkLastTagWas(0);
 
-        nioBuffer.position(nioBuffer.position() + length);
+        BufferUtils.position(nioBuffer, nioBuffer.position() + length);
         return value;
     }
 

--- a/jraft-rheakv/rheakv-core/src/main/java/com/alipay/sofa/jraft/rhea/serialization/impl/protostuff/io/UnsafeNioBufInput.java
+++ b/jraft-rheakv/rheakv-core/src/main/java/com/alipay/sofa/jraft/rhea/serialization/impl/protostuff/io/UnsafeNioBufInput.java
@@ -19,18 +19,21 @@ package com.alipay.sofa.jraft.rhea.serialization.impl.protostuff.io;
 import java.io.IOException;
 import java.lang.reflect.Method;
 import java.nio.ByteBuffer;
-import com.alipay.sofa.jraft.rhea.util.internal.UnsafeDirectBufferUtil;
+
 import com.alipay.sofa.jraft.util.BufferUtils;
-import com.alipay.sofa.jraft.util.internal.ThrowUtil;
-import com.alipay.sofa.jraft.util.internal.UnsafeUtf8Util;
-import com.alipay.sofa.jraft.util.internal.UnsafeUtil;
 import io.protostuff.ByteBufferInput;
 import io.protostuff.ByteString;
 import io.protostuff.Input;
+
 import io.protostuff.Output;
 import io.protostuff.ProtobufException;
 import io.protostuff.Schema;
 import io.protostuff.UninitializedMessageException;
+
+import com.alipay.sofa.jraft.util.internal.ThrowUtil;
+import com.alipay.sofa.jraft.rhea.util.internal.UnsafeDirectBufferUtil;
+import com.alipay.sofa.jraft.util.internal.UnsafeUtf8Util;
+import com.alipay.sofa.jraft.util.internal.UnsafeUtil;
 
 import static io.protostuff.WireFormat.WIRETYPE_END_GROUP;
 import static io.protostuff.WireFormat.WIRETYPE_FIXED32;

--- a/jraft-rheakv/rheakv-core/src/main/java/com/alipay/sofa/jraft/rhea/serialization/impl/protostuff/io/UnsafeNioBufOutput.java
+++ b/jraft-rheakv/rheakv-core/src/main/java/com/alipay/sofa/jraft/rhea/serialization/impl/protostuff/io/UnsafeNioBufOutput.java
@@ -21,6 +21,7 @@ import java.io.IOException;
 import com.alipay.sofa.jraft.rhea.serialization.io.OutputBuf;
 import com.alipay.sofa.jraft.rhea.util.VarInts;
 import com.alipay.sofa.jraft.rhea.util.internal.UnsafeDirectBufferUtil;
+import com.alipay.sofa.jraft.util.BufferUtils;
 import com.alipay.sofa.jraft.util.internal.UnsafeUtf8Util;
 import com.alipay.sofa.jraft.util.internal.UnsafeUtil;
 
@@ -62,16 +63,16 @@ class UnsafeNioBufOutput extends NioBufOutput {
             // Save the current position and increment past the length field. We'll come back
             // and write the length field after the encoding is complete.
             int stringStartPos = position + maxLengthVarIntSize;
-            nioBuffer.position(stringStartPos);
+            BufferUtils.position(nioBuffer, stringStartPos);
 
             // Encode the string.
             UnsafeUtf8Util.encodeUtf8Direct(value, nioBuffer);
 
             // Write the length and advance the position.
             int length = nioBuffer.position() - stringStartPos;
-            nioBuffer.position(position);
+            BufferUtils.position(nioBuffer, position);
             writeVarInt32(length);
-            nioBuffer.position(stringStartPos + length);
+            BufferUtils.position(nioBuffer, stringStartPos + length);
         } else {
             // Calculate and write the encoded length.
             int length = UnsafeUtf8Util.encodedLength(value);
@@ -132,7 +133,7 @@ class UnsafeNioBufOutput extends NioBufOutput {
             position += 4;
             UnsafeDirectBufferUtil.setByte(address(position++), (byte) (value >>> 28));
         }
-        nioBuffer.position(position);
+        BufferUtils.position(nioBuffer, position);
     }
 
     @Override
@@ -245,7 +246,7 @@ class UnsafeNioBufOutput extends NioBufOutput {
             position += 8;
             UnsafeDirectBufferUtil.setByte(address(position++), (byte) (value >>> 56));
         }
-        nioBuffer.position(position);
+        BufferUtils.position(nioBuffer, position);
     }
 
     @Override
@@ -253,7 +254,7 @@ class UnsafeNioBufOutput extends NioBufOutput {
         ensureCapacity(4);
         int position = nioBuffer.position();
         UnsafeDirectBufferUtil.setIntLE(address(position), value);
-        nioBuffer.position(position + 4);
+        BufferUtils.position(nioBuffer, position + 4);
     }
 
     @Override
@@ -261,7 +262,7 @@ class UnsafeNioBufOutput extends NioBufOutput {
         ensureCapacity(8);
         int position = nioBuffer.position();
         UnsafeDirectBufferUtil.setLongLE(address(position), value);
-        nioBuffer.position(position + 8);
+        BufferUtils.position(nioBuffer, position + 8);
     }
 
     @Override
@@ -269,7 +270,7 @@ class UnsafeNioBufOutput extends NioBufOutput {
         ensureCapacity(1);
         int position = nioBuffer.position();
         UnsafeDirectBufferUtil.setByte(address(position), value);
-        nioBuffer.position(position + 1);
+        BufferUtils.position(nioBuffer, position + 1);
     }
 
     @Override
@@ -277,7 +278,7 @@ class UnsafeNioBufOutput extends NioBufOutput {
         ensureCapacity(length);
         int position = nioBuffer.position();
         UnsafeDirectBufferUtil.setBytes(address(position), value, offset, length);
-        nioBuffer.position(position + length);
+        BufferUtils.position(nioBuffer, position + length);
     }
 
     @Override

--- a/jraft-rheakv/rheakv-core/src/test/java/com/alipay/sofa/jraft/rhea/serialization/SerializerTest.java
+++ b/jraft-rheakv/rheakv-core/src/test/java/com/alipay/sofa/jraft/rhea/serialization/SerializerTest.java
@@ -17,11 +17,10 @@
 package com.alipay.sofa.jraft.rhea.serialization;
 
 import java.nio.ByteBuffer;
-
-import org.junit.Test;
-
 import com.alipay.sofa.jraft.rhea.storage.KVOperation;
+import com.alipay.sofa.jraft.util.BufferUtils;
 import com.alipay.sofa.jraft.util.BytesUtil;
+import org.junit.Test;
 
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
@@ -38,7 +37,7 @@ public class SerializerTest {
         final byte[] bytes = serializer.writeObject(op);
         final ByteBuffer buffer = ByteBuffer.allocateDirect(bytes.length);
         buffer.put(bytes);
-        buffer.flip();
+        BufferUtils.flip(buffer);
 
         final KVOperation op1 = serializer.readObject(bytes, KVOperation.class);
         final KVOperation op2 = serializer.readObject(buffer, KVOperation.class);

--- a/jraft-rheakv/rheakv-core/src/test/java/com/alipay/sofa/jraft/rhea/serialization/SerializerTest.java
+++ b/jraft-rheakv/rheakv-core/src/test/java/com/alipay/sofa/jraft/rhea/serialization/SerializerTest.java
@@ -17,10 +17,12 @@
 package com.alipay.sofa.jraft.rhea.serialization;
 
 import java.nio.ByteBuffer;
-import com.alipay.sofa.jraft.rhea.storage.KVOperation;
+
 import com.alipay.sofa.jraft.util.BufferUtils;
-import com.alipay.sofa.jraft.util.BytesUtil;
 import org.junit.Test;
+
+import com.alipay.sofa.jraft.rhea.storage.KVOperation;
+import com.alipay.sofa.jraft.util.BytesUtil;
 
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;

--- a/jraft-test/src/main/java/com/alipay/sofa/jraft/test/atomic/server/processor/BaseAsyncUserProcessor.java
+++ b/jraft-test/src/main/java/com/alipay/sofa/jraft/test/atomic/server/processor/BaseAsyncUserProcessor.java
@@ -28,6 +28,7 @@ import com.alipay.sofa.jraft.test.atomic.server.AtomicRangeGroup;
 import com.alipay.sofa.jraft.test.atomic.server.AtomicServer;
 import com.alipay.sofa.jraft.test.atomic.server.CommandType;
 import com.alipay.sofa.jraft.test.atomic.server.LeaderTaskClosure;
+import com.alipay.sofa.jraft.util.BufferUtils;
 
 public abstract class BaseAsyncUserProcessor<T extends BaseRequestCommand> implements RpcProcessor<T> {
     protected AtomicServer server;
@@ -67,7 +68,7 @@ public abstract class BaseAsyncUserProcessor<T extends BaseRequestCommand> imple
         final ByteBuffer data = ByteBuffer.allocate(cmdBytes.length + 1);
         data.put(cmdType.toByte());
         data.put(cmdBytes);
-        data.flip();
+        BufferUtils.flip(data);
         return new Task(data, closure);
     }
 }


### PR DESCRIPTION
### Motivation:

使用jdk9及以上版本编译源码后进行引入,再默认序列化下,会出现以下异常
java.lang.NoSuchMethodError: java.nio.ByteBuffer.flip()Ljava/nio/ByteBuffer)
需要将ByteBuffer转换为Buffer再调用相关函数

### Modification:

Describe the idea and modifications you've done.

### Result:

Fixes #<GitHub issue number>.

If there is no issue then describe the changes introduced by this PR.
