### PR TITLE
feat: refactor closing local snapshot writer to provide detail error msg

### DIFF
--- a/jraft-core/src/main/java/com/alipay/sofa/jraft/storage/snapshot/local/LocalSnapshotStorage.java
+++ b/jraft-core/src/main/java/com/alipay/sofa/jraft/storage/snapshot/local/LocalSnapshotStorage.java
@@ -198,6 +198,8 @@ public class LocalSnapshotStorage implements SnapshotStorage {
 
     void close(final LocalSnapshotWriter writer, final boolean keepDataOnError) throws IOException {
         int ret = writer.getCode();
+        IOException ioe = null;
+
         // noinspection ConstantConditions
         do {
             if (ret != 0) {
@@ -211,6 +213,7 @@ public class LocalSnapshotStorage implements SnapshotStorage {
             } catch (final IOException e) {
                 LOG.error("Fail to sync writer {}.", writer.getPath(), e);
                 ret = RaftError.EIO.getNumber();
+                ioe = e;
                 break;
             }
             final long oldIndex = getLastSnapshotIndex();
@@ -226,12 +229,14 @@ public class LocalSnapshotStorage implements SnapshotStorage {
             if (!destroySnapshot(newPath)) {
                 LOG.warn("Delete new snapshot path failed, path is {}.", newPath);
                 ret = RaftError.EIO.getNumber();
+                ioe = new IOException("Fail to delete new snapshot path: " + newPath);
                 break;
             }
             LOG.info("Renaming {} to {}.", tempPath, newPath);
             if (!Utils.atomicMoveFile(new File(tempPath), new File(newPath), true)) {
                 LOG.error("Renamed temp snapshot failed, from path {} to path {}.", tempPath, newPath);
                 ret = RaftError.EIO.getNumber();
+                ioe = new IOException("Fail to rename temp snapshot from: " + tempPath + " to: " + newPath);
                 break;
             }
             ref(newIndex);
@@ -244,12 +249,18 @@ public class LocalSnapshotStorage implements SnapshotStorage {
             }
             unref(oldIndex);
         } while (false);
-        if (ret != 0 && !keepDataOnError) {
-            destroySnapshot(writer.getPath());
+
+        if (ret != 0) {
+            LOG.warn("Close snapshot writer {} with exit code: {}", writer.getPath(), ret);
+            if (!keepDataOnError) {
+                destroySnapshot(writer.getPath());
+            }
         }
-        if (ret == RaftError.EIO.getNumber()) {
-            throw new IOException();
+
+        if (ioe != null) {
+            throw ioe;
         }
+
     }
 
     @Override

--- a/jraft-core/src/main/java/com/alipay/sofa/jraft/storage/snapshot/local/LocalSnapshotStorage.java
+++ b/jraft-core/src/main/java/com/alipay/sofa/jraft/storage/snapshot/local/LocalSnapshotStorage.java
@@ -251,7 +251,7 @@ public class LocalSnapshotStorage implements SnapshotStorage {
         } while (false);
 
         if (ret != 0) {
-            LOG.warn("Close snapshot writer {} with exit code: {}", writer.getPath(), ret);
+            LOG.warn("Close snapshot writer {} with exit code: {}.", writer.getPath(), ret);
             if (!keepDataOnError) {
                 destroySnapshot(writer.getPath());
             }

--- a/jraft-core/src/main/java/com/alipay/sofa/jraft/util/Utils.java
+++ b/jraft-core/src/main/java/com/alipay/sofa/jraft/util/Utils.java
@@ -205,7 +205,7 @@ public final class Utils {
             closeable.close();
             return 0;
         } catch (final IOException e) {
-            LOG.error("Fail to close", e);
+            LOG.error("Fail to close {}", closeable, e);
             return RaftError.EIO.getNumber();
         }
     }

--- a/jraft-core/src/main/java/com/alipay/sofa/jraft/util/Utils.java
+++ b/jraft-core/src/main/java/com/alipay/sofa/jraft/util/Utils.java
@@ -205,7 +205,7 @@ public final class Utils {
             closeable.close();
             return 0;
         } catch (final IOException e) {
-            LOG.error("Fail to close {}", closeable, e);
+            LOG.error("Fail to close {}.", closeable, e);
             return RaftError.EIO.getNumber();
         }
     }


### PR DESCRIPTION
refactor `LocalSnapshotStorage#close(LocalSnapshotWriter, boolean)`, try to provide detail error message when go wrong.
