### PR TITLE
Update sofa-bolt to 1.6.11

### DIFF
--- a/jraft-core/src/main/java/com/alipay/sofa/jraft/storage/log/RocksDBSegmentLogStorage.java
+++ b/jraft-core/src/main/java/com/alipay/sofa/jraft/storage/log/RocksDBSegmentLogStorage.java
@@ -42,7 +42,7 @@ import org.rocksdb.RocksDBException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.alipay.sofa.common.profile.StringUtil;
+import com.alipay.sofa.common.utils.StringUtil;
 import com.alipay.sofa.jraft.option.RaftOptions;
 import com.alipay.sofa.jraft.storage.impl.RocksDBLogStorage;
 import com.alipay.sofa.jraft.storage.log.CheckpointFile.Checkpoint;

--- a/jraft-extension/java-log-storage-impl/src/main/java/com/alipay/sofa/jraft/storage/db/AbstractDB.java
+++ b/jraft-extension/java-log-storage-impl/src/main/java/com/alipay/sofa/jraft/storage/db/AbstractDB.java
@@ -28,7 +28,7 @@ import org.apache.commons.io.FilenameUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.alipay.sofa.common.profile.StringUtil;
+import com.alipay.sofa.common.utils.StringUtil;
 import com.alipay.sofa.jraft.Lifecycle;
 import com.alipay.sofa.jraft.entity.LogEntry;
 import com.alipay.sofa.jraft.entity.codec.LogEntryDecoder;

--- a/pom.xml
+++ b/pom.xml
@@ -50,7 +50,7 @@
     <properties>
         <affinity.version>3.1.7</affinity.version>
         <asm.version>6.0</asm.version>
-        <bolt.version>1.6.7</bolt.version>
+        <bolt.version>1.6.11</bolt.version>
         <commons.compress.version>1.21</commons.compress.version>
         <commons.io.version>2.8.0</commons.io.version>
         <commons.lang.version>2.6</commons.lang.version>


### PR DESCRIPTION
Motivation:
I am developing a new service based on sofa-jraft and I need to synchronize all dependencies with spring-boot 3.4. However, I encountered a version conflict related to the sofa-common-tools project. The latest version of this library has already fixed all the issues, so it is enough to simply update the dependency version.

Change:
Update sofa-bolt to 1.6.11 and resolve conflicts.

Result:
After the update, I will be able to synchronize all dependencies in the new service with spring-boot 3.4.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Streamlined internal utility references to ensure consistent behavior.
  
- **Chores**
  - Upgraded a key dependency version for enhanced compatibility and overall system stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->