### PR TITLE
 Specified IP addresses can be listened to to prevent risks caused by all-zero listening

### DIFF
--- a/jraft-extension/rpc-grpc-impl/src/main/java/com/alipay/sofa/jraft/rpc/impl/GrpcRaftRpcFactory.java
+++ b/jraft-extension/rpc-grpc-impl/src/main/java/com/alipay/sofa/jraft/rpc/impl/GrpcRaftRpcFactory.java
@@ -16,13 +16,15 @@
  */
 package com.alipay.sofa.jraft.rpc.impl;
 
+import java.net.InetSocketAddress;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
 import io.grpc.Server;
-import io.grpc.ServerBuilder;
+import io.grpc.netty.shaded.io.grpc.netty.NettyServerBuilder
 import io.grpc.util.MutableHandlerRegistry;
 
+import com.alipay.remoting.util.StringUtils;
 import com.alipay.sofa.jraft.rpc.RaftRpcFactory;
 import com.alipay.sofa.jraft.rpc.RpcClient;
 import com.alipay.sofa.jraft.rpc.RpcResponseFactory;

--- a/jraft-extension/rpc-grpc-impl/src/main/java/com/alipay/sofa/jraft/rpc/impl/GrpcRaftRpcFactory.java
+++ b/jraft-extension/rpc-grpc-impl/src/main/java/com/alipay/sofa/jraft/rpc/impl/GrpcRaftRpcFactory.java
@@ -42,28 +42,34 @@ import com.google.protobuf.Message;
 @SPI(priority = 1)
 public class GrpcRaftRpcFactory implements RaftRpcFactory {
 
-    static final String FIXED_METHOD_NAME              = "_call";
-    static final int    RPC_SERVER_PROCESSOR_POOL_SIZE = SystemPropertyUtil.getInt(
-            "jraft.grpc.default_rpc_server_processor_pool_size", 100);
+    static final String             FIXED_METHOD_NAME              = "_call";
+    static final int                RPC_SERVER_PROCESSOR_POOL_SIZE = SystemPropertyUtil
+                                                                       .getInt(
+                                                                           "jraft.grpc.default_rpc_server_processor_pool_size",
+                                                                           100);
 
-    static final int RPC_MAX_INBOUND_MESSAGE_SIZE = SystemPropertyUtil.getInt(
-            "jraft.grpc.max_inbound_message_size.bytes", 4 * 1024 * 1024);
+    static final int                RPC_MAX_INBOUND_MESSAGE_SIZE   = SystemPropertyUtil.getInt(
+                                                                       "jraft.grpc.max_inbound_message_size.bytes",
+                                                                       4 * 1024 * 1024);
 
-    static final RpcResponseFactory RESPONSE_FACTORY = new GrpcResponseFactory();
+    static final RpcResponseFactory RESPONSE_FACTORY               = new GrpcResponseFactory();
 
-    final Map<String, Message> parserClasses             = new ConcurrentHashMap<>();
-    final MarshallerRegistry   defaultMarshallerRegistry = new MarshallerRegistry() {
+    final Map<String, Message>      parserClasses                  = new ConcurrentHashMap<>();
+    final MarshallerRegistry        defaultMarshallerRegistry      = new MarshallerRegistry() {
 
-        @Override
-        public Message findResponseInstanceByRequest(final String reqCls) {
-            return MarshallerHelper.findRespInstance(reqCls);
-        }
+                                                                       @Override
+                                                                       public Message findResponseInstanceByRequest(final String reqCls) {
+                                                                           return MarshallerHelper
+                                                                               .findRespInstance(reqCls);
+                                                                       }
 
-        @Override
-        public void registerResponseInstance(final String reqCls, final Message respIns) {
-            MarshallerHelper.registerRespInstance(reqCls, respIns);
-        }
-    };
+                                                                       @Override
+                                                                       public void registerResponseInstance(final String reqCls,
+                                                                                                            final Message respIns) {
+                                                                           MarshallerHelper.registerRespInstance(
+                                                                               reqCls, respIns);
+                                                                       }
+                                                                   };
 
     @Override
     public void registerProtobufSerializer(final String className, final Object... args) {
@@ -85,14 +91,13 @@ public class GrpcRaftRpcFactory implements RaftRpcFactory {
         Requires.requireTrue(port > 0 && port < 0xFFFF, "port out of range:" + port);
         final MutableHandlerRegistry handlerRegistry = new MutableHandlerRegistry();
         InetSocketAddress address = StringUtils.isNotBlank(endpoint.getIp()) ? new InetSocketAddress(endpoint.getIp(),
-                port) : new InetSocketAddress(port);
+            port) : new InetSocketAddress(port);
         final Server server = NettyServerBuilder.forAddress(address) //
-                .fallbackHandlerRegistry(handlerRegistry) //
-                .directExecutor() //
-                .maxInboundMessageSize(RPC_MAX_INBOUND_MESSAGE_SIZE) //
-                .build();
-        final RpcServer rpcServer = new GrpcServer(server, handlerRegistry, this.parserClasses,
-                getMarshallerRegistry());
+            .fallbackHandlerRegistry(handlerRegistry) //
+            .directExecutor() //
+            .maxInboundMessageSize(RPC_MAX_INBOUND_MESSAGE_SIZE) //
+            .build();
+        final RpcServer rpcServer = new GrpcServer(server, handlerRegistry, this.parserClasses, getMarshallerRegistry());
         if (helper != null) {
             helper.config(rpcServer);
         }

--- a/jraft-extension/rpc-grpc-impl/src/main/java/com/alipay/sofa/jraft/rpc/impl/GrpcRaftRpcFactory.java
+++ b/jraft-extension/rpc-grpc-impl/src/main/java/com/alipay/sofa/jraft/rpc/impl/GrpcRaftRpcFactory.java
@@ -90,10 +90,9 @@ public class GrpcRaftRpcFactory implements RaftRpcFactory {
         final int port = Requires.requireNonNull(endpoint, "endpoint").getPort();
         Requires.requireTrue(port > 0 && port < 0xFFFF, "port out of range:" + port);
         final MutableHandlerRegistry handlerRegistry = new MutableHandlerRegistry();
-        InetSocketAddress address = StringUtils.isNotBlank(endpoint.getIp())
-            ? new InetSocketAddress(endpoint.getIp(), port)
-            : new InetSocketAddress(port);
-        final Server server = NettyServerBuilder.forAddress(address)//
+        InetSocketAddress address = StringUtils.isNotBlank(endpoint.getIp()) ? new InetSocketAddress(endpoint.getIp(),
+                port) : new InetSocketAddress(port);
+        final Server server = NettyServerBuilder.forAddress(address) //
             .fallbackHandlerRegistry(handlerRegistry) //
             .directExecutor() //
             .maxInboundMessageSize(RPC_MAX_INBOUND_MESSAGE_SIZE) //

--- a/jraft-extension/rpc-grpc-impl/src/main/java/com/alipay/sofa/jraft/rpc/impl/GrpcRaftRpcFactory.java
+++ b/jraft-extension/rpc-grpc-impl/src/main/java/com/alipay/sofa/jraft/rpc/impl/GrpcRaftRpcFactory.java
@@ -88,7 +88,10 @@ public class GrpcRaftRpcFactory implements RaftRpcFactory {
         final int port = Requires.requireNonNull(endpoint, "endpoint").getPort();
         Requires.requireTrue(port > 0 && port < 0xFFFF, "port out of range:" + port);
         final MutableHandlerRegistry handlerRegistry = new MutableHandlerRegistry();
-        final Server server = ServerBuilder.forPort(port) //
+        InetSocketAddress address = StringUtils.isNotBlank(endpoint.getIp())
+            ? new InetSocketAddress(endpoint.getIp(), port)
+            : new InetSocketAddress(port);
+        final Server server = NettyServerBuilder.forAddress(address)//
             .fallbackHandlerRegistry(handlerRegistry) //
             .directExecutor() //
             .maxInboundMessageSize(RPC_MAX_INBOUND_MESSAGE_SIZE) //

--- a/jraft-extension/rpc-grpc-impl/src/main/java/com/alipay/sofa/jraft/rpc/impl/GrpcRaftRpcFactory.java
+++ b/jraft-extension/rpc-grpc-impl/src/main/java/com/alipay/sofa/jraft/rpc/impl/GrpcRaftRpcFactory.java
@@ -42,34 +42,28 @@ import com.google.protobuf.Message;
 @SPI(priority = 1)
 public class GrpcRaftRpcFactory implements RaftRpcFactory {
 
-    static final String             FIXED_METHOD_NAME              = "_call";
-    static final int                RPC_SERVER_PROCESSOR_POOL_SIZE = SystemPropertyUtil
-                                                                       .getInt(
-                                                                           "jraft.grpc.default_rpc_server_processor_pool_size",
-                                                                           100);
+    static final String FIXED_METHOD_NAME              = "_call";
+    static final int    RPC_SERVER_PROCESSOR_POOL_SIZE = SystemPropertyUtil.getInt(
+            "jraft.grpc.default_rpc_server_processor_pool_size", 100);
 
-    static final int                RPC_MAX_INBOUND_MESSAGE_SIZE   = SystemPropertyUtil.getInt(
-                                                                       "jraft.grpc.max_inbound_message_size.bytes",
-                                                                       4 * 1024 * 1024);
+    static final int RPC_MAX_INBOUND_MESSAGE_SIZE = SystemPropertyUtil.getInt(
+            "jraft.grpc.max_inbound_message_size.bytes", 4 * 1024 * 1024);
 
-    static final RpcResponseFactory RESPONSE_FACTORY               = new GrpcResponseFactory();
+    static final RpcResponseFactory RESPONSE_FACTORY = new GrpcResponseFactory();
 
-    final Map<String, Message>      parserClasses                  = new ConcurrentHashMap<>();
-    final MarshallerRegistry        defaultMarshallerRegistry      = new MarshallerRegistry() {
+    final Map<String, Message> parserClasses             = new ConcurrentHashMap<>();
+    final MarshallerRegistry   defaultMarshallerRegistry = new MarshallerRegistry() {
 
-                                                                       @Override
-                                                                       public Message findResponseInstanceByRequest(final String reqCls) {
-                                                                           return MarshallerHelper
-                                                                               .findRespInstance(reqCls);
-                                                                       }
+        @Override
+        public Message findResponseInstanceByRequest(final String reqCls) {
+            return MarshallerHelper.findRespInstance(reqCls);
+        }
 
-                                                                       @Override
-                                                                       public void registerResponseInstance(final String reqCls,
-                                                                                                            final Message respIns) {
-                                                                           MarshallerHelper.registerRespInstance(
-                                                                               reqCls, respIns);
-                                                                       }
-                                                                   };
+        @Override
+        public void registerResponseInstance(final String reqCls, final Message respIns) {
+            MarshallerHelper.registerRespInstance(reqCls, respIns);
+        }
+    };
 
     @Override
     public void registerProtobufSerializer(final String className, final Object... args) {
@@ -93,11 +87,12 @@ public class GrpcRaftRpcFactory implements RaftRpcFactory {
         InetSocketAddress address = StringUtils.isNotBlank(endpoint.getIp()) ? new InetSocketAddress(endpoint.getIp(),
                 port) : new InetSocketAddress(port);
         final Server server = NettyServerBuilder.forAddress(address) //
-            .fallbackHandlerRegistry(handlerRegistry) //
-            .directExecutor() //
-            .maxInboundMessageSize(RPC_MAX_INBOUND_MESSAGE_SIZE) //
-            .build();
-        final RpcServer rpcServer = new GrpcServer(server, handlerRegistry, this.parserClasses, getMarshallerRegistry());
+                .fallbackHandlerRegistry(handlerRegistry) //
+                .directExecutor() //
+                .maxInboundMessageSize(RPC_MAX_INBOUND_MESSAGE_SIZE) //
+                .build();
+        final RpcServer rpcServer = new GrpcServer(server, handlerRegistry, this.parserClasses,
+                getMarshallerRegistry());
         if (helper != null) {
             helper.config(rpcServer);
         }

--- a/jraft-extension/rpc-grpc-impl/src/main/java/com/alipay/sofa/jraft/rpc/impl/GrpcRaftRpcFactory.java
+++ b/jraft-extension/rpc-grpc-impl/src/main/java/com/alipay/sofa/jraft/rpc/impl/GrpcRaftRpcFactory.java
@@ -21,7 +21,7 @@ import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
 import io.grpc.Server;
-import io.grpc.netty.shaded.io.grpc.netty.NettyServerBuilder
+import io.grpc.netty.shaded.io.grpc.netty.NettyServerBuilder;
 import io.grpc.util.MutableHandlerRegistry;
 
 import com.alipay.remoting.util.StringUtils;


### PR DESCRIPTION
Specified IP addresses can be listened to to prevent risks caused by all-zero listening.

Motivation:
When I used Nacos, I noticed that the jraft port was listening on all zeros. Upon reviewing the Nacos source code, I found that it passed an IP address when creating the jraft server, but sofa-jraft still opted to listen on all zeros, which could introduce some security risks.

Modification:
Determine whether the incoming endpoint contains an IP address. If it does, listen directly on that IP; otherwise, continue to listen on all interfaces with an IP address of 0.

Result:
Specified IP addresses can be listened to to prevent risks caused by all-zero listening.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved server setup by explicitly specifying the network address, enhancing connection reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->