### PR TITLE
Fix/last commit index

### DIFF
--- a/jraft-core/src/main/java/com/alipay/sofa/jraft/core/BallotBox.java
+++ b/jraft-core/src/main/java/com/alipay/sofa/jraft/core/BallotBox.java
@@ -88,6 +88,7 @@ public class BallotBox implements Lifecycle<BallotBoxOptions>, Describer {
         this.opts = opts;
         this.waiter = opts.getWaiter();
         this.closureQueue = opts.getClosureQueue();
+        this.lastCommittedIndex = opts.getLastCommittedIndex();
         return true;
     }
 
@@ -165,11 +166,10 @@ public class BallotBox implements Lifecycle<BallotBoxOptions>, Describer {
      * committed until a log at the new term becomes committed, so
      * |newPendingIndex| should be |last_log_index| + 1.
      * @param newPendingIndex pending index of new leader
-     * @param the group quorum size
      *
      * @return returns true if reset success
      */
-    public boolean resetPendingIndex(final long newPendingIndex, int quorum) {
+    public boolean resetPendingIndex(final long newPendingIndex) {
         final long stamp = this.stampedLock.writeLock();
         try {
             if (!(this.pendingIndex == 0 && this.pendingMetaQueue.isEmpty())) {
@@ -181,11 +181,6 @@ public class BallotBox implements Lifecycle<BallotBoxOptions>, Describer {
                 LOG.error("Node {} resetPendingIndex fail, newPendingIndex={}, lastCommittedIndex={}.",
                     this.opts.getNodeId(), newPendingIndex, this.lastCommittedIndex);
                 return false;
-            }
-
-            if (quorum == 1) {
-                // Fix https://github.com/sofastack/sofa-jraft/issues/1049
-                this.lastCommittedIndex = newPendingIndex - 1;
             }
 
             this.pendingIndex = newPendingIndex;

--- a/jraft-core/src/main/java/com/alipay/sofa/jraft/core/NodeImpl.java
+++ b/jraft-core/src/main/java/com/alipay/sofa/jraft/core/NodeImpl.java
@@ -1255,7 +1255,7 @@ public class NodeImpl implements Node, RaftServerService {
         }
 
         // init commit manager
-        this.ballotBox.resetPendingIndex(this.logManager.getLastLogIndex() + 1);
+        this.ballotBox.resetPendingIndex(this.logManager.getLastLogIndex() + 1, getQuorum());
         // Register _conf_ctx to reject configuration changing before the first log
         // is committed.
         if (this.confCtx.isBusy()) {

--- a/jraft-core/src/main/java/com/alipay/sofa/jraft/core/NodeImpl.java
+++ b/jraft-core/src/main/java/com/alipay/sofa/jraft/core/NodeImpl.java
@@ -1385,6 +1385,18 @@ public class NodeImpl implements Node, RaftServerService {
     }
 
     private void executeApplyingTasks(final List<LogEntryAndClosure> tasks) {
+	if (!this.logManager.hasAvailableCapacityToAppendEntries(1)) {
+		// It's overload, fail-fast
+		final List<Closure> dones = tasks.stream().map(ele -> ele.done).filter(Objects::nonNull)
+				.collect(Collectors.toList());
+		ThreadPoolsFactory.runInThread(this.groupId, () -> {
+			for (final Closure done : dones) {
+				done.run(new Status(RaftError.EBUSY, "Node %s log manager is busy.", this.getNodeId()));
+			}
+		});
+		return;
+	}
+
         this.writeLock.lock();
         try {
             final int size = tasks.size();

--- a/jraft-core/src/main/java/com/alipay/sofa/jraft/option/BallotBoxOptions.java
+++ b/jraft-core/src/main/java/com/alipay/sofa/jraft/option/BallotBoxOptions.java
@@ -32,9 +32,18 @@ public class BallotBoxOptions {
     private FSMCaller    waiter;
     private ClosureQueue closureQueue;
     private NodeId       nodeId;
+    private long         lastCommittedIndex;
 
     public NodeId getNodeId() {
         return nodeId;
+    }
+
+    public long getLastCommittedIndex() {
+        return lastCommittedIndex;
+    }
+
+    public void setLastCommittedIndex(long lastCommittedIndex) {
+        this.lastCommittedIndex = lastCommittedIndex;
     }
 
     public void setNodeId(NodeId nodeId) {

--- a/jraft-core/src/main/java/com/alipay/sofa/jraft/storage/SnapshotExecutor.java
+++ b/jraft-core/src/main/java/com/alipay/sofa/jraft/storage/SnapshotExecutor.java
@@ -49,6 +49,12 @@ public interface SnapshotExecutor extends Lifecycle<SnapshotExecutorOptions>, De
     void doSnapshot(final Closure done);
 
     /**
+     * Returns the last snapshot index.
+     * @return
+     */
+    long getLastSnapshotIndex();
+
+    /**
      * Start to snapshot StateMachine immediately with the latest log applied to state machine.
      * You MUST call this method in {@link StateMachine} callback methods to trigger a snapshot synchronously, otherwise throws {@link IllegalStateException}.
      * And |done| is called after the execution finishes or fails.

--- a/jraft-core/src/main/java/com/alipay/sofa/jraft/storage/snapshot/SnapshotExecutorImpl.java
+++ b/jraft-core/src/main/java/com/alipay/sofa/jraft/storage/snapshot/SnapshotExecutorImpl.java
@@ -112,10 +112,6 @@ public class SnapshotExecutorImpl implements SnapshotExecutor {
         return this.lastSnapshotTerm;
     }
 
-    /**
-     * Only for test
-     */
-    @OnlyForTest
     public long getLastSnapshotIndex() {
         return this.lastSnapshotIndex;
     }

--- a/jraft-core/src/test/java/com/alipay/sofa/jraft/core/BallotBoxTest.java
+++ b/jraft-core/src/test/java/com/alipay/sofa/jraft/core/BallotBoxTest.java
@@ -64,9 +64,20 @@ public class BallotBoxTest {
     public void testResetPendingIndex() {
         assertEquals(0, closureQueue.getFirstIndex());
         assertEquals(0, box.getPendingIndex());
-        assertTrue(box.resetPendingIndex(1));
+        assertTrue(box.resetPendingIndex(1, 2));
+        assertEquals(0, box.getLastCommittedIndex());
         assertEquals(1, closureQueue.getFirstIndex());
         assertEquals(1, box.getPendingIndex());
+    }
+
+    @Test
+    public void testResetPendingIndexWithSingleNode() {
+        assertEquals(0, closureQueue.getFirstIndex());
+        assertEquals(0, box.getPendingIndex());
+        assertTrue(box.resetPendingIndex(10, 1));
+        assertEquals(9, box.getLastCommittedIndex());
+        assertEquals(10, closureQueue.getFirstIndex());
+        assertEquals(10, box.getPendingIndex());
     }
 
     @Test
@@ -82,7 +93,7 @@ public class BallotBoxTest {
 
                 }
             }));
-        assertTrue(box.resetPendingIndex(1));
+        assertTrue(box.resetPendingIndex(1, 2));
         assertTrue(this.box.appendPendingTask(
             JRaftUtils.getConfiguration("localhost:8081,localhost:8082,localhost:8083"),
             JRaftUtils.getConfiguration("localhost:8081"), new Closure() {
@@ -109,7 +120,7 @@ public class BallotBoxTest {
     @Test
     public void testCommitAt() {
         assertFalse(this.box.commitAt(1, 3, new PeerId("localhost", 8081)));
-        assertTrue(box.resetPendingIndex(1));
+        assertTrue(box.resetPendingIndex(1, 2));
         assertTrue(this.box.appendPendingTask(
             JRaftUtils.getConfiguration("localhost:8081,localhost:8082,localhost:8083"),
             JRaftUtils.getConfiguration("localhost:8081"), new Closure() {
@@ -137,7 +148,7 @@ public class BallotBoxTest {
 
     @Test(expected = IllegalArgumentException.class)
     public void testSetLastCommittedIndexHasPending() {
-        assertTrue(box.resetPendingIndex(1));
+        assertTrue(box.resetPendingIndex(1, 2));
         assertFalse(this.box.setLastCommittedIndex(1));
     }
 

--- a/jraft-core/src/test/java/com/alipay/sofa/jraft/core/BallotBoxTest.java
+++ b/jraft-core/src/test/java/com/alipay/sofa/jraft/core/BallotBoxTest.java
@@ -51,6 +51,7 @@ public class BallotBoxTest {
         this.closureQueue = new ClosureQueueImpl(GROUP_ID);
         opts.setClosureQueue(this.closureQueue);
         opts.setWaiter(this.waiter);
+        opts.setLastCommittedIndex(0);
         box = new BallotBox();
         assertTrue(box.init(opts));
     }
@@ -61,23 +62,26 @@ public class BallotBoxTest {
     }
 
     @Test
-    public void testResetPendingIndex() {
-        assertEquals(0, closureQueue.getFirstIndex());
-        assertEquals(0, box.getPendingIndex());
-        assertTrue(box.resetPendingIndex(1, 2));
-        assertEquals(0, box.getLastCommittedIndex());
-        assertEquals(1, closureQueue.getFirstIndex());
-        assertEquals(1, box.getPendingIndex());
+    public void initWithLastCommittedIndex() {
+        BallotBoxOptions opts = new BallotBoxOptions();
+        this.closureQueue = new ClosureQueueImpl(GROUP_ID);
+        opts.setClosureQueue(this.closureQueue);
+        opts.setWaiter(this.waiter);
+        opts.setLastCommittedIndex(9);
+        box = new BallotBox();
+        assertTrue(box.init(opts));
+
+        assertEquals(box.getLastCommittedIndex(), 9);
     }
 
     @Test
-    public void testResetPendingIndexWithSingleNode() {
+    public void testResetPendingIndex() {
         assertEquals(0, closureQueue.getFirstIndex());
         assertEquals(0, box.getPendingIndex());
-        assertTrue(box.resetPendingIndex(10, 1));
-        assertEquals(9, box.getLastCommittedIndex());
-        assertEquals(10, closureQueue.getFirstIndex());
-        assertEquals(10, box.getPendingIndex());
+        assertTrue(box.resetPendingIndex(1));
+        assertEquals(0, box.getLastCommittedIndex());
+        assertEquals(1, closureQueue.getFirstIndex());
+        assertEquals(1, box.getPendingIndex());
     }
 
     @Test
@@ -93,7 +97,7 @@ public class BallotBoxTest {
 
                 }
             }));
-        assertTrue(box.resetPendingIndex(1, 2));
+        assertTrue(box.resetPendingIndex(1));
         assertTrue(this.box.appendPendingTask(
             JRaftUtils.getConfiguration("localhost:8081,localhost:8082,localhost:8083"),
             JRaftUtils.getConfiguration("localhost:8081"), new Closure() {
@@ -120,7 +124,7 @@ public class BallotBoxTest {
     @Test
     public void testCommitAt() {
         assertFalse(this.box.commitAt(1, 3, new PeerId("localhost", 8081)));
-        assertTrue(box.resetPendingIndex(1, 2));
+        assertTrue(box.resetPendingIndex(1));
         assertTrue(this.box.appendPendingTask(
             JRaftUtils.getConfiguration("localhost:8081,localhost:8082,localhost:8083"),
             JRaftUtils.getConfiguration("localhost:8081"), new Closure() {
@@ -148,7 +152,7 @@ public class BallotBoxTest {
 
     @Test(expected = IllegalArgumentException.class)
     public void testSetLastCommittedIndexHasPending() {
-        assertTrue(box.resetPendingIndex(1, 2));
+        assertTrue(box.resetPendingIndex(1));
         assertFalse(this.box.setLastCommittedIndex(1));
     }
 

--- a/jraft-extension/java-log-storage-impl/src/main/java/com/alipay/sofa/jraft/storage/HybridLogStorage.java
+++ b/jraft-extension/java-log-storage-impl/src/main/java/com/alipay/sofa/jraft/storage/HybridLogStorage.java
@@ -16,10 +16,12 @@
  */
 package com.alipay.sofa.jraft.storage;
 
+import java.io.File;
 import java.io.IOException;
 import java.nio.file.Paths;
 import java.util.List;
 
+import org.apache.commons.io.FileUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -48,6 +50,11 @@ public class HybridLogStorage implements LogStorage {
     private long                                thresholdIndex;
 
     public HybridLogStorage(final String path, final StoreOptions storeOptions, final LogStorage oldStorage) {
+        try {
+            FileUtils.forceMkdir(new File(path));
+        } catch (IOException e) {
+            // ignore
+        }
         final String newLogStoragePath = Paths.get(path, storeOptions.getStoragePath()).toString();
         this.newLogStorage = new LogitLogStorage(newLogStoragePath, storeOptions);
         this.oldLogStorage = oldStorage;

--- a/jraft-extension/java-log-storage-impl/src/test/java/com/alipay/sofa/jraft/core/NodeTest.java
+++ b/jraft-extension/java-log-storage-impl/src/test/java/com/alipay/sofa/jraft/core/NodeTest.java
@@ -3407,13 +3407,13 @@ public class NodeTest {
         for (final ChangeArg arg : args) {
             arg.stop = true;
         }
-        for (final Future<?> future : futures) {
-        	try {
-            future.get(20, TimeUnit.SECONDS);
-        	}catch(TimeoutException e) {
-        		// ignore
-        	}
-        }
+	for (final Future<?> future : futures) {
+		try {
+			future.get(20, TimeUnit.SECONDS);
+		} catch (TimeoutException e) {
+			// ignore
+		}
+	}
 
         cluster.waitLeader();
         final SynchronizedClosure done = new SynchronizedClosure();


### PR DESCRIPTION
### Motivation & Modification:

Main changes:

* Fixed #1049 
* Try to initialize the `lastCommittedIndex` in `BallotBox` to a proper value when restart #1092 
* Fail fast when log manager is overloaded while applying tasks #649 


### Result:

#1049 , #1092 , #649 
