### PR TITLE
(fix) NullPointerException at FSMCallerImpl#doCommitted when this.node.getOptions() #1035

### DIFF
--- a/jraft-core/src/main/java/com/alipay/sofa/jraft/core/FSMCallerImpl.java
+++ b/jraft-core/src/main/java/com/alipay/sofa/jraft/core/FSMCallerImpl.java
@@ -449,7 +449,7 @@ public class FSMCallerImpl implements FSMCaller {
                     case SHUTDOWN:
                         this.currTask = TaskType.SHUTDOWN;
                         shutdown = task.shutdownLatch;
-						doShutdown();
+                        doShutdown();
                         break;
                     case FLUSH:
                         this.currTask = TaskType.FLUSH;

--- a/jraft-core/src/main/java/com/alipay/sofa/jraft/core/FSMCallerImpl.java
+++ b/jraft-core/src/main/java/com/alipay/sofa/jraft/core/FSMCallerImpl.java
@@ -233,7 +233,6 @@ public class FSMCallerImpl implements FSMCaller {
                 task.shutdownLatch = latch;
             }));
         }
-        doShutdown();
     }
 
     @Override
@@ -450,6 +449,7 @@ public class FSMCallerImpl implements FSMCaller {
                     case SHUTDOWN:
                         this.currTask = TaskType.SHUTDOWN;
                         shutdown = task.shutdownLatch;
+						doShutdown();
                         break;
                     case FLUSH:
                         this.currTask = TaskType.FLUSH;


### PR DESCRIPTION
(fix) NullPointerException at FSMCallerImpl#doCommitted when this.node.getOptions() #1035

### Motivation:

I'm worried about the racing NullPointerException.

### Modification:

Do the shutdown not outside but in the last task.

### Result:

Fixes #1035.

If there is no issue then describe the changes introduced by this PR.
