### PR TITLE
fix: read and write leader time out of lock

### DIFF
--- a/jraft-core/src/main/java/com/alipay/sofa/jraft/core/NodeImpl.java
+++ b/jraft-core/src/main/java/com/alipay/sofa/jraft/core/NodeImpl.java
@@ -617,15 +617,15 @@ public class NodeImpl implements Node, RaftServerService {
     }
 
     private void handleElectionTimeout() {
+        if (this.state != State.STATE_FOLLOWER) {
+            return;
+        }
+        if (isCurrentLeaderValid()) {
+            return;
+        }
         boolean doUnlock = true;
         this.writeLock.lock();
         try {
-            if (this.state != State.STATE_FOLLOWER) {
-                return;
-            }
-            if (isCurrentLeaderValid()) {
-                return;
-            }
             resetLeaderId(PeerId.emptyPeer(), new Status(RaftError.ERAFTTIMEDOUT, "Lost connection from leader %s.",
                 this.leaderId));
 
@@ -1935,39 +1935,40 @@ public class NodeImpl implements Node, RaftServerService {
 
     @Override
     public Message handleAppendEntriesRequest(final AppendEntriesRequest request, final RpcRequestClosure done) {
+        if (!this.state.isActive()) {
+            LOG.warn("Node {} is not in active state, currTerm={}.", getNodeId(), this.currTerm);
+            return RpcFactoryHelper //
+                .responseFactory() //
+                .newResponse(AppendEntriesResponse.getDefaultInstance(), RaftError.EINVAL,
+                    "Node %s is not in active state, state %s.", getNodeId(), this.state.name());
+        }
+
+        final PeerId serverId = new PeerId();
+        if (!serverId.parse(request.getServerId())) {
+            LOG.warn("Node {} received AppendEntriesRequest from {} serverId bad format.", getNodeId(),
+                request.getServerId());
+            return RpcFactoryHelper //
+                .responseFactory() //
+                .newResponse(AppendEntriesResponse.getDefaultInstance(), RaftError.EINVAL,
+                    "Parse serverId failed: %s.", request.getServerId());
+        }
+
+        // Check stale term
+        if (request.getTerm() < this.currTerm) {
+            LOG.warn("Node {} ignore stale AppendEntriesRequest from {}, term={}, currTerm={}.", getNodeId(),
+                request.getServerId(), request.getTerm(), this.currTerm);
+            return AppendEntriesResponse.newBuilder() //
+                .setSuccess(false) //
+                .setTerm(this.currTerm) //
+                .build();
+        }
+        updateLastLeaderTimestamp(Utils.monotonicMs());
         boolean doUnlock = true;
         final long startMs = Utils.monotonicMs();
         this.writeLock.lock();
         final int entriesCount = request.getEntriesCount();
         boolean success = false;
         try {
-            if (!this.state.isActive()) {
-                LOG.warn("Node {} is not in active state, currTerm={}.", getNodeId(), this.currTerm);
-                return RpcFactoryHelper //
-                    .responseFactory() //
-                    .newResponse(AppendEntriesResponse.getDefaultInstance(), RaftError.EINVAL,
-                        "Node %s is not in active state, state %s.", getNodeId(), this.state.name());
-            }
-
-            final PeerId serverId = new PeerId();
-            if (!serverId.parse(request.getServerId())) {
-                LOG.warn("Node {} received AppendEntriesRequest from {} serverId bad format.", getNodeId(),
-                    request.getServerId());
-                return RpcFactoryHelper //
-                    .responseFactory() //
-                    .newResponse(AppendEntriesResponse.getDefaultInstance(), RaftError.EINVAL,
-                        "Parse serverId failed: %s.", request.getServerId());
-            }
-
-            // Check stale term
-            if (request.getTerm() < this.currTerm) {
-                LOG.warn("Node {} ignore stale AppendEntriesRequest from {}, term={}, currTerm={}.", getNodeId(),
-                    request.getServerId(), request.getTerm(), this.currTerm);
-                return AppendEntriesResponse.newBuilder() //
-                    .setSuccess(false) //
-                    .setTerm(this.currTerm) //
-                    .build();
-            }
 
             // Check term and state to step down
             checkStepDown(request.getTerm(), serverId);
@@ -1984,7 +1985,6 @@ public class NodeImpl implements Node, RaftServerService {
                     .build();
             }
 
-            updateLastLeaderTimestamp(Utils.monotonicMs());
 
             if (entriesCount > 0 && this.snapshotExecutor != null && this.snapshotExecutor.isInstallingSnapshot()) {
                 LOG.warn("Node {} received AppendEntriesRequest while installing snapshot.", getNodeId());


### PR DESCRIPTION

### Motivation:

When appendEntry takes time more than electiontimeout, election-timer would block in writer lock and then dectect leader timeout. 

### Modification:

It's no matter to write and read leader timestamp out of lock
1. election-timer read leadertimestamp out of lock
2. appendentry handler write leadertimestamp out of lock
### Result:




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Enhanced system responsiveness by optimizing validation steps to occur earlier, reducing delays during election timeouts and log entry updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->