### PR TITLE
feat: 添加节点参与投票异常监听器

### DIFF
--- a/jraft-core/src/main/java/com/alipay/sofa/jraft/Node.java
+++ b/jraft-core/src/main/java/com/alipay/sofa/jraft/Node.java
@@ -345,6 +345,32 @@ public interface Node extends Lifecycle<NodeOptions>, Describer {
     List<Replicator.ReplicatorStateListener> getReplicatorStatueListeners();
 
     /**
+     * SOFAJRaft users can implement the NodeStateListener interface by themselves.
+     * So users can do their own logical operator in this listener when node error, destroyed or had some errors.
+     *
+     * @param nodeStateListener added NodeStateListener which is implemented by users.
+     */
+    void addNodeStateListener(final Node.NodeStateListener nodeStateListener);
+
+    /**
+     * End User can remove their implement the NodeStateListener interface by themselves.
+     *
+     * @param nodeStateListener need to remove the NodeStateListener which has been added by users.
+     */
+    void removeNodeStateListener(final Node.NodeStateListener nodeStateListener);
+
+    /**
+     * Remove all the NodeStateListener which have been added by users.
+     */
+    void clearNodeStateListener();
+
+    /**
+     * Get the NodeStateListener which have been added by users.
+     * @return node's nodeStateListener which have been added by users.
+     */
+    List<Node.NodeStateListener> getNodeStateListeners();
+
+    /**
      * Get the node's target election priority value.
      *
      * @return node's target election priority value.
@@ -380,4 +406,35 @@ public interface Node extends Lifecycle<NodeOptions>, Describer {
      * @since 1.3.12
      */
     long getLastAppliedLogIndex();
+
+    /**
+     * User can implement the NodeStateListener interface by themselves.
+     * So they can do some their own logic codes when node error, destroyed or had some errors.
+     *
+     * @author zxuanhong
+     *
+     * 2024-04-10 09:23
+     */
+    interface NodeStateListener {
+
+        /**
+         * Called when this can't do preVote as it is not in conf
+         *
+         * @param nodeId current node id
+         * @param options current node options
+         */
+        default void peerNotInConf(NodeId nodeId, NodeOptions options) {
+
+        }
+
+        /**
+         * Called when this PreVoteResponse no voting granted.
+         *
+         * @param nodeId current node id
+         * @param options current node options
+         */
+        default void noVotingGranted(NodeId nodeId, NodeOptions options) {
+
+        }
+    }
 }


### PR DESCRIPTION
添加节点投票异常监听器，以便为用户提供处理自动加入集群的时机；

### Motivation:

1. 在新节点加入集群或历史节点被移除后再次启动加入集群时，由于缺少触发参与集群投票异常的时机，使得无法做自动加入集群处理。当前pr在新加入集群(参与者不在配置中)，或投票提示么有权限(节点被移除后再次启动时)；
2. 对于为什么会出现历史节点移除后再次加入集群。目前出现的原因是，一般系统可能会添加一定心跳时间无法响应时做出自动移除节点(一般是节点下线)，后系统再次回复。
### Modification:

1. 在NodeImpl preVote方法配置检查异常时添加peerNotInConf回调方法，处理当前参与者不在配置中(没有加入)；
3. 在NodeImpl handlePreVoteResponse响应提示没有投票权时添加noVotingGranted回调方法，处理当前参与者虽然在本地配置中，但是不在集群配置中，也就是没有投票权(节点被自动移除然后恢复时)。



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added functionality to manage `NodeStateListener` instances, allowing users to subscribe to specific node state changes.
	- Introduced `NodeStateListener` interface for custom handling of node state events.
- **Documentation**
	- Updated comments for enhanced clarity and understanding of the code.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->