### PR TITLE
fix java-log-storage-impl moudle FileManger.truncatePrefix bug

### DIFF
--- a/jraft-extension/java-log-storage-impl/src/main/java/com/alipay/sofa/jraft/storage/file/FileManager.java
+++ b/jraft-extension/java-log-storage-impl/src/main/java/com/alipay/sofa/jraft/storage/file/FileManager.java
@@ -436,7 +436,7 @@ public class FileManager {
             for (final AbstractFile abstractFile : this.files) {
                 final long lastLogIndex = abstractFile.getLastLogIndex();
                 if (lastLogIndex < firstIndexKept) {
-                    willRemoveFiles.addAll(this.files);
+                    willRemoveFiles.add(abstractFile);
                 }
             }
             return true;


### PR DESCRIPTION
该bug会导致宕机，生成了hs_err_pidxxx.log，原因是底层的MappedByteBuffer被unmap，但仍然存在put操作
