### PR TITLE
Remove StringUtils.isEmpty(s) and improve comments

### DIFF
--- a/jraft-core/src/main/java/com/alipay/sofa/jraft/core/State.java
+++ b/jraft-core/src/main/java/com/alipay/sofa/jraft/core/State.java
@@ -23,15 +23,32 @@ package com.alipay.sofa.jraft.core;
  * 2018-Apr-08 5:41:54 PM
  */
 public enum State {
-    STATE_LEADER, // It's a leader
-    STATE_TRANSFERRING, // It's transferring leadership
-    STATE_CANDIDATE, //  It's a candidate
-    STATE_FOLLOWER, // It's a follower
-    STATE_ERROR, // It's in error
-    STATE_UNINITIALIZED, // It's uninitialized
-    STATE_SHUTTING, // It's shutting down
-    STATE_SHUTDOWN, // It's shutdown already
-    STATE_END; // State end
+    /** The node is a leader */
+    STATE_LEADER,
+
+    /** The node is transferring leadership */
+    STATE_TRANSFERRING,
+
+    /** The node is a candidate */
+    STATE_CANDIDATE,
+
+    /** The node is a follower */
+    STATE_FOLLOWER,
+
+    /** The node is in error */
+    STATE_ERROR,
+
+    /** The node is uninitialized */
+    STATE_UNINITIALIZED,
+
+    /** The node is shutting down */
+    STATE_SHUTTING,
+
+    /** The node is shut down */
+    STATE_SHUTDOWN,
+
+    /** The node is ending */
+    STATE_END;
 
     public boolean isActive() {
         return this.ordinal() < STATE_ERROR.ordinal();

--- a/jraft-core/src/main/java/com/alipay/sofa/jraft/entity/PeerId.java
+++ b/jraft-core/src/main/java/com/alipay/sofa/jraft/entity/PeerId.java
@@ -192,7 +192,7 @@ public class PeerId implements Copiable<PeerId>, Serializable, Checksum {
      *
      */
     public boolean parse(final String s) {
-        if (StringUtils.isEmpty(s) || StringUtils.isBlank(s)) {
+        if (StringUtils.isBlank(s)) {
             return false;
         }
 


### PR DESCRIPTION
### Motivation:

StringUtils.isBlank(s) can detect null, empty, and space strings, without retaining StringUtils.isEmpty(s)

### Result:

Fixes #<GitHub issue number>.

If there is no issue then describe the changes introduced by this PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Updated comments for `State` enum to clarify the roles of nodes in different states.

- **Refactor**
  - Simplified string validation in `PeerId` class by removing redundant `StringUtils.isEmpty` check.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->