### PR TITLE
(fix) 修复时间轮算法多循环低效率问题

### DIFF
--- a/jraft-core/src/main/java/com/alipay/sofa/jraft/util/timer/HashedWheelTimer.java
+++ b/jraft-core/src/main/java/com/alipay/sofa/jraft/util/timer/HashedWheelTimer.java
@@ -247,11 +247,15 @@ public class HashedWheelTimer implements Timer {
     }
 
     private static int normalizeTicksPerWheel(int ticksPerWheel) {
-        int normalizedTicksPerWheel = 1;
-        while (normalizedTicksPerWheel < ticksPerWheel) {
-            normalizedTicksPerWheel <<= 1;
-        }
-        return normalizedTicksPerWheel;
+        // Fixed calculation process to avoid multi-cycle inefficiency
+        int n = ticksPerWheel - 1;
+        n |= n >>> 1;
+        n |= n >>> 2;
+        n |= n >>> 4;
+        n |= n >>> 8;
+        n |= n >>> 16;
+        // Prevent spillage, 1073741824 = 2^30
+        return (n < 0) ? 1 : (n >= 1073741824) ? 1073741824 : n + 1;
     }
 
     /**


### PR DESCRIPTION
### Motivation:
原方法HashedWheelTimer#normalizeTicksPerWheel循环多次，方法执行时间不稳定，效率可能会偏低。
### Modification:
使用java8 HashMap的相关实现来完善该算法
### Result:
Fixes #926.