### PR TITLE
chore: remove redundant code

### DIFF
--- a/jraft-core/src/test/java/com/alipay/sofa/jraft/core/BallotBoxTest.java
+++ b/jraft-core/src/test/java/com/alipay/sofa/jraft/core/BallotBoxTest.java
@@ -64,7 +64,6 @@ public class BallotBoxTest {
     @Test
     public void initWithLastCommittedIndex() {
         BallotBoxOptions opts = new BallotBoxOptions();
-        this.closureQueue = new ClosureQueueImpl(GROUP_ID);
         opts.setClosureQueue(this.closureQueue);
         opts.setWaiter(this.waiter);
         opts.setLastCommittedIndex(9);


### PR DESCRIPTION
### Motivation:

```
    @Before
    public void setup() {
        BallotBoxOptions opts = new BallotBoxOptions();
        this.closureQueue = new ClosureQueueImpl(GROUP_ID);
        opts.setClosureQueue(this.closureQueue);
        opts.setWaiter(this.waiter);
        opts.setLastCommittedIndex(0);
        box = new BallotBox();
        assertTrue(box.init(opts));
    }
```
The code in before is repeated
### Modification:

Describe the idea and modifications you've done.

### Result:

Fixes #<GitHub issue number>.

If there is no issue then describe the changes introduced by this PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Updated the `initWithLastCommittedIndex()` test method in `BallotBoxTest` to no longer initialize `closureQueue` with `ClosureQueueImpl(GROUP_ID)`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->