### PR TITLE
fix: ThreadId miss unlock(#1107)

### DIFF
--- a/jraft-core/src/main/java/com/alipay/sofa/jraft/util/ThreadId.java
+++ b/jraft-core/src/main/java/com/alipay/sofa/jraft/util/ThreadId.java
@@ -124,10 +124,9 @@ public class ThreadId {
             if (this.onError != null) {
                 this.onError.onError(this, this.data, errorCode);
             }
-
         } finally {
-            // Maybe destroyed in callback
-            if (!this.destroyed) {
+            // It may have been released during onError to avoid throwing an exception.
+            if (this.lock.isHeldByCurrentThread()) {
                 this.lock.unlock();
             }
         }

--- a/jraft-core/src/test/java/com/alipay/sofa/jraft/util/ThreadIdTest.java
+++ b/jraft-core/src/test/java/com/alipay/sofa/jraft/util/ThreadIdTest.java
@@ -59,7 +59,7 @@ public class ThreadIdTest implements ThreadId.OnError {
         Thread.sleep(1000);
         this.id.unlock();
         latch.await();
-        assertEquals(1000, cost.get(), 10);
+        assertEquals(1000, cost.get(), 20);
     }
 
     @Test


### PR DESCRIPTION
### Motivation:

在 ThreadId lock 和 destroy ThreadId 并发情况下，可能导致 ThreadId 锁不释放

### Modification:

取消判断 ThreadId 是否 destroy 来释放锁，而是只要持有就释放。因为在 onError 中可能释放锁，需要判断 `isHeldByCurrentThread()`  是否持有来释放锁

### Result:

Fixes #1107


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved thread safety by ensuring locks are only released if held by the current thread.

- **Tests**
  - Adjusted test case assertion to reflect updated logic for thread handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->