### PR TITLE
add judgement for SimpleForwardingServerCall in method ServerStreamHelper.getServerStream

### DIFF
--- a/jraft-extension/rpc-grpc-impl/src/main/java/io/grpc/internal/ServerStreamHelper.java
+++ b/jraft-extension/rpc-grpc-impl/src/main/java/io/grpc/internal/ServerStreamHelper.java
@@ -28,15 +28,15 @@ import io.grpc.ServerCall;
  */
 public class ServerStreamHelper {
 
-    private static final ReferenceFieldUpdater<ServerCallImpl<?, ?>, ServerStream> STREAM_GETTER = Updaters
-                                                                                                     .newReferenceFieldUpdater(
-                                                                                                         ServerCallImpl.class,
-                                                                                                         "stream");
+    private static final ReferenceFieldUpdater<ServerCallImpl<?, ?>, ServerStream>                                      STREAM_GETTER      = Updaters
+                                                                                                                                               .newReferenceFieldUpdater(
+                                                                                                                                                   ServerCallImpl.class,
+                                                                                                                                                   "stream");
 
     private static final ReferenceFieldUpdater<ForwardingServerCall.SimpleForwardingServerCall<?, ?>, ServerCall<?, ?>> SERVER_CALL_GETTER = Updaters
-                                                                                                                                                .newReferenceFieldUpdater(
-                                                                                                                                                    ForwardingServerCall.SimpleForwardingServerCall.class,
-                                                                                                                                                        "delegate");
+                                                                                                                                               .newReferenceFieldUpdater(
+                                                                                                                                                   ForwardingServerCall.SimpleForwardingServerCall.class,
+                                                                                                                                                   "delegate");
 
     public static ServerStream getServerStream(final ServerCall<?, ?> call) {
         ServerCall<?, ?> lastServerCall = call;

--- a/jraft-extension/rpc-grpc-impl/src/main/java/io/grpc/internal/ServerStreamHelper.java
+++ b/jraft-extension/rpc-grpc-impl/src/main/java/io/grpc/internal/ServerStreamHelper.java
@@ -16,10 +16,10 @@
  */
 package io.grpc.internal;
 
-import io.grpc.ServerCall;
-
 import com.alipay.sofa.jraft.util.internal.ReferenceFieldUpdater;
 import com.alipay.sofa.jraft.util.internal.Updaters;
+import io.grpc.ForwardingServerCall;
+import io.grpc.ServerCall;
 
 /**
  * Get grpc's server stream.
@@ -33,9 +33,18 @@ public class ServerStreamHelper {
                                                                                                          ServerCallImpl.class,
                                                                                                          "stream");
 
+    private static final ReferenceFieldUpdater<ForwardingServerCall.SimpleForwardingServerCall<?, ?>, ServerCall<?, ?>> SERVER_CALL_GETTER = Updaters
+                                                                                                                                                .newReferenceFieldUpdater(
+                                                                                                                                                    ForwardingServerCall.SimpleForwardingServerCall.class,
+                                                                                                                                                        "delegate");
+
     public static ServerStream getServerStream(final ServerCall<?, ?> call) {
-        if (call instanceof ServerCallImpl) {
-            return STREAM_GETTER.get((ServerCallImpl<?, ?>) call);
+        ServerCall<?, ?> lastServerCall = call;
+        if (call instanceof ForwardingServerCall.SimpleForwardingServerCall) {
+            lastServerCall = SERVER_CALL_GETTER.get((ForwardingServerCall.SimpleForwardingServerCall<?, ?>) call);
+        }
+        if (lastServerCall instanceof ServerCallImpl) {
+            return STREAM_GETTER.get((ServerCallImpl<?, ?>) lastServerCall);
         }
         return null;
     }


### PR DESCRIPTION

### Motivation:

ServerCall is usually enhanced to ForwardingServerCall.SimpleForwardingServerCall by skywalking-agent or opentelemetry-javaagent,etc.At this point, ServerCallImpl will become the delegate of SimpleForwardingServerCall

### Modification:

Add judgement for SimpleForwardingServerCall in method ServerStreamHelper.getServerStream

### Result:

resolve [issue](https://github.com/sofastack/sofa-jraft/issues/1043)
associate [issue](https://github.com/alibaba/nacos/issues/11422) from nacos