### PR TITLE
feat: impl soft limit on cached log entries in memory

### DIFF
--- a/jraft-core/src/main/java/com/alipay/sofa/jraft/entity/Ballot.java
+++ b/jraft-core/src/main/java/com/alipay/sofa/jraft/entity/Ballot.java
@@ -55,8 +55,8 @@ public class Ballot implements EstimatedSize {
     private int                       oldQuorum;
 
     @Override
-    public int estimatedSize() {
-        return 20 + 8 + (peers.size() + oldPeers.size()) * 48;
+    public long estimatedSize() {
+        return 28 + (peers.size() + oldPeers.size()) * 144;
     }
 
     /**

--- a/jraft-core/src/main/java/com/alipay/sofa/jraft/entity/Ballot.java
+++ b/jraft-core/src/main/java/com/alipay/sofa/jraft/entity/Ballot.java
@@ -56,7 +56,7 @@ public class Ballot implements EstimatedSize {
 
     @Override
     public long estimatedSize() {
-        return 28 + (peers.size() + oldPeers.size()) * 144;
+        return 28 + (peers.size() + oldPeers.size()) * PeerId.ESTIMATED_BYTES;
     }
 
     /**

--- a/jraft-core/src/main/java/com/alipay/sofa/jraft/entity/Ballot.java
+++ b/jraft-core/src/main/java/com/alipay/sofa/jraft/entity/Ballot.java
@@ -20,6 +20,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import com.alipay.sofa.jraft.conf.Configuration;
+import com.alipay.sofa.jraft.util.SegmentList.EstimatedSize;
 
 /**
  * A ballot to vote.
@@ -28,7 +29,7 @@ import com.alipay.sofa.jraft.conf.Configuration;
  *
  * 2018-Mar-15 2:29:11 PM
  */
-public class Ballot {
+public class Ballot implements EstimatedSize {
 
     public static final class PosHint {
         int pos0 = -1; // position in current peers
@@ -52,6 +53,11 @@ public class Ballot {
     private int                       quorum;
     private final List<UnfoundPeerId> oldPeers = new ArrayList<>();
     private int                       oldQuorum;
+
+    @Override
+    public int estimatedSize() {
+        return 20 + 8 + (peers.size() + oldPeers.size()) * 48;
+    }
 
     /**
      * Init the ballot with current conf and old conf.

--- a/jraft-core/src/main/java/com/alipay/sofa/jraft/entity/LogEntry.java
+++ b/jraft-core/src/main/java/com/alipay/sofa/jraft/entity/LogEntry.java
@@ -25,6 +25,7 @@ import com.alipay.sofa.jraft.entity.codec.v1.LogEntryV1CodecFactory;
 import com.alipay.sofa.jraft.entity.codec.v1.V1Decoder;
 import com.alipay.sofa.jraft.entity.codec.v1.V1Encoder;
 import com.alipay.sofa.jraft.util.CrcUtil;
+import com.alipay.sofa.jraft.util.SegmentList.EstimatedSize;
 
 /**
  * A replica log entry.
@@ -33,7 +34,7 @@ import com.alipay.sofa.jraft.util.CrcUtil;
  *
  * 2018-Mar-12 3:13:02 PM
  */
-public class LogEntry implements Checksum {
+public class LogEntry implements Checksum, EstimatedSize {
 
     public static final ByteBuffer EMPTY_DATA = ByteBuffer.wrap(new byte[0]);
 
@@ -84,6 +85,19 @@ public class LogEntry implements Checksum {
     public boolean hasLearners() {
         return (this.learners != null && !this.learners.isEmpty())
                || (this.oldLearners != null && !this.oldLearners.isEmpty());
+    }
+
+    // The estimated memory size of log entry
+    public int estimatedSize() {
+        return 16 + 32 + 36 + estimatedSize(this.learners) + //
+               estimatedSize(this.oldLearners) + //
+               estimatedSize(this.peers) + //
+               estimatedSize(this.oldPeers) + //
+               (this.data != null ? this.data.remaining() : 0) + 9;
+    }
+
+    private static int estimatedSize(List<PeerId> peers) {
+        return 40 * (peers != null ? peers.size() : 0) + 16;
     }
 
     @Override

--- a/jraft-core/src/main/java/com/alipay/sofa/jraft/entity/PeerId.java
+++ b/jraft-core/src/main/java/com/alipay/sofa/jraft/entity/PeerId.java
@@ -56,6 +56,8 @@ public class PeerId implements Copiable<PeerId>, Serializable, Checksum {
 
     private long                checksum;
 
+    public final static int     ESTIMATED_BYTES  = 120;
+
     public PeerId() {
         super();
     }

--- a/jraft-core/src/main/java/com/alipay/sofa/jraft/option/RaftOptions.java
+++ b/jraft-core/src/main/java/com/alipay/sofa/jraft/option/RaftOptions.java
@@ -42,6 +42,8 @@ public class RaftOptions implements Copiable<RaftOptions> {
     private int            maxAppendBufferSize                  = 256 * 1024;
     /** Maximum election delay time allowed by user */
     private int            maxElectionDelayMs                   = 1000;
+    /** Maximum cached log entries memory (bytes). This is a soft limit; -1 or negative integer means no limit. */
+    private int            maxLogsInMemoryBytes                 = -1;
     /** Raft election:heartbeat timeout factor */
     private int            electionHeartbeatFactor              = 10;
     /** Maximum number of tasks that can be applied in a batch */
@@ -120,6 +122,18 @@ public class RaftOptions implements Copiable<RaftOptions> {
 
     public int getDisruptorPublishEventWaitTimeoutSecs() {
         return this.disruptorPublishEventWaitTimeoutSecs;
+    }
+
+    public int getMaxLogsInMemoryBytes() {
+        return maxLogsInMemoryBytes;
+    }
+
+    /**
+     * Maximum cached log entries memory (bytes). This is a soft limit; -1 means no limit. Default is -1.
+     * @param maxLogsInMemoryBytes
+     */
+    public void setMaxLogsInMemoryBytes(int maxLogsInMemoryBytes) {
+        this.maxLogsInMemoryBytes = maxLogsInMemoryBytes;
     }
 
     public void setDisruptorPublishEventWaitTimeoutSecs(final int disruptorPublishEventWaitTimeoutSecs) {

--- a/jraft-core/src/main/java/com/alipay/sofa/jraft/option/RaftOptions.java
+++ b/jraft-core/src/main/java/com/alipay/sofa/jraft/option/RaftOptions.java
@@ -42,8 +42,8 @@ public class RaftOptions implements Copiable<RaftOptions> {
     private int            maxAppendBufferSize                  = 256 * 1024;
     /** Maximum election delay time allowed by user */
     private int            maxElectionDelayMs                   = 1000;
-    /** Maximum cached log entries memory (bytes). This is a soft limit; -1 or negative integer means no limit. */
-    private int            maxLogsInMemoryBytes                 = -1;
+    /** Maximum cached log entries memory (bytes). This is a soft limit; any negative integers means no limit, -1 by default. */
+    private long           maxLogsInMemoryBytes                 = -1;
     /** Raft election:heartbeat timeout factor */
     private int            electionHeartbeatFactor              = 10;
     /** Maximum number of tasks that can be applied in a batch */
@@ -124,7 +124,7 @@ public class RaftOptions implements Copiable<RaftOptions> {
         return this.disruptorPublishEventWaitTimeoutSecs;
     }
 
-    public int getMaxLogsInMemoryBytes() {
+    public long getMaxLogsInMemoryBytes() {
         return maxLogsInMemoryBytes;
     }
 
@@ -132,7 +132,7 @@ public class RaftOptions implements Copiable<RaftOptions> {
      * Maximum cached log entries memory (bytes). This is a soft limit; -1 means no limit. Default is -1.
      * @param maxLogsInMemoryBytes
      */
-    public void setMaxLogsInMemoryBytes(int maxLogsInMemoryBytes) {
+    public void setMaxLogsInMemoryBytes(long maxLogsInMemoryBytes) {
         this.maxLogsInMemoryBytes = maxLogsInMemoryBytes;
     }
 
@@ -305,6 +305,7 @@ public class RaftOptions implements Copiable<RaftOptions> {
         raftOptions.setEnableLogEntryChecksum(this.enableLogEntryChecksum);
         raftOptions.setReadOnlyOptions(this.readOnlyOptions);
         raftOptions.setStartupOldStorage(this.startupOldStorage);
+        raftOptions.setMaxLogsInMemoryBytes(this.maxLogsInMemoryBytes);
         return raftOptions;
     }
 

--- a/jraft-core/src/main/java/com/alipay/sofa/jraft/storage/impl/LogManagerImpl.java
+++ b/jraft-core/src/main/java/com/alipay/sofa/jraft/storage/impl/LogManagerImpl.java
@@ -105,10 +105,10 @@ public class LogManagerImpl implements LogManager {
     private NodeMetrics                                      nodeMetrics;
     private final CopyOnWriteArrayList<LastLogIndexListener> lastLogIndexListeners = new CopyOnWriteArrayList<>();
 
-    private final static class LogsInMememoryMetricSet implements MetricSet {
+    private final static class LogsInMemoryMetricSet implements MetricSet {
         final SegmentList<LogEntry> logsInMemory;
 
-        public LogsInMememoryMetricSet(SegmentList<LogEntry> logsInMemory) {
+        public LogsInMemoryMetricSet(SegmentList<LogEntry> logsInMemory) {
             super();
             this.logsInMemory = logsInMemory;
         }
@@ -229,7 +229,7 @@ public class LogManagerImpl implements LogManager {
             if (this.nodeMetrics.getMetricRegistry() != null) {
                 this.nodeMetrics.getMetricRegistry().register("jraft-log-manager-disruptor",
                     new DisruptorMetricSet(this.diskQueue));
-                this.nodeMetrics.getMetricRegistry().register("jraft-logs-manager-logs-in-memory", new LogsInMememoryMetricSet(this.logsInMemory));
+                this.nodeMetrics.getMetricRegistry().register("jraft-logs-manager-logs-in-memory", new LogsInMemoryMetricSet(this.logsInMemory));
             }
         } finally {
             this.writeLock.unlock();

--- a/jraft-core/src/main/java/com/alipay/sofa/jraft/util/SegmentList.java
+++ b/jraft-core/src/main/java/com/alipay/sofa/jraft/util/SegmentList.java
@@ -141,8 +141,8 @@ public class SegmentList<T extends SegmentList.EstimatedSize> {
         }
 
         @SuppressWarnings({ "SuspiciousSystemArraycopy", "unchecked" })
-        private int addAll(final Object[] src, final int srcPos, final int len) {
-            int addBytes = 0;
+        private long addAll(final Object[] src, final int srcPos, final int len) {
+            long addBytes = 0;
             System.arraycopy(src, srcPos, this.elements, this.pos, len);
             for (int i = srcPos; i < srcPos + len; i++) {
                 addBytes += ((T) src[i]).estimatedSize();
@@ -447,7 +447,7 @@ public class SegmentList<T extends SegmentList.EstimatedSize> {
             }
 
             int len = Math.min(lastSeg.cap(), srcSize - srcPos);
-            int bytes = lastSeg.addAll(src, srcPos, len);
+            long bytes = lastSeg.addAll(src, srcPos, len);
             srcPos += len;
             this.size += len;
             this.estimatedBytes += bytes;

--- a/jraft-core/src/test/java/com/alipay/sofa/jraft/core/TestCluster.java
+++ b/jraft-core/src/test/java/com/alipay/sofa/jraft/core/TestCluster.java
@@ -137,6 +137,12 @@ public class TestCluster {
         return this.start(addr, false, 300);
     }
 
+    public boolean startWithSoftMemLimit(final Endpoint addr, long softMemoryLimit) throws Exception {
+        final RaftOptions opts = new RaftOptions();
+        opts.setMaxLogsInMemoryBytes(softMemoryLimit);
+        return this.start(addr, false, 300, false, null, opts);
+    }
+
     public boolean start(final Endpoint addr, final int priority) throws Exception {
         return this.start(addr, false, 300, false, null, null, priority);
     }

--- a/jraft-core/src/test/java/com/alipay/sofa/jraft/core/TestJRaftServiceFactory.java
+++ b/jraft-core/src/test/java/com/alipay/sofa/jraft/core/TestJRaftServiceFactory.java
@@ -18,18 +18,14 @@ package com.alipay.sofa.jraft.core;
 
 import com.alipay.sofa.jraft.option.RaftOptions;
 import com.alipay.sofa.jraft.storage.LogStorage;
+import com.alipay.sofa.jraft.storage.impl.RocksDBLogStorage;
 import com.alipay.sofa.jraft.storage.log.RocksDBSegmentLogStorage;
 
 public class TestJRaftServiceFactory extends DefaultJRaftServiceFactory {
 
     @Override
     public LogStorage createLogStorage(final String uri, final RaftOptions raftOptions) {
-        return RocksDBSegmentLogStorage.builder(uri, raftOptions) //
-            .setPreAllocateSegmentCount(1) //
-            .setKeepInMemorySegmentCount(2) //
-            .setMaxSegmentFileSize(512 * 1024) //
-            .setValueSizeThreshold(0) //
-            .build();
+        return new RocksDBLogStorage(uri, raftOptions);
     }
 
 }

--- a/jraft-core/src/test/java/com/alipay/sofa/jraft/core/TestJRaftServiceFactory.java
+++ b/jraft-core/src/test/java/com/alipay/sofa/jraft/core/TestJRaftServiceFactory.java
@@ -19,7 +19,6 @@ package com.alipay.sofa.jraft.core;
 import com.alipay.sofa.jraft.option.RaftOptions;
 import com.alipay.sofa.jraft.storage.LogStorage;
 import com.alipay.sofa.jraft.storage.impl.RocksDBLogStorage;
-import com.alipay.sofa.jraft.storage.log.RocksDBSegmentLogStorage;
 
 public class TestJRaftServiceFactory extends DefaultJRaftServiceFactory {
 

--- a/jraft-core/src/test/java/com/alipay/sofa/jraft/util/SegmentListTest.java
+++ b/jraft-core/src/test/java/com/alipay/sofa/jraft/util/SegmentListTest.java
@@ -41,7 +41,7 @@ public class SegmentListTest {
         }
 
         @Override
-        public int estimatedSize() {
+        public long estimatedSize() {
             return 4;
         }
 
@@ -313,9 +313,11 @@ public class SegmentListTest {
             //            for(Integer o: tmpList) {
             //                list.add(o);
             //            }
+            assertEquals(this.list.size()*4, this.list.estimatedBytes());
             int removePos = start + ThreadLocalRandom.current().nextInt(tmpList.size());
             this.list.get(removePos - start);
             this.list.removeFromFirstWhen(x -> x.val <= removePos);
+            assertEquals(this.list.size()*4, this.list.estimatedBytes());
             start += tmpList.size();
         }
     }

--- a/jraft-core/src/test/java/com/alipay/sofa/jraft/util/SegmentListTest.java
+++ b/jraft-core/src/test/java/com/alipay/sofa/jraft/util/SegmentListTest.java
@@ -32,11 +32,26 @@ import io.netty.util.internal.ThreadLocalRandom;
 
 public class SegmentListTest {
 
-    private SegmentList<Integer> list;
+    static class WrapperInteger implements SegmentList.EstimatedSize {
+        int val;
+
+        public WrapperInteger(int val) {
+            super();
+            this.val = val;
+        }
+
+        @Override
+        public int estimatedSize() {
+            return 4;
+        }
+
+    }
+
+    private SegmentList<WrapperInteger> list;
 
     @Before
     public void setup() {
-        this.list = new SegmentList<>(true);
+        this.list = new SegmentList<WrapperInteger>(true);
     }
 
     @Test
@@ -49,9 +64,10 @@ public class SegmentListTest {
 
     private void assertFilledList() {
         for (int i = 0; i < 1000; i++) {
-            assertEquals(i, (int) this.list.get(i));
+            assertEquals(i, this.list.get(i).val);
         }
         assertEquals(1000, this.list.size());
+        assertEquals(4000, this.list.estimatedBytes());
         assertFalse(this.list.isEmpty());
         assertEquals(1000 / SegmentList.SEGMENT_SIZE + 1, this.list.segmentSize());
     }
@@ -59,32 +75,35 @@ public class SegmentListTest {
     private void fillList() {
         int originSize = this.list.size();
         for (int i = 0; i < 1000; i++) {
-            this.list.add(i);
+            this.list.add(new WrapperInteger(i));
             assertEquals(originSize + i + 1, this.list.size());
+            assertEquals((originSize + i + 1) * 4, this.list.estimatedBytes());
         }
     }
 
     @Test
     public void testAddAllGet() {
-        List<Integer> tmpList = new ArrayList<>();
+        List<WrapperInteger> tmpList = new ArrayList<WrapperInteger>();
         for (int i = 0; i < 1000; i++) {
-            tmpList.add(i);
+            tmpList.add(new WrapperInteger(i));
         }
 
         this.list.addAll(tmpList);
         assertFilledList();
 
-        this.list.removeFromFirstWhen(x -> x < 100);
+        this.list.removeFromFirstWhen(x -> x.val < 100);
         assertEquals(900, this.list.size());
+        assertEquals(3600, this.list.estimatedBytes());
 
         this.list.addAll(tmpList);
         assertEquals(1900, this.list.size());
+        assertEquals(1900*4, this.list.estimatedBytes());
 
         for (int i = 0; i < 1900; i++) {
             if (i < 900) {
-                assertEquals(i + 100, (int) this.list.get(i));
+                assertEquals(i + 100,  this.list.get(i).val);
             } else {
-                assertEquals(i - 900, (int) this.list.get(i));
+                assertEquals(i - 900,  this.list.get(i).val);
             }
         }
 
@@ -98,20 +117,22 @@ public class SegmentListTest {
         this.list.removeFromFirst(len);
 
         assertEquals(1000 - len, this.list.size());
+        assertEquals((1000 - len) * 4, this.list.estimatedBytes());
 
         for (int i = 0; i < 1000 - len; i++) {
-            assertEquals(i + len, (int) this.list.get(i));
+            assertEquals(i + len, this.list.get(i).val);
         }
 
         this.list.removeFromFirst(100);
         assertEquals(1000 - len - 100, this.list.size());
 
         for (int i = 0; i < 1000 - len - 100; i++) {
-            assertEquals(i + len + 100, (int) this.list.get(i));
+            assertEquals(i + len + 100, this.list.get(i).val);
         }
 
         this.list.removeFromFirst(1000 - len - 100);
         assertTrue(this.list.isEmpty());
+        assertEquals(0, this.list.estimatedBytes());
         assertEquals(0, this.list.segmentSize());
         assertNull(this.list.peekFirst());
         assertNull(this.list.peekLast());
@@ -120,22 +141,25 @@ public class SegmentListTest {
     @Test
     public void testRemoveFromFirstWhen() {
         fillList();
-        this.list.removeFromFirstWhen(x -> x < 200);
+        this.list.removeFromFirstWhen(x -> x.val < 200);
         assertEquals(800, this.list.size());
-        assertEquals(200, (int) this.list.get(0));
+        assertEquals(3200, this.list.estimatedBytes());
+        assertEquals(200,   this.list.get(0).val);
 
         for (int i = 0; i < 800; i++) {
-            assertEquals(200 + i, (int) this.list.get(i));
+            assertEquals(200 + i,  this.list.get(i).val);
         }
 
-        this.list.removeFromFirstWhen(x -> x < 500);
+        this.list.removeFromFirstWhen(x -> x.val < 500);
         assertEquals(500, this.list.size());
+        assertEquals(2000, this.list.estimatedBytes());
         for (int i = 0; i < 500; i++) {
-            assertEquals(500 + i, (int) this.list.get(i));
+            assertEquals(500 + i, this.list.get(i).val);
         }
 
-        this.list.removeFromFirstWhen(x -> x < 1000);
+        this.list.removeFromFirstWhen(x -> x.val < 1000);
         assertTrue(this.list.isEmpty());
+        assertEquals(0, this.list.estimatedBytes());
         assertEquals(0, this.list.segmentSize());
 
         fillList();
@@ -147,11 +171,12 @@ public class SegmentListTest {
         fillList();
 
         // remove elements is greater or equal to 150.
-        this.list.removeFromLastWhen(x -> x >= 150);
+        this.list.removeFromLastWhen(x -> x.val >= 150);
         assertEquals(150, this.list.size());
+        assertEquals(600, this.list.estimatedBytes());
         assertFalse(this.list.isEmpty());
         for (int i = 0; i < 150; i++) {
-            assertEquals(i, (int) this.list.get(i));
+            assertEquals(i,  this.list.get(i).val);
         }
         try {
             this.list.get(151);
@@ -162,11 +187,12 @@ public class SegmentListTest {
         assertEquals(150 / SegmentList.SEGMENT_SIZE + 1, this.list.segmentSize());
 
         // remove  elements is greater or equal to 32.
-        this.list.removeFromLastWhen(x -> x >= 32);
+        this.list.removeFromLastWhen(x -> x.val >= 32);
         assertEquals(32, this.list.size());
+        assertEquals(128, this.list.estimatedBytes());
         assertFalse(this.list.isEmpty());
         for (int i = 0; i < 32; i++) {
-            assertEquals(i, (int) this.list.get(i));
+            assertEquals(i,  this.list.get(i).val);
         }
         try {
             this.list.get(32);
@@ -179,11 +205,12 @@ public class SegmentListTest {
         // Add elements again.
         fillList();
         assertEquals(1032, this.list.size());
+        assertEquals(1032*4, this.list.estimatedBytes());
         for (int i = 0; i < 1032; i++) {
             if (i < 32) {
-                assertEquals(i, (int) this.list.get(i));
+                assertEquals(i,  this.list.get(i).val);
             } else {
-                assertEquals(i - 32, (int) this.list.get(i));
+                assertEquals(i - 32, this.list.get(i).val);
             }
         }
     }
@@ -191,10 +218,11 @@ public class SegmentListTest {
     @Test
     public void testAddPeek() {
         for (int i = 0; i < 1000; i++) {
-            this.list.add(i);
-            assertEquals(i, (int) this.list.peekLast());
-            assertEquals(0, (int) this.list.peekFirst());
+            this.list.add(new WrapperInteger(i));
+            assertEquals(i, this.list.peekLast().val);
+            assertEquals(0, this.list.peekFirst().val);
         }
+        assertEquals(4000, this.list.estimatedBytes());
     }
 
     @Test
@@ -206,7 +234,7 @@ public class SegmentListTest {
         double segListOps = 0;
         // test ArrayDequeue
         {
-            ArrayDeque<Integer> deque = new ArrayDeque<>();
+            ArrayDeque<WrapperInteger> deque = new ArrayDeque<>();
             System.gc();
             // wramup
             benchArrayDequeue(warmupRepeats, deque);
@@ -239,10 +267,10 @@ public class SegmentListTest {
 
     }
 
-    private void benchArrayDequeue(final int repeats, final ArrayDeque<Integer> deque) {
+    private void benchArrayDequeue(final int repeats, final ArrayDeque<WrapperInteger> deque) {
         int start = 0;
         for (int i = 0; i < repeats; i++) {
-            List<Integer> tmpList = genData(start);
+            List<WrapperInteger> tmpList = genData(start);
             deque.addAll(tmpList);
             //            for (Integer o : tmpList) {
             //                deque.add(o);
@@ -253,7 +281,7 @@ public class SegmentListTest {
 
             int index = 0;
             for (int j = 0; j < deque.size(); j++) {
-                if (deque.get(j) > removePos) {
+                if (deque.get(j).val > removePos) {
                     index = j;
                     break;
                 }
@@ -267,11 +295,11 @@ public class SegmentListTest {
         }
     }
 
-    private List<Integer> genData(final int start) {
+    private List<WrapperInteger> genData(final int start) {
         int n = ThreadLocalRandom.current().nextInt(500) + 10;
-        List<Integer> tmpList = new ArrayList<>(n);
+        List<WrapperInteger> tmpList = new ArrayList<>(n);
         for (int i = 0; i < n; i++) {
-            tmpList.add(i + start);
+            tmpList.add(new WrapperInteger(i + start));
         }
         return tmpList;
     }
@@ -280,14 +308,14 @@ public class SegmentListTest {
         int start = 0;
 
         for (int i = 0; i < repeats; i++) {
-            List<Integer> tmpList = genData(start);
+            List<WrapperInteger> tmpList = genData(start);
             this.list.addAll(tmpList);
             //            for(Integer o: tmpList) {
             //                list.add(o);
             //            }
             int removePos = start + ThreadLocalRandom.current().nextInt(tmpList.size());
             this.list.get(removePos - start);
-            this.list.removeFromFirstWhen(x -> x <= removePos);
+            this.list.removeFromFirstWhen(x -> x.val <= removePos);
             start += tmpList.size();
         }
     }


### PR DESCRIPTION
### Motivation:

Explain the context, and why you're making that change.
To make others understand what is the problem you're trying to solve.

### Modification:

Ad the title said. 

* Adds a new raft option `maxLogsInMemoryBytes`,  which is soft limit on maximum cached log entries memory (bytes). After reaching this limit, applying new task will return a busy error.
* Adds metrics for logs in memory.

### Result:

Close #840 

If there is no issue then describe the changes introduced by this PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
  - Introduced memory usage estimation for key data structures to track in-memory resource consumption.
  - Added a configurable soft limit on maximum memory used by cached log entries.
  - Exposed new metrics for monitoring the count and estimated memory usage of in-memory logs.
  - Added support for starting cluster nodes with a soft memory limit for in-memory logs.

- **Tests**
  - Enhanced tests to validate memory estimation and size tracking functionality.
  - Added a test verifying task application and log replication under soft memory limit constraints.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->