### PR TITLE
 chore: fix typo, adjust the test code order and method of obtaining term id

### DIFF
--- a/jraft-core/src/test/java/com/alipay/sofa/jraft/storage/impl/BaseLogStorageTest.java
+++ b/jraft-core/src/test/java/com/alipay/sofa/jraft/storage/impl/BaseLogStorageTest.java
@@ -187,7 +187,7 @@ public abstract class BaseLogStorageTest extends BaseStorageTest {
     }
 
     @Test
-    public void testAppendMantyLargeEntries() {
+    public void testAppendManyLargeEntries() {
         final long start = Utils.monotonicMs();
         final int totalLogs = 100000;
         final int logSize = 16 * 1024;

--- a/jraft-core/src/test/java/com/alipay/sofa/jraft/storage/impl/BaseLogStorageTest.java
+++ b/jraft-core/src/test/java/com/alipay/sofa/jraft/storage/impl/BaseLogStorageTest.java
@@ -149,10 +149,10 @@ public abstract class BaseLogStorageTest extends BaseStorageTest {
         assertEquals(0, this.logStorage.getFirstLogIndex());
         assertEquals(9, this.logStorage.getLastLogIndex());
         for (int i = 0; i < 10; i++) {
-            assertEquals(i, this.logStorage.getTerm(i));
-            final LogEntry entry = this.logStorage.getEntry(i);
-            assertNotNull(entry);
-            assertEquals(entries.get(i), entry);
+            final LogEntry logEntry = this.logStorage.getEntry(i);
+            assertNotNull(logEntry);
+            assertEquals(entries.get(i), logEntry);
+            assertEquals(i, logEntry.getId().getTerm());
         }
     }
 


### PR DESCRIPTION
### Motivation:

 1.fix typo
 2.adjust the test code order and method of obtaining term id

### Modification:

1. rename testAppendMantyLargeEntries to testAppendManyLargeEntries
2. adjust test case testAddManyEntries
 
### Result:

Fixes #<GitHub issue number>.

If there is no issue then describe the changes introduced by this PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
	- Renamed variables and updated method name for improved clarity in `BaseLogStorageTest` tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->