### PR TITLE
fix: print error detail when atomicMoveFile fails, #857

### DIFF
--- a/jraft-core/src/main/java/com/alipay/sofa/jraft/util/Utils.java
+++ b/jraft-core/src/main/java/com/alipay/sofa/jraft/util/Utils.java
@@ -352,7 +352,7 @@ public final class Utils {
             if (e instanceof AtomicMoveNotSupportedException) {
                 LOG.warn("Atomic move not supported, falling back to non-atomic move, error: {}.", e.getMessage());
             } else {
-                LOG.warn("Unable to move atomically, falling back to non-atomic move, error: {}.", e.getMessage());
+                LOG.error("Unable to move atomically, falling back to non-atomic move, error: {}.", e);
             }
 
             if (target.exists()) {
@@ -363,13 +363,13 @@ public final class Utils {
                 success = Files.move(sourcePath, targetPath, StandardCopyOption.REPLACE_EXISTING) != null;
             } catch (final IOException e1) {
                 e1.addSuppressed(e);
-                LOG.warn("Unable to move {} to {}. Attempting to delete {} and abandoning.", sourcePath, targetPath,
-                    sourcePath);
+                LOG.error("Unable to move {} to {}. Attempting to delete {} and abandoning.", sourcePath, targetPath,
+                    sourcePath, e1);
                 try {
                     Files.deleteIfExists(sourcePath);
                 } catch (final IOException e2) {
                     e2.addSuppressed(e1);
-                    LOG.warn("Unable to delete {}, good bye then!", sourcePath);
+                    LOG.error("Unable to delete {}, good bye then!", sourcePath, e2);
                     throw e2;
                 }
 


### PR DESCRIPTION
### Motivation:

Log the exception detail when `Utils.atomicMoveFile` fails.
