### PR TITLE
1.3.11

### DIFF
--- a/jraft-core/pom.xml
+++ b/jraft-core/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>jraft-parent</artifactId>
         <groupId>com.alipay.sofa</groupId>
-        <version>1.3.10.bugfix_2</version>
+        <version>1.3.11</version>
     </parent>
     <artifactId>jraft-core</artifactId>
     <packaging>jar</packaging>

--- a/jraft-example/pom.xml
+++ b/jraft-example/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>jraft-parent</artifactId>
         <groupId>com.alipay.sofa</groupId>
-        <version>1.3.10.bugfix_2</version>
+        <version>1.3.11</version>
     </parent>
     <artifactId>jraft-example</artifactId>
     <packaging>jar</packaging>

--- a/jraft-extension/bdb-log-storage-impl/pom.xml
+++ b/jraft-extension/bdb-log-storage-impl/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>jraft-extension</artifactId>
         <groupId>com.alipay.sofa</groupId>
-        <version>1.3.9</version>
+        <version>1.3.11</version>
     </parent>
     <artifactId>bdb-log-storage-impl</artifactId>
     <name>bdb-log-storage-impl</name>

--- a/jraft-extension/java-log-storage-impl/pom.xml
+++ b/jraft-extension/java-log-storage-impl/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>jraft-extension</artifactId>
         <groupId>com.alipay.sofa</groupId>
-        <version>1.3.10.bugfix_2</version>
+        <version>1.3.11</version>
     </parent>
 
     <artifactId>java-log-storage-impl</artifactId>

--- a/jraft-extension/pom.xml
+++ b/jraft-extension/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>jraft-parent</artifactId>
         <groupId>com.alipay.sofa</groupId>
-        <version>1.3.10.bugfix_2</version>
+        <version>1.3.11</version>
     </parent>
 
     <artifactId>jraft-extension</artifactId>

--- a/jraft-extension/rpc-grpc-impl/pom.xml
+++ b/jraft-extension/rpc-grpc-impl/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>jraft-extension</artifactId>
         <groupId>com.alipay.sofa</groupId>
-        <version>1.3.10.bugfix_2</version>
+        <version>1.3.11</version>
     </parent>
 
     <artifactId>rpc-grpc-impl</artifactId>

--- a/jraft-rheakv/pom.xml
+++ b/jraft-rheakv/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>jraft-parent</artifactId>
         <groupId>com.alipay.sofa</groupId>
-        <version>1.3.10.bugfix_2</version>
+        <version>1.3.11</version>
     </parent>
 
     <artifactId>jraft-rheakv</artifactId>

--- a/jraft-rheakv/rheakv-core/pom.xml
+++ b/jraft-rheakv/rheakv-core/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>jraft-rheakv</artifactId>
         <groupId>com.alipay.sofa</groupId>
-        <version>1.3.10.bugfix_2</version>
+        <version>1.3.11</version>
     </parent>
 
     <artifactId>jraft-rheakv-core</artifactId>

--- a/jraft-rheakv/rheakv-pd/pom.xml
+++ b/jraft-rheakv/rheakv-pd/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>jraft-rheakv</artifactId>
         <groupId>com.alipay.sofa</groupId>
-        <version>1.3.10.bugfix_2</version>
+        <version>1.3.11</version>
     </parent>
 
     <artifactId>jraft-rheakv-pd</artifactId>

--- a/jraft-test/pom.xml
+++ b/jraft-test/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>jraft-parent</artifactId>
         <groupId>com.alipay.sofa</groupId>
-        <version>1.3.10.bugfix_2</version>
+        <version>1.3.11</version>
     </parent>
     <artifactId>jraft-test</artifactId>
     <packaging>jar</packaging>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>com.alipay.sofa</groupId>
     <artifactId>jraft-parent</artifactId>
-    <version>1.3.10.bugfix_2</version>
+    <version>1.3.11</version>
     <packaging>pom</packaging>
 
     <name>${project.groupId}:${project.artifactId}</name>


### PR DESCRIPTION
## 1.3.11

2022-06-20


- Features
    - 性能优化： RheaKV follower 节点忽略掉读操作 #798 
    - RouteTable 增加刷新 Learners #817 

 - Bug Fixes
    - 修复 `truncatePrefix` 时 key 没有被删除 #806 
    - 修复 RPC 超时 bug #812 
    - 修复因为 RPC overflow 导致的 waitId 被意外清空  #847 

- Breaking Changes
    - 无

- 致谢（排名不分先后）
    @MartianQiu @xh1202 @horizonzy @killme2008 @supergaga @fengjiachun @haoyann 