### PR TITLE
perf: use double-checked in handleElectionTimeout

### DIFF
--- a/jraft-core/src/main/java/com/alipay/sofa/jraft/core/NodeImpl.java
+++ b/jraft-core/src/main/java/com/alipay/sofa/jraft/core/NodeImpl.java
@@ -617,6 +617,12 @@ public class NodeImpl implements Node, RaftServerService {
     }
 
     private void handleElectionTimeout() {
+        if (this.state != State.STATE_FOLLOWER) {
+            return;
+        }
+        if (isCurrentLeaderValid()) {
+            return;
+        }
         boolean doUnlock = true;
         this.writeLock.lock();
         try {


### PR DESCRIPTION
### Motivation:

Make the heartbeat mechanism independent of the node lock, or at least minimize its impact on it.

### Modification:
Use double-checked locking in handleElectionTimeout to remain lock-free in most cases.

### Result:

Fixes #1192 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Improved efficiency of election timeout handling, reducing unnecessary internal processing when the node is not a follower or the leader remains valid. No visible changes to end-user functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->