### PR TITLE
feat: remove redundant address check

### DIFF
--- a/jraft-core/src/main/java/com/alipay/sofa/jraft/NodeManager.java
+++ b/jraft-core/src/main/java/com/alipay/sofa/jraft/NodeManager.java
@@ -78,10 +78,6 @@ public class NodeManager {
      * Adds a node.
      */
     public boolean add(final Node node) {
-        // check address ok?
-        if (!serverExists(node.getNodeId().getPeerId().getEndpoint())) {
-            return false;
-        }
         final NodeId nodeId = node.getNodeId();
         if (this.nodeMap.putIfAbsent(nodeId, node) == null) {
             final String groupId = node.getGroupId();


### PR DESCRIPTION
### Motivation:

The first step of nodeImpl is to check address. I don't understand why it is necessary to check address later.
```
        if (!NodeManager.getInstance().serverExists(this.serverId.getEndpoint())) {
            LOG.error("No RPC server attached to, did you forget to call addService?");
            return false;
        }

```

### Modification:

Describe the idea and modifications you've done.

### Result:

Fixes #<GitHub issue number>.

If there is no issue then describe the changes introduced by this PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Simplified node management by removing redundant conditional checks and address validation in the NodeManager.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->