### PR TITLE
fix: log errors when starting a new group during runtime

### DIFF
--- a/jraft-core/src/main/java/com/alipay/sofa/jraft/RaftGroupService.java
+++ b/jraft-core/src/main/java/com/alipay/sofa/jraft/RaftGroupService.java
@@ -129,7 +129,7 @@ public class RaftGroupService {
         this.node = RaftServiceFactory.createAndInitRaftNode(this.groupId, this.serverId, this.nodeOptions);
         if (startRpcServer) {
             this.rpcServer.init(null);
-        } else if (!rpcServer.isStarted()) {
+        } else if (rpcServer == null || !rpcServer.isStarted()) {
             LOG.warn("RPC server is not started in RaftGroupService.");
         }
         this.started = true;

--- a/jraft-core/src/main/java/com/alipay/sofa/jraft/RaftGroupService.java
+++ b/jraft-core/src/main/java/com/alipay/sofa/jraft/RaftGroupService.java
@@ -129,7 +129,7 @@ public class RaftGroupService {
         this.node = RaftServiceFactory.createAndInitRaftNode(this.groupId, this.serverId, this.nodeOptions);
         if (startRpcServer) {
             this.rpcServer.init(null);
-        } else {
+        } else if (!rpcServer.isStarted()) {
             LOG.warn("RPC server is not started in RaftGroupService.");
         }
         this.started = true;

--- a/jraft-core/src/main/java/com/alipay/sofa/jraft/rpc/RpcServer.java
+++ b/jraft-core/src/main/java/com/alipay/sofa/jraft/rpc/RpcServer.java
@@ -46,7 +46,7 @@ public interface RpcServer extends Lifecycle<Void> {
     int boundPort();
 
     /**
-     * isStart the service.
+     *  Returns true when the rpc server is already started.
      *
      * @return true when started.
      */

--- a/jraft-core/src/main/java/com/alipay/sofa/jraft/rpc/RpcServer.java
+++ b/jraft-core/src/main/java/com/alipay/sofa/jraft/rpc/RpcServer.java
@@ -44,4 +44,12 @@ public interface RpcServer extends Lifecycle<Void> {
      * @return bound port
      */
     int boundPort();
+
+    /**
+     * isStart the service.
+     *
+     * @return true when started.
+     */
+    boolean isStarted();
+
 }

--- a/jraft-core/src/main/java/com/alipay/sofa/jraft/rpc/impl/BoltRpcServer.java
+++ b/jraft-core/src/main/java/com/alipay/sofa/jraft/rpc/impl/BoltRpcServer.java
@@ -22,7 +22,6 @@ import com.alipay.remoting.AsyncContext;
 import com.alipay.remoting.BizContext;
 import com.alipay.remoting.ConnectionEventType;
 import com.alipay.remoting.config.BoltClientOption;
-import com.alipay.remoting.config.switches.GlobalSwitch;
 import com.alipay.remoting.rpc.protocol.AsyncUserProcessor;
 import com.alipay.sofa.jraft.rpc.Connection;
 import com.alipay.sofa.jraft.rpc.RpcContext;
@@ -90,6 +89,11 @@ public class BoltRpcServer implements RpcServer {
     @Override
     public int boundPort() {
         return this.rpcServer.port();
+    }
+
+    @Override
+    public boolean isStarted() {
+        return rpcServer.isStarted();
     }
 
     @Override

--- a/jraft-extension/rpc-grpc-impl/src/main/java/com/alipay/sofa/jraft/rpc/impl/GrpcServer.java
+++ b/jraft-extension/rpc-grpc-impl/src/main/java/com/alipay/sofa/jraft/rpc/impl/GrpcServer.java
@@ -211,6 +211,11 @@ public class GrpcServer implements RpcServer {
         return this.server.getPort();
     }
 
+    @Override
+    public boolean isStarted() {
+        return started.get();
+    }
+
     public void setDefaultExecutor(ExecutorService defaultExecutor) {
         this.defaultExecutor = defaultExecutor;
     }


### PR DESCRIPTION
### Motivation:

目前在运行中扩展新的group并启动时,实际上rpcserver已经启动,但是它仍输出`RPC server is not started in RaftGroupService.` 这段日志.

### Modification:

Describe the idea and modifications you've done.

### Result:

Fixes #<GitHub issue number>.

If there is no issue then describe the changes introduced by this PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added the ability to check whether the RPC server has already started, improving status visibility in both Bolt and gRPC server implementations.

- **Bug Fixes**
  - Improved warning messages to avoid unnecessary alerts when the RPC server is already running.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->