### PR TITLE
fix: don't block heartbeat response when fsm is busy

### DIFF
--- a/jraft-core/src/main/java/com/alipay/sofa/jraft/FSMCaller.java
+++ b/jraft-core/src/main/java/com/alipay/sofa/jraft/FSMCaller.java
@@ -66,6 +66,14 @@ public interface FSMCaller extends Lifecycle<FSMCallerOptions>, Describer {
     boolean onCommitted(final long committedIndex);
 
     /**
+     * Given specified <tt>requiredCapacity</tt> determines if that amount of space
+     * is available to submit new tasks to fsm. Returns true when available.
+     * @param requiredCapacity
+     * @return Returns true when available.
+     */
+    public boolean hasAvailableCapacity(final int requiredCapacity);
+
+    /**
      * Called when loading snapshot.
      *
      * @param done callback

--- a/jraft-core/src/main/java/com/alipay/sofa/jraft/core/FSMCallerImpl.java
+++ b/jraft-core/src/main/java/com/alipay/sofa/jraft/core/FSMCallerImpl.java
@@ -252,6 +252,14 @@ public class FSMCallerImpl implements FSMCaller {
     }
 
     @Override
+    public boolean hasAvailableCapacity(int requiredCapacity) {
+        if (this.shutdownLatch != null) {
+            return false;
+        }
+        return this.taskQueue.hasAvailableCapacity(requiredCapacity);
+    }
+
+    @Override
     public boolean onCommitted(final long committedIndex) {
         return enqueueTask((task, sequence) -> {
             task.type = TaskType.COMMITTED;

--- a/jraft-core/src/main/java/com/alipay/sofa/jraft/core/NodeImpl.java
+++ b/jraft-core/src/main/java/com/alipay/sofa/jraft/core/NodeImpl.java
@@ -1017,6 +1017,7 @@ public class NodeImpl implements Node, RaftServerService {
         final BallotBoxOptions ballotBoxOpts = new BallotBoxOptions();
         ballotBoxOpts.setWaiter(this.fsmCaller);
         ballotBoxOpts.setClosureQueue(this.closureQueue);
+        ballotBoxOpts.setNodeId(getNodeId());
         if (!this.ballotBox.init(ballotBoxOpts)) {
             LOG.error("Node {} init ballotBox failed.", getNodeId());
             return false;

--- a/jraft-core/src/main/java/com/alipay/sofa/jraft/core/ReadOnlyServiceImpl.java
+++ b/jraft-core/src/main/java/com/alipay/sofa/jraft/core/ReadOnlyServiceImpl.java
@@ -234,7 +234,8 @@ public class ReadOnlyServiceImpl implements ReadOnlyService, LastAppliedLogIndex
         final List<ReadIndexState> states = events.stream()
                 .filter(it -> option.equals(it.readOnlyOptions))
                 .map(it -> {
-                    rb.addEntries(ZeroByteStringHelper.wrap(it.requestContext.get()));
+                	byte [] bytes = it.requestContext.get();
+                    rb.addEntries(ZeroByteStringHelper.wrap(bytes == null? new byte[0]: bytes));
                     return new ReadIndexState(it.requestContext, it.done, it.startTime);
                 })
                 .collect(Collectors.toList());

--- a/jraft-core/src/main/java/com/alipay/sofa/jraft/core/ReadOnlyServiceImpl.java
+++ b/jraft-core/src/main/java/com/alipay/sofa/jraft/core/ReadOnlyServiceImpl.java
@@ -234,7 +234,7 @@ public class ReadOnlyServiceImpl implements ReadOnlyService, LastAppliedLogIndex
         final List<ReadIndexState> states = events.stream()
                 .filter(it -> option.equals(it.readOnlyOptions))
                 .map(it -> {
-                	byte [] bytes = it.requestContext.get();
+             byte [] bytes = it.requestContext.get();
                     rb.addEntries(ZeroByteStringHelper.wrap(bytes == null? new byte[0]: bytes));
                     return new ReadIndexState(it.requestContext, it.done, it.startTime);
                 })

--- a/jraft-core/src/main/java/com/alipay/sofa/jraft/option/BallotBoxOptions.java
+++ b/jraft-core/src/main/java/com/alipay/sofa/jraft/option/BallotBoxOptions.java
@@ -18,6 +18,7 @@ package com.alipay.sofa.jraft.option;
 
 import com.alipay.sofa.jraft.FSMCaller;
 import com.alipay.sofa.jraft.closure.ClosureQueue;
+import com.alipay.sofa.jraft.entity.NodeId;
 
 /**
  * Ballot box options.
@@ -30,6 +31,15 @@ public class BallotBoxOptions {
 
     private FSMCaller    waiter;
     private ClosureQueue closureQueue;
+    private NodeId       nodeId;
+
+    public NodeId getNodeId() {
+        return nodeId;
+    }
+
+    public void setNodeId(NodeId nodeId) {
+        this.nodeId = nodeId;
+    }
 
     public FSMCaller getWaiter() {
         return this.waiter;

--- a/jraft-core/src/main/java/com/alipay/sofa/jraft/option/NodeOptions.java
+++ b/jraft-core/src/main/java/com/alipay/sofa/jraft/option/NodeOptions.java
@@ -104,6 +104,7 @@ public class NodeOptions extends RpcOptions implements Copiable<NodeOptions> {
     // Describe a specific SnapshotStorage in format ${type}://${parameters}
     private String                          snapshotUri;
 
+    // Snapshot temp directory for writing. Default is null(not present), jraft will use a `temp` dir under #{snapshotUri}
     private String                          snapshotTempUri;
 
     // If enable, we will filter duplicate files before copy remote snapshot,

--- a/jraft-core/src/test/java/com/alipay/sofa/jraft/core/BallotBoxTest.java
+++ b/jraft-core/src/test/java/com/alipay/sofa/jraft/core/BallotBoxTest.java
@@ -148,9 +148,10 @@ public class BallotBoxTest {
 
     @Test
     public void testSetLastCommittedIndex() {
+        Mockito.when(this.waiter.hasAvailableCapacity(1)).thenReturn(true);
         assertEquals(0, this.box.getLastCommittedIndex());
         assertTrue(this.box.setLastCommittedIndex(1));
         assertEquals(1, this.box.getLastCommittedIndex());
-        Mockito.verify(this.waiter, Mockito.only()).onCommitted(1);
+        Mockito.verify(this.waiter, Mockito.times(1)).onCommitted(1);
     }
 }


### PR DESCRIPTION
### Motivation:

Don't block processing heartbeat requests when FSM is busy.

### Modification:

When FSM is busy, then don't update the `lastCommitIndex` at that time. It's fine because the heartbeat requests and append entries requests will keep attaching the latest commit index.


### Result:

Fixes #845 #830 

