### PR TITLE
(fix) Remove unused import in ReadOnlyOption

### DIFF
--- a/jraft-core/src/main/java/com/alipay/sofa/jraft/option/ReadOnlyOption.java
+++ b/jraft-core/src/main/java/com/alipay/sofa/jraft/option/ReadOnlyOption.java
@@ -16,8 +16,6 @@
  */
 package com.alipay.sofa.jraft.option;
 
-import org.apache.commons.lang.StringUtils;
-
 import com.alipay.sofa.jraft.entity.EnumOutter;
 
 /**


### PR DESCRIPTION
This PR removes an unused import statement `org.apache.commons.lang.StringUtils` in the `ReadOnlyOption` class.

- The import statement is not used anywhere in the class and can be safely removed.
- Verified with `mvn clean compile` and all tests passed.

Fixes #1169

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Cleaned up unused import statement in the codebase

<!-- end of auto-generated comment: release notes by coderabbit.ai -->