### PR TITLE
(fix) 修复truncateSuffix方法bug

### DIFF
--- a/jraft-core/src/main/java/com/alipay/sofa/jraft/storage/impl/RocksDBLogStorage.java
+++ b/jraft-core/src/main/java/com/alipay/sofa/jraft/storage/impl/RocksDBLogStorage.java
@@ -623,10 +623,11 @@ public class RocksDBLogStorage implements LogStorage, Describer {
             try {
                 onTruncateSuffix(lastIndexKept);
             } finally {
+                long lastLogIndex = getLastLogIndex();
                 this.db.deleteRange(this.defaultHandle, this.writeOptions, getKeyBytes(lastIndexKept + 1),
-                    getKeyBytes(getLastLogIndex() + 1));
+                    getKeyBytes(lastLogIndex + 1));
                 this.db.deleteRange(this.confHandle, this.writeOptions, getKeyBytes(lastIndexKept + 1),
-                    getKeyBytes(getLastLogIndex() + 1));
+                    getKeyBytes(lastLogIndex + 1));
             }
             return true;
         } catch (final RocksDBException | IOException e) {


### PR DESCRIPTION
### Motivation:

fix RocksDBLogStorage truncateSuffix() method bug

### Modification:

 only call getLastLogIndex() once

### Result:

Fixes #<1187>.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Improved internal efficiency and consistency when deleting log ranges, resulting in more reliable log management. No changes to user-facing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->