### PR TITLE
(fix) testLeaderFail

### DIFF
--- a/jraft-core/src/test/java/com/alipay/sofa/jraft/core/MockStateMachine.java
+++ b/jraft-core/src/test/java/com/alipay/sofa/jraft/core/MockStateMachine.java
@@ -33,6 +33,7 @@ import com.alipay.sofa.jraft.Closure;
 import com.alipay.sofa.jraft.Iterator;
 import com.alipay.sofa.jraft.Status;
 import com.alipay.sofa.jraft.entity.LeaderChangeContext;
+import com.alipay.sofa.jraft.entity.RaftOutter.SnapshotMeta;
 import com.alipay.sofa.jraft.error.RaftError;
 import com.alipay.sofa.jraft.storage.snapshot.SnapshotReader;
 import com.alipay.sofa.jraft.storage.snapshot.SnapshotWriter;
@@ -164,7 +165,8 @@ public class MockStateMachine extends StateMachineAdapter {
 
     @Override
     public boolean onSnapshotLoad(final SnapshotReader reader) {
-        this.lastAppliedIndex.set(0);
+        SnapshotMeta meta = reader.load();
+        this.lastAppliedIndex.set(meta.getLastIncludedIndex());
         this.loadSnapshotTimes++;
         final String path = reader.getPath() + File.separator + "data";
         final File file = new File(path);

--- a/jraft-core/src/test/java/com/alipay/sofa/jraft/core/NodeTest.java
+++ b/jraft-core/src/test/java/com/alipay/sofa/jraft/core/NodeTest.java
@@ -1668,7 +1668,7 @@ public class NodeTest {
         assertTrue(cluster.start(oldLeader.getEndpoint()));
         assertTrue(cluster.ensureSame(-1));
         for (final MockStateMachine fsm : cluster.getFsms()) {
-            assertEquals(30, fsm.getLogs().size());
+            assertTrue(fsm.getLogs().size() >= 30);
         }
         cluster.stopAll();
     }


### PR DESCRIPTION
在 old leader 停止期间， 提交到 follower 的任务可能因为选举快速成功，从而提交成功，原来的断言条件过于严格。