### PR TITLE
feat: only keeps request header to reduce memory in replicator

### DIFF
--- a/jraft-core/src/main/java/com/alipay/sofa/jraft/core/RpcRequestHeader.java
+++ b/jraft-core/src/main/java/com/alipay/sofa/jraft/core/RpcRequestHeader.java
@@ -1,0 +1,72 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alipay.sofa.jraft.core;
+
+import com.alipay.sofa.jraft.entity.RaftOutter.SnapshotMeta;
+
+/**
+ * AppendEntriesRequest header, which only keeps the request metadata info without the data.
+ * It's designed to reduce the memory consumption for RPC.
+ * @author dennis
+ *
+ */
+class RpcRequestHeader {
+    final long         prevLogIndex;
+    final long         prevLogTerm;
+    final int          entriesCount;
+    final int          dataBytes;
+    final SnapshotMeta meta;
+
+    public RpcRequestHeader(long prevLogIndex, long prevLogTerm, int entriesCount, int dataBytes) {
+        super();
+        this.prevLogIndex = prevLogIndex;
+        this.prevLogTerm = prevLogTerm;
+        this.entriesCount = entriesCount;
+        this.dataBytes = dataBytes;
+        this.meta = null;
+    }
+
+    public RpcRequestHeader(SnapshotMeta meta) {
+        super();
+        this.prevLogIndex = 0;
+        this.prevLogTerm = 0;
+        this.entriesCount = 0;
+        this.dataBytes = 0;
+        this.meta = meta;
+    }
+
+    public SnapshotMeta getMeta() {
+        return meta;
+    }
+
+    long getPrevLogIndex() {
+        return prevLogIndex;
+    }
+
+    long getPrevLogTerm() {
+        return prevLogTerm;
+    }
+
+    int getEntriesCount() {
+        return entriesCount;
+    }
+
+    int getDataBytes() {
+        return dataBytes;
+    }
+
+}


### PR DESCRIPTION
### Motivation:

Explain the context, and why you're making that change.
To make others understand what is the problem you're trying to solve.

### Modification:
Currently, replicator sends entries asynchronously, but the RPC invocation callback retains the entire request in memory, delaying its release. This is especially problematic for large requests, as it leads to high memory usage.

This PR introduces `RpcRequestHeader` for `InstallSnapshotRequest` and `AppendEntriesRequest`, which retains only essential information while awaiting a response. This should significantly reduce memory consumption during replication.

### Result:

Fixes #<GitHub issue number>.

If there is no issue then describe the changes introduced by this PR.
