### PR TITLE
(fix) Cleanup unused imports across the project

### DIFF
--- a/jraft-core/src/main/java/com/alipay/sofa/jraft/core/ReadOnlyServiceImpl.java
+++ b/jraft-core/src/main/java/com/alipay/sofa/jraft/core/ReadOnlyServiceImpl.java
@@ -29,7 +29,6 @@ import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
 import java.util.stream.Collectors;
 
-import com.alipay.sofa.jraft.entity.EnumOutter;
 import com.alipay.sofa.jraft.option.ReadOnlyOption;
 import com.alipay.sofa.jraft.util.ThreadPoolsFactory;
 import org.slf4j.Logger;

--- a/jraft-core/src/main/java/com/alipay/sofa/jraft/rpc/impl/AbstractClientService.java
+++ b/jraft-core/src/main/java/com/alipay/sofa/jraft/rpc/impl/AbstractClientService.java
@@ -45,7 +45,6 @@ import com.alipay.sofa.jraft.util.NamedThreadFactory;
 import com.alipay.sofa.jraft.util.RpcFactoryHelper;
 import com.alipay.sofa.jraft.util.ThreadPoolMetricSet;
 import com.alipay.sofa.jraft.util.ThreadPoolUtil;
-import com.alipay.sofa.jraft.util.Utils;
 import com.google.protobuf.Descriptors;
 import com.google.protobuf.Message;
 

--- a/jraft-core/src/main/java/com/alipay/sofa/jraft/rpc/impl/BoltRpcServer.java
+++ b/jraft-core/src/main/java/com/alipay/sofa/jraft/rpc/impl/BoltRpcServer.java
@@ -22,7 +22,6 @@ import com.alipay.remoting.AsyncContext;
 import com.alipay.remoting.BizContext;
 import com.alipay.remoting.ConnectionEventType;
 import com.alipay.remoting.config.BoltClientOption;
-import com.alipay.remoting.config.switches.GlobalSwitch;
 import com.alipay.remoting.rpc.protocol.AsyncUserProcessor;
 import com.alipay.sofa.jraft.rpc.Connection;
 import com.alipay.sofa.jraft.rpc.RpcContext;

--- a/jraft-core/src/test/java/com/alipay/sofa/jraft/closure/ClosureQueueTest.java
+++ b/jraft-core/src/test/java/com/alipay/sofa/jraft/closure/ClosureQueueTest.java
@@ -20,8 +20,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.CountDownLatch;
 
-import com.alipay.sofa.jraft.util.ThreadPoolsFactory;
-import com.codahale.metrics.MetricRegistry;
 import org.junit.Before;
 import org.junit.Test;
 

--- a/jraft-core/src/test/java/com/alipay/sofa/jraft/core/IteratorTest.java
+++ b/jraft-core/src/test/java/com/alipay/sofa/jraft/core/IteratorTest.java
@@ -21,7 +21,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicLong;
 
-import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;

--- a/jraft-core/src/test/java/com/alipay/sofa/jraft/util/ThreadPoolsFactoryTest.java
+++ b/jraft-core/src/test/java/com/alipay/sofa/jraft/util/ThreadPoolsFactoryTest.java
@@ -21,7 +21,6 @@ import java.util.concurrent.SynchronousQueue;
 import java.util.concurrent.ThreadPoolExecutor;
 
 import org.junit.Assert;
-import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.runners.MockitoJUnitRunner;

--- a/jraft-core/src/test/java/com/alipay/sofa/jraft/util/UtilsTest.java
+++ b/jraft-core/src/test/java/com/alipay/sofa/jraft/util/UtilsTest.java
@@ -16,20 +16,13 @@
  */
 package com.alipay.sofa.jraft.util;
 
-import java.nio.ByteBuffer;
-import java.util.concurrent.CountDownLatch;
-
 import org.junit.Assert;
 import org.junit.Test;
 
-import com.alipay.sofa.jraft.Closure;
-import com.alipay.sofa.jraft.Status;
-import com.alipay.sofa.jraft.error.RaftError;
+import java.nio.ByteBuffer;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertTrue;
 
 /**
  * 

--- a/jraft-test/src/main/java/com/alipay/sofa/jraft/test/atomic/server/AtomicStateMachine.java
+++ b/jraft-test/src/main/java/com/alipay/sofa/jraft/test/atomic/server/AtomicStateMachine.java
@@ -47,7 +47,6 @@ import com.alipay.sofa.jraft.test.atomic.command.GetCommand;
 import com.alipay.sofa.jraft.test.atomic.command.IncrementAndGetCommand;
 import com.alipay.sofa.jraft.test.atomic.command.SetCommand;
 import com.alipay.sofa.jraft.test.atomic.command.ValueCommand;
-import com.alipay.sofa.jraft.util.Utils;
 
 /**
  * Atomic state machine


### PR DESCRIPTION
### Problem
This PR removes unused import statements across the SOFA-JRaft codebase. These unused imports were identified using IntelliJ IDEA's "Inspect Code" tool. Removing these imports helps improve code readability and maintainability without affecting functionality.

### Changes
The following files were updated to remove unused imports:

1. **AbstractClientService.java**
   - Line 48: `import com.alipay.sofa.jraft.util.Utils;`

2. **AtomicStateMachine.java**
   - Line 50: `import com.alipay.sofa.jraft.util.Utils;`

3. **BoltRpcServer.java**
   - Line 25: `import com.alipay.remoting.config.switches.GlobalSwitch;`

4. **ClosureQueueTest.java**
   - Line 23: `import com.alipay.sofa.jraft.util.ThreadPoolsFactory;`
   - Line 24: `import com.codahale.metrics.MetricRegistry;`

5. **IteratorTest.java**
   - Line 24: `import org.junit.After;`

6. **ReadOnlyServiceImpl.java**
   - Line 32: `import com.alipay.sofa.jraft.entity.EnumOutter;`

7. **ThreadPoolsFactoryTest.java**
   - Line 24: `import org.junit.Before;`

8. **UtilsTest.java**
   - Line 20: `import java.util.concurrent.CountDownLatch;`
   - Line 25: `import com.alipay.sofa.jraft.Closure;`
   - Line 26: `import com.alipay.sofa.jraft.Status;`
   - Line 27: `import com.alipay.sofa.jraft.error.RaftError;`
   - Line 30: `import static org.junit.Assert.assertFalse;`
   - Line 32: `import static org.junit.Assert.assertTrue;`

### Verification
- Verified locally by running `mvn clean compile` and `mvn clean test`.
- Confirmed no build or test failures after the changes.

### Related Issue
Fixes #1173 