### PR TITLE
release: 1.3.12

### DIFF
--- a/jraft-core/pom.xml
+++ b/jraft-core/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>jraft-parent</artifactId>
         <groupId>com.alipay.sofa</groupId>
-        <version>1.3.11</version>
+        <version>1.3.12</version>
     </parent>
     <artifactId>jraft-core</artifactId>
     <packaging>jar</packaging>

--- a/jraft-example/pom.xml
+++ b/jraft-example/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>jraft-parent</artifactId>
         <groupId>com.alipay.sofa</groupId>
-        <version>1.3.11</version>
+        <version>1.3.12</version>
     </parent>
     <artifactId>jraft-example</artifactId>
     <packaging>jar</packaging>

--- a/jraft-extension/bdb-log-storage-impl/pom.xml
+++ b/jraft-extension/bdb-log-storage-impl/pom.xml
@@ -4,10 +4,10 @@
     <parent>
         <artifactId>jraft-extension</artifactId>
         <groupId>com.alipay.sofa</groupId>
-        <version>1.3.11</version>
+        <version>1.3.12</version>
     </parent>
     <artifactId>bdb-log-storage-impl</artifactId>
-    <name>bdb-log-storage-impl</name>
+    <name>bdb-log-storage-impl ${project.version}</name>
     <url>http://maven.apache.org</url>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/jraft-extension/java-log-storage-impl/pom.xml
+++ b/jraft-extension/java-log-storage-impl/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>jraft-extension</artifactId>
         <groupId>com.alipay.sofa</groupId>
-        <version>1.3.11</version>
+        <version>1.3.12</version>
     </parent>
 
     <artifactId>java-log-storage-impl</artifactId>

--- a/jraft-extension/pom.xml
+++ b/jraft-extension/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>jraft-parent</artifactId>
         <groupId>com.alipay.sofa</groupId>
-        <version>1.3.11</version>
+        <version>1.3.12</version>
     </parent>
 
     <artifactId>jraft-extension</artifactId>

--- a/jraft-extension/rpc-grpc-impl/pom.xml
+++ b/jraft-extension/rpc-grpc-impl/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>jraft-extension</artifactId>
         <groupId>com.alipay.sofa</groupId>
-        <version>1.3.11</version>
+        <version>1.3.12</version>
     </parent>
 
     <artifactId>rpc-grpc-impl</artifactId>

--- a/jraft-rheakv/pom.xml
+++ b/jraft-rheakv/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>jraft-parent</artifactId>
         <groupId>com.alipay.sofa</groupId>
-        <version>1.3.11</version>
+        <version>1.3.12</version>
     </parent>
 
     <artifactId>jraft-rheakv</artifactId>

--- a/jraft-rheakv/rheakv-core/pom.xml
+++ b/jraft-rheakv/rheakv-core/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>jraft-rheakv</artifactId>
         <groupId>com.alipay.sofa</groupId>
-        <version>1.3.11</version>
+        <version>1.3.12</version>
     </parent>
 
     <artifactId>jraft-rheakv-core</artifactId>

--- a/jraft-rheakv/rheakv-pd/pom.xml
+++ b/jraft-rheakv/rheakv-pd/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>jraft-rheakv</artifactId>
         <groupId>com.alipay.sofa</groupId>
-        <version>1.3.11</version>
+        <version>1.3.12</version>
     </parent>
 
     <artifactId>jraft-rheakv-pd</artifactId>

--- a/jraft-test/pom.xml
+++ b/jraft-test/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>jraft-parent</artifactId>
         <groupId>com.alipay.sofa</groupId>
-        <version>1.3.11</version>
+        <version>1.3.12</version>
     </parent>
     <artifactId>jraft-test</artifactId>
     <packaging>jar</packaging>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>com.alipay.sofa</groupId>
     <artifactId>jraft-parent</artifactId>
-    <version>1.3.11</version>
+    <version>1.3.12</version>
     <packaging>pom</packaging>
 
     <name>${project.groupId}:${project.artifactId}</name>


### PR DESCRIPTION
* [x] unit test
 * [ ] [jepsen verification](https://github.com/sofastack/sofa-jraft-jepsen)
    - [x] configuration-test: remove and add a random node
    - [x] bridge-test: weaving the network into happy little intersecting majority rings
    - [x] pause-test: pausing random node with SIGSTOP/SIGCONT
    - [x] crash-test: killing random nodes and restarting them
    - [x] partition-test: Cuts the network into randomly chosen halves
    - [x] partition-majority-test: Cuts the network into randomly majority groups


 * [x] release note
 * [ ] release


## 1.3.12

~~2022-11-28~~
2022-12-13


- Features
    - Custom thread pool instead of global thread pool #853 #855
    - `ReadOnlyOption` can be set individually for each request #867 
    - RheaKV supports setting compression levels for snapshots #875 
    - New API for getting last log indexes #880 #879 
    - Upgrade RocksDB to v7.7.3 #896
    - Upgrade gRPC to v1.50.2 #904

 - Bug Fixes
    - Fixes `exec-maven-plugin unkown` error #878 
    - Fixes `NodeOptions.copy() without base class RpcOptions` #902 
    - RheaKV bugfix: `containsKey` inconsistent results returned after Snapshot #905 #909
  

- Breaking Changes
    - 无

- 致谢（排名不分先后）
@shihuili1218 @nobodyiam @qiujiayu @xtr1993 @killme2008 @lfygh @KomachiSion 
    