### PR TITLE
修复状态机iterImpl.done()抛出异常导致状态机同一个Task执行两次

### DIFF
--- a/jraft-core/src/main/java/com/alipay/sofa/jraft/core/NodeImpl.java
+++ b/jraft-core/src/main/java/com/alipay/sofa/jraft/core/NodeImpl.java
@@ -2373,10 +2373,12 @@ public class NodeImpl implements Node, RaftServerService {
         @Override
         public void run(final Status status) {
             if (status.isOk()) {
-                onConfigurationChangeDone(this.term);
-                if (this.leaderStart) {
-                    getOptions().getFsm().onLeaderStart(this.term);
-                }
+                ThreadPoolsFactory.runInThread(groupId, () -> {
+                    onConfigurationChangeDone(ConfigurationChangeDone.this.term);
+                    if (ConfigurationChangeDone.this.leaderStart) {
+                        getOptions().getFsm().onLeaderStart(ConfigurationChangeDone.this.term);
+                    }
+                });
             } else {
                 LOG.error("Fail to run ConfigurationChangeDone, status: {}.", status);
             }


### PR DESCRIPTION
### Motivation:

修复状态机iterImpl.done()抛出异常导致状态机同一个Task执行两次，异步执行状态机iterImpl.done()避免形成死锁

### Modification:

状态机异步执行Closure，避免抛出异常导致重复执行Task导致状态机不一致，避免形成死锁

### Result:

Fixes #<1195>.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Improved performance by executing certain configuration change operations asynchronously, reducing potential delays in the main thread.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->