### PR TITLE
Bug fix: add exec-maven-plugin version

### DIFF
--- a/jraft-example/pom.xml
+++ b/jraft-example/pom.xml
@@ -78,6 +78,7 @@
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>exec-maven-plugin</artifactId>
+                <version>1.6.0</version>
                 <configuration>
                     <executable>java</executable>
                     <mainClass>com.alipay.sofa.jraft.benchmark.BenchmarkBootstrap</mainClass>


### PR DESCRIPTION
Describe the bug
When I compile the project, I find exec-maven-plugin unkown，Because this plugin does not specify a version number

Expected behavior
Compilation failed

Actual behavior
Compilation failed

Steps to reproduce
mvn clean install

Minimal yet complete reproducer code (or GitHub URL to code)
Environment
SOFABolt version:
JVM version (e.g. java -version):
OS version (e.g. uname -a):
Maven version:
IDE version:
