### PR TITLE
修复loader.getResources无法读取资源的问题

### DIFF
--- a/jraft-core/src/main/java/com/alipay/sofa/jraft/util/JRaftServiceLoader.java
+++ b/jraft-core/src/main/java/com/alipay/sofa/jraft/util/JRaftServiceLoader.java
@@ -58,7 +58,7 @@ public final class JRaftServiceLoader<S> implements Iterable<S> {
     private LazyIterator             lookupIterator;
 
     public static <S> JRaftServiceLoader<S> load(final Class<S> service) {
-        return JRaftServiceLoader.load(service, Thread.currentThread().getContextClassLoader());
+        return JRaftServiceLoader.load(service, JRaftServiceLoader.class.getClassLoader());
     }
 
     public static <S> JRaftServiceLoader<S> load(final Class<S> service, final ClassLoader loader) {


### PR DESCRIPTION
### Motivation:
解决jraft-core无法读取resources文件的问题

### Modification:

修改 `Thread.currentThread().getContextClassLoader()` 为 `JRaftServiceLoader.class.getClassLoader()`

### Result:

Fixes #1065.

