### PR TITLE
Motivation: update RocksDB version and remove some @Deprecated method

### DIFF
--- a/jraft-core/src/main/java/com/alipay/sofa/jraft/util/StorageOptionsFactory.java
+++ b/jraft-core/src/main/java/com/alipay/sofa/jraft/util/StorageOptionsFactory.java
@@ -20,8 +20,17 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
 
-import org.rocksdb.*;
+import org.rocksdb.BlockBasedTableConfig;
+import org.rocksdb.BloomFilter;
+import org.rocksdb.ColumnFamilyOptions;
+import org.rocksdb.CompactionStyle;
+import org.rocksdb.CompressionType;
+import org.rocksdb.DBOptions;
+import org.rocksdb.IndexType;
+import org.rocksdb.RocksDB;
+import org.rocksdb.RocksObject;
 import org.rocksdb.util.SizeUnit;
+import org.rocksdb.LRUCache;
 
 /**
  * @author jiachun.fjc

--- a/jraft-core/src/main/java/com/alipay/sofa/jraft/util/StorageOptionsFactory.java
+++ b/jraft-core/src/main/java/com/alipay/sofa/jraft/util/StorageOptionsFactory.java
@@ -20,15 +20,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
 
-import org.rocksdb.BlockBasedTableConfig;
-import org.rocksdb.BloomFilter;
-import org.rocksdb.ColumnFamilyOptions;
-import org.rocksdb.CompactionStyle;
-import org.rocksdb.CompressionType;
-import org.rocksdb.DBOptions;
-import org.rocksdb.IndexType;
-import org.rocksdb.RocksDB;
-import org.rocksdb.RocksObject;
+import org.rocksdb.*;
 import org.rocksdb.util.SizeUnit;
 
 /**
@@ -375,15 +367,17 @@ public final class StorageOptionsFactory {
             .setPinL0FilterAndIndexBlocksInCache(true) //
             // End of partitioned index filters settings.
             .setBlockSize(4 * SizeUnit.KB)//
-            .setBlockCacheSize(512 * SizeUnit.MB) //
-            .setCacheNumShardBits(8);
+//            .setBlockCacheSize(512 * SizeUnit.MB) //
+//            .setCacheNumShardBits(8)
+            .setBlockCache(new LRUCache(512 * SizeUnit.MB,8));
     }
 
     private static BlockBasedTableConfig copyTableFormatConfig(final BlockBasedTableConfig cfg) {
         return new BlockBasedTableConfig() //
             .setNoBlockCache(cfg.noBlockCache()) //
-            .setBlockCacheSize(cfg.blockCacheSize()) //
-            .setCacheNumShardBits(cfg.cacheNumShardBits()) //
+//            .setBlockCacheSize(cfg.blockCacheSize()) //
+//            .setCacheNumShardBits(cfg.cacheNumShardBits()) //
+            .setBlockCache(new LRUCache(512 * SizeUnit.MB,8))
             .setBlockSize(cfg.blockSize()) //
             .setBlockSizeDeviation(cfg.blockSizeDeviation()) //
             .setBlockRestartInterval(cfg.blockRestartInterval()) //
@@ -394,9 +388,9 @@ public final class StorageOptionsFactory {
             .setPartitionFilters(cfg.partitionFilters()) //
             .setMetadataBlockSize(cfg.metadataBlockSize()) //
             .setPinTopLevelIndexAndFilter(cfg.pinTopLevelIndexAndFilter()) //
-            .setHashIndexAllowCollision(cfg.hashIndexAllowCollision()) //
-            .setBlockCacheCompressedSize(cfg.blockCacheCompressedSize()) //
-            .setBlockCacheCompressedNumShardBits(cfg.blockCacheCompressedNumShardBits()) //
+//            .setHashIndexAllowCollision(cfg.hashIndexAllowCollision()) //
+//            .setBlockCacheCompressedSize(cfg.blockCacheCompressedSize()) //
+//            .setBlockCacheCompressedNumShardBits(cfg.blockCacheCompressedNumShardBits()) //
             .setChecksumType(cfg.checksumType()) //
             .setIndexType(cfg.indexType()) //
             .setFormatVersion(cfg.formatVersion());

--- a/pom.xml
+++ b/pom.xml
@@ -76,7 +76,7 @@
         <project.encoding>UTF-8</project.encoding>
         <protobuf.version>3.5.1</protobuf.version>
         <protostuff.version>1.6.0</protostuff.version>
-        <rocksdb.version>7.7.3</rocksdb.version>
+        <rocksdb.version>8.1.1.1</rocksdb.version>
         <slf4j.version>1.7.21</slf4j.version>
     </properties>
 


### PR DESCRIPTION
### Modification:
update RocksDB version to 8.1.1.1
remove some @Deprecated method
RocksdDB has removed blockCacheCompressed after 8.1.1.1

### Result:
Fixes #982