### PR TITLE
Support tests in apple silicon and fix NPE in BaseLogStorageTest

### DIFF
--- a/jraft-core/pom.xml
+++ b/jraft-core/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>jraft-parent</artifactId>
         <groupId>com.alipay.sofa</groupId>
-        <version>1.3.15.bugfix</version>
+        <version>1.3.16</version>
     </parent>
     <artifactId>jraft-core</artifactId>
     <packaging>jar</packaging>

--- a/jraft-example/pom.xml
+++ b/jraft-example/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>jraft-parent</artifactId>
         <groupId>com.alipay.sofa</groupId>
-        <version>1.3.15.bugfix</version>
+        <version>1.3.16</version>
     </parent>
     <artifactId>jraft-example</artifactId>
     <packaging>jar</packaging>

--- a/jraft-extension/bdb-log-storage-impl/pom.xml
+++ b/jraft-extension/bdb-log-storage-impl/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>jraft-extension</artifactId>
         <groupId>com.alipay.sofa</groupId>
-        <version>1.3.15.bugfix</version>
+        <version>1.3.16</version>
     </parent>
     <artifactId>bdb-log-storage-impl</artifactId>
     <name>bdb-log-storage-impl ${project.version}</name>

--- a/jraft-extension/bdb-log-storage-impl/src/test/java/com/alipay/sofa/jraft/storage/impl/BaseLogStorageTest.java
+++ b/jraft-extension/bdb-log-storage-impl/src/test/java/com/alipay/sofa/jraft/storage/impl/BaseLogStorageTest.java
@@ -69,6 +69,7 @@ public abstract class BaseLogStorageTest extends BaseStorageTest {
         final LogStorageOptions opts = new LogStorageOptions();
         opts.setConfigurationManager(this.confManager);
         opts.setLogEntryCodecFactory(this.logEntryCodecFactory);
+        opts.setGroupId("test");
         return opts;
     }
 

--- a/jraft-extension/java-log-storage-impl/pom.xml
+++ b/jraft-extension/java-log-storage-impl/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>jraft-extension</artifactId>
         <groupId>com.alipay.sofa</groupId>
-        <version>1.3.15.bugfix</version>
+        <version>1.3.16</version>
     </parent>
 
     <artifactId>java-log-storage-impl</artifactId>

--- a/jraft-extension/pom.xml
+++ b/jraft-extension/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>jraft-parent</artifactId>
         <groupId>com.alipay.sofa</groupId>
-        <version>1.3.15.bugfix</version>
+        <version>1.3.16</version>
     </parent>
 
     <artifactId>jraft-extension</artifactId>

--- a/jraft-extension/rpc-grpc-impl/pom.xml
+++ b/jraft-extension/rpc-grpc-impl/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>jraft-extension</artifactId>
         <groupId>com.alipay.sofa</groupId>
-        <version>1.3.15.bugfix</version>
+        <version>1.3.16</version>
     </parent>
 
     <artifactId>rpc-grpc-impl</artifactId>

--- a/jraft-rheakv/pom.xml
+++ b/jraft-rheakv/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>jraft-parent</artifactId>
         <groupId>com.alipay.sofa</groupId>
-        <version>1.3.15.bugfix</version>
+        <version>1.3.16</version>
     </parent>
 
     <artifactId>jraft-rheakv</artifactId>

--- a/jraft-rheakv/rheakv-core/pom.xml
+++ b/jraft-rheakv/rheakv-core/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>jraft-rheakv</artifactId>
         <groupId>com.alipay.sofa</groupId>
-        <version>1.3.15.bugfix</version>
+        <version>1.3.16</version>
     </parent>
 
     <artifactId>jraft-rheakv-core</artifactId>

--- a/jraft-rheakv/rheakv-pd/pom.xml
+++ b/jraft-rheakv/rheakv-pd/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>jraft-rheakv</artifactId>
         <groupId>com.alipay.sofa</groupId>
-        <version>1.3.15.bugfix</version>
+        <version>1.3.16</version>
     </parent>
 
     <artifactId>jraft-rheakv-pd</artifactId>

--- a/jraft-test/pom.xml
+++ b/jraft-test/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>jraft-parent</artifactId>
         <groupId>com.alipay.sofa</groupId>
-        <version>1.3.15.bugfix</version>
+        <version>1.3.16</version>
     </parent>
     <artifactId>jraft-test</artifactId>
     <packaging>jar</packaging>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>com.alipay.sofa</groupId>
     <artifactId>jraft-parent</artifactId>
-    <version>1.3.15.bugfix</version>
+    <version>1.3.16</version>
     <packaging>pom</packaging>
 
     <name>${project.groupId}:${project.artifactId}</name>
@@ -63,7 +63,7 @@
         <java.target.version>1.8</java.target.version>
         <jctools.version>2.1.1</jctools.version>
         <jmh.version>1.20</jmh.version>
-        <jna.version>5.5.0</jna.version>
+        <jna.version>5.7.0</jna.version>
         <jsr305.version>3.0.2</jsr305.version>
         <junit.dep.version>4.8.2</junit.dep.version>
         <junit.version>4.13.1</junit.version>


### PR DESCRIPTION
I tried to run the project tests for the first time, but they failed. I found 2 reasons and fixed them:
1 - jna.version = 5.5.0 does not support Apple Silicon processors. So I upgraded the version to 5.7.0
2 - BaseLogStorageTest#testTruncatePrefix test failed, it failed with NullPointerException inside ThreadPoolsFactory#runInThread method when accessing ConcurrentHashMap with key == null. To fix this, I added a method to call LogStorageOptions.setGroupId("test"); before running the tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Upgraded core parent dependency versions across the project and aligned key library dependencies to the latest release, supporting improved build stability and performance.
  
- **Tests**
  - Refined log storage test configurations to ensure consistent grouping behavior during test runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->