### PR TITLE
feat: adds close state checking for snapshot reader and writer

### DIFF
--- a/jraft-core/src/main/java/com/alipay/sofa/jraft/storage/snapshot/SnapshotReader.java
+++ b/jraft-core/src/main/java/com/alipay/sofa/jraft/storage/snapshot/SnapshotReader.java
@@ -22,7 +22,7 @@ import com.alipay.sofa.jraft.Lifecycle;
 import com.alipay.sofa.jraft.entity.RaftOutter.SnapshotMeta;
 
 /**
- * Snapshot reader.
+ * Snapshot reader.<strong>Note: it's not thread-safe.</strong>
  *
  * @author boyan (boyan@alibaba-inc.com)
  *

--- a/jraft-core/src/main/java/com/alipay/sofa/jraft/storage/snapshot/SnapshotWriter.java
+++ b/jraft-core/src/main/java/com/alipay/sofa/jraft/storage/snapshot/SnapshotWriter.java
@@ -24,7 +24,7 @@ import com.alipay.sofa.jraft.entity.RaftOutter.SnapshotMeta;
 import com.google.protobuf.Message;
 
 /**
- * Snapshot writer.
+ * Snapshot writer. <strong>Note: it's not thread-safe.</strong>
  *
  * @author boyan (boyan@alibaba-inc.com)
  *

--- a/jraft-core/src/main/java/com/alipay/sofa/jraft/storage/snapshot/local/SnapshotFileReader.java
+++ b/jraft-core/src/main/java/com/alipay/sofa/jraft/storage/snapshot/local/SnapshotFileReader.java
@@ -30,7 +30,7 @@ import com.alipay.sofa.jraft.util.BufferUtils;
 import com.alipay.sofa.jraft.util.ByteBufferCollector;
 
 /**
- * Snapshot file reader
+ * Snapshot file reader. <strong>Note: it's not thread-safe.</strong>
  *
  * @author boyan (boyan@alibaba-inc.com)
  *


### PR DESCRIPTION
### Motivation:

* Adds note about thread safety for `SnapshotReader` and `SnapshopWriter`
* Adds `close` state checking for `SnapshotReader` and `SnapshopWriter`

### Modification:

Describe the idea and modifications you've done.

### Result:

After this PR, i think we can close #1099 

If there is no issue then describe the changes introduced by this PR.
