### PR TITLE
NPE in NodeImpl

### DIFF
--- a/jraft-core/src/main/java/com/alipay/sofa/jraft/storage/impl/LogManagerImpl.java
+++ b/jraft-core/src/main/java/com/alipay/sofa/jraft/storage/impl/LogManagerImpl.java
@@ -894,6 +894,19 @@ public class LogManagerImpl implements LogManager {
             Thread.currentThread().interrupt();
             throw new IllegalStateException(e);
         }
+        if (c.lastLogId == null) {
+            assert stopped;
+
+            try {
+                shutDownLatch.await();
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+
+                throw new IllegalStateException(e);
+            }
+
+            return new LogId(this.lastLogIndex, unsafeGetTerm(this.lastLogIndex));
+        }
         return c.lastLogId;
     }
 

--- a/jraft-core/src/main/java/com/alipay/sofa/jraft/storage/impl/LogManagerImpl.java
+++ b/jraft-core/src/main/java/com/alipay/sofa/jraft/storage/impl/LogManagerImpl.java
@@ -846,6 +846,11 @@ public class LogManagerImpl implements LogManager {
             Thread.currentThread().interrupt();
             throw new IllegalStateException(e);
         }
+        if (c.lastLogId == null) {
+            assert stopped : "Last log id can be null only when node is stopping.";
+
+            throw new IllegalStateException("Node is shutting down");
+        }
         return c.lastLogId.getIndex();
     }
 
@@ -895,17 +900,9 @@ public class LogManagerImpl implements LogManager {
             throw new IllegalStateException(e);
         }
         if (c.lastLogId == null) {
-            assert stopped;
+            assert stopped : "Last log id can be null only when node is stopping.";
 
-            try {
-                shutDownLatch.await();
-            } catch (InterruptedException e) {
-                Thread.currentThread().interrupt();
-
-                throw new IllegalStateException(e);
-            }
-
-            return new LogId(this.lastLogIndex, unsafeGetTerm(this.lastLogIndex));
+            throw new IllegalStateException("Node is shutting down");
         }
         return c.lastLogId;
     }

--- a/jraft-core/src/test/java/com/alipay/sofa/jraft/storage/impl/LogManagerTest.java
+++ b/jraft-core/src/test/java/com/alipay/sofa/jraft/storage/impl/LogManagerTest.java
@@ -51,6 +51,7 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotSame;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 
 @RunWith(value = MockitoJUnitRunner.class)
@@ -416,4 +417,23 @@ public class LogManagerTest extends BaseStorageTest {
         assertEquals("localhost:8081,localhost:8082", lastEntry.getOldConf().toString());
     }
 
+    @Test
+    public void testLastLogIdWhenShutdown() throws Exception {
+        mockAddEntries();
+        assertEquals(1, this.logManager.getFirstLogIndex());
+        assertEquals(10, this.logManager.getLastLogIndex());
+        this.logManager.shutdown();
+        Exception e = assertThrows(IllegalStateException.class, () -> this.logManager.getLastLogId(true));
+        assertEquals("Node is shutting down", e.getMessage());
+    }
+
+    @Test
+    public void testLastLogIndexWhenShutdown() throws Exception {
+        mockAddEntries();
+        assertEquals(1, this.logManager.getFirstLogIndex());
+        assertEquals(10, this.logManager.getLastLogIndex());
+        this.logManager.shutdown();
+        Exception e = assertThrows(IllegalStateException.class, () -> this.logManager.getLastLogIndex(true));
+        assertEquals("Node is shutting down", e.getMessage());
+    }
 }


### PR DESCRIPTION
### Motivation:

We want to make sure that `com.alipay.sofa.jraft.storage.impl.LogManagerImpl#getLastLogId` won't return `null`, that can lead to NPEs when a Node is stopping

https://github.com/sofastack/sofa-jraft/issues/1152

### Modification:

Describe the idea and modifications you've done.

### Result:

Fixes https://github.com/sofastack/sofa-jraft/issues/1152.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced error handling for retrieving the last log ID and index during node shutdown, ensuring graceful failure with appropriate error messages.

- **Tests**
	- Added tests to verify that accessing log information during shutdown throws the correct exceptions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->