### PR TITLE
1.3.10

### DIFF
--- a/jraft-core/pom.xml
+++ b/jraft-core/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>jraft-parent</artifactId>
         <groupId>com.alipay.sofa</groupId>
-        <version>1.3.9</version>
+        <version>1.3.10</version>
     </parent>
     <artifactId>jraft-core</artifactId>
     <packaging>jar</packaging>

--- a/jraft-example/pom.xml
+++ b/jraft-example/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>jraft-parent</artifactId>
         <groupId>com.alipay.sofa</groupId>
-        <version>1.3.9</version>
+        <version>1.3.10</version>
     </parent>
     <artifactId>jraft-example</artifactId>
     <packaging>jar</packaging>

--- a/jraft-extension/pom.xml
+++ b/jraft-extension/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>jraft-parent</artifactId>
         <groupId>com.alipay.sofa</groupId>
-        <version>1.3.9</version>
+        <version>1.3.10</version>
     </parent>
 
     <artifactId>jraft-extension</artifactId>

--- a/jraft-extension/rpc-grpc-impl/pom.xml
+++ b/jraft-extension/rpc-grpc-impl/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>jraft-extension</artifactId>
         <groupId>com.alipay.sofa</groupId>
-        <version>1.3.9</version>
+        <version>1.3.10</version>
     </parent>
 
     <artifactId>rpc-grpc-impl</artifactId>

--- a/jraft-rheakv/pom.xml
+++ b/jraft-rheakv/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>jraft-parent</artifactId>
         <groupId>com.alipay.sofa</groupId>
-        <version>1.3.9</version>
+        <version>1.3.10</version>
     </parent>
 
     <artifactId>jraft-rheakv</artifactId>

--- a/jraft-rheakv/rheakv-core/pom.xml
+++ b/jraft-rheakv/rheakv-core/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>jraft-rheakv</artifactId>
         <groupId>com.alipay.sofa</groupId>
-        <version>1.3.9</version>
+        <version>1.3.10</version>
     </parent>
 
     <artifactId>jraft-rheakv-core</artifactId>

--- a/jraft-rheakv/rheakv-pd/pom.xml
+++ b/jraft-rheakv/rheakv-pd/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>jraft-rheakv</artifactId>
         <groupId>com.alipay.sofa</groupId>
-        <version>1.3.9</version>
+        <version>1.3.10</version>
     </parent>
 
     <artifactId>jraft-rheakv-pd</artifactId>

--- a/jraft-test/pom.xml
+++ b/jraft-test/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>jraft-parent</artifactId>
         <groupId>com.alipay.sofa</groupId>
-        <version>1.3.9</version>
+        <version>1.3.10</version>
     </parent>
     <artifactId>jraft-test</artifactId>
     <packaging>jar</packaging>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>com.alipay.sofa</groupId>
     <artifactId>jraft-parent</artifactId>
-    <version>1.3.9</version>
+    <version>1.3.10</version>
     <packaging>pom</packaging>
 
     <name>${project.groupId}:${project.artifactId}</name>

--- a/pom.xml
+++ b/pom.xml
@@ -67,7 +67,7 @@
         <jsr305.version>3.0.2</jsr305.version>
         <junit.dep.version>4.8.2</junit.dep.version>
         <junit.version>4.13.1</junit.version>
-        <log4j.version>2.17.0</log4j.version>
+        <log4j.version>2.17.1</log4j.version>
         <main.user.dir>${user.dir}</main.user.dir>
         <metrics.version>4.0.2</metrics.version>
         <mockito.version>1.9.5</mockito.version>


### PR DESCRIPTION
* [x] unit test
 * [x] [jepsen verification](https://github.com/sofastack/sofa-jraft-jepsen)
    - [x] configuration-test: remove and add a random node
    - [x] bridge-test: weaving the network into happy little intersecting majority rings
    - [x] pause-test: pausing random node with SIGSTOP/SIGCONT
    - [x] crash-test: killing random nodes and restarting them
    - [x] partition-test: Cuts the network into randomly chosen halves
    - [x] partition-majority-test: Cuts the network into randomly majority groups


 * [x]  benchmark
 * [x] release note
 * [ ] release


## 1.3.10

2022-03-17


- Features
    - 优化 read-index 读，增加 `readIndexToleranceThreshold ` 参数设置快速失败阈值 #738 
    - LogEntry 增加切片读取 API #762 
    - 在删除 rocksdb 大 range 数据时，优化空间回收速度 #768 
    - 在节点过载时，将原有的快速失败策略修改为反压策略，依赖于这个特性的用户推荐升级 #764 
    - 

 - Bug Fixes
    - 升级 Log4j 以解决安全漏洞
    - snapshot 文件使用 `atomic move` 避免文件重新命名是被损坏 #745 #604 
    - 修复 Counter demo 不兼容 gRPC 的问题
    - 修复对 snapshot 并行压缩/解压的配置项错误 
    - 修复在某种竞争条件下 Replicator 可能停止发送心跳的 bug #783 
  

- Breaking Changes
    - 无

- 致谢（排名不分先后）
    @farawayliu @horizonzy @yuyang0423 @googlespot @MartianQiu @OneSizeFitsQuorum 