### PR TITLE
fix: async snapshot lost file

### DIFF
--- a/jraft-core/src/main/java/com/alipay/sofa/jraft/storage/snapshot/local/LocalSnapshotMetaTable.java
+++ b/jraft-core/src/main/java/com/alipay/sofa/jraft/storage/snapshot/local/LocalSnapshotMetaTable.java
@@ -18,9 +18,9 @@ package com.alipay.sofa.jraft.storage.snapshot.local;
 
 import java.io.IOException;
 import java.nio.ByteBuffer;
-import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -51,7 +51,7 @@ public class LocalSnapshotMetaTable {
 
     public LocalSnapshotMetaTable(RaftOptions raftOptions) {
         super();
-        this.fileMap = new HashMap<>();
+        this.fileMap = new ConcurrentHashMap<>();
         this.raftOptions = raftOptions;
     }
 


### PR DESCRIPTION
### Motivation:

异步保存snapshot可以提升系统性能。在异步保存snapshot时会存在 多线程并发保存不同的状态机信息到不同文件 的情况，此时com.alipay.sofa.jraft.storage.snapshot.SnapshotWriter#addFile(java.lang.String) 也是并发操作，但对于file信息的存储 com.alipay.sofa.jraft.storage.snapshot.local.LocalSnapshotMetaTable#fileMap 类型是HashMap，它是非线程安全的，在并发调用addFile会出现信息丢失的情况，目前我是靠并发调用addFile前加锁解决的。

### Modification:

com.alipay.sofa.jraft.storage.snapshot.local.LocalSnapshotMetaTable#fileMap 的类型改为线程安全的 ConcurrentHashMap

### Result:




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Improved thread safety in snapshot management by utilizing `ConcurrentHashMap`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->