### PR TITLE
参考BDBLogStorage 基于ChronicleMap、MapDB、H2MVStore、LevelDB-Java实现的日志存储 

### DIFF
--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -1,0 +1,165 @@
+name: build-macos
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  check_format:
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up JDK 17
+        uses: actions/setup-java@v3
+        with:
+          distribution: temurin
+          java-version: 17
+      - name: Check format
+        run: mvn clean install -DskipTests=true -Dmaven.javadoc.skip=true -B -V
+          && sh ./tools/check_format.sh
+
+  test_jraft_core:
+    needs: check_format
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up JDK 17
+        uses: actions/setup-java@v3
+        with:
+          distribution: temurin
+          java-version: 17
+      - name: Maven Test
+        run: mvn clean install -DskipTests=true -Dmaven.javadoc.skip=true -B -V
+          && (mvn --projects jraft-core test
+            || mvn --projects jraft-core test
+            || mvn --projects jraft-core test)
+
+  test_rheakv_core:
+    needs: check_format
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up JDK 17
+        uses: actions/setup-java@v3
+        with:
+          distribution: temurin
+          java-version: 17
+      - name: Maven Test
+        run: mvn clean install -DskipTests=true -Dmaven.javadoc.skip=true -B -V
+          && (mvn --projects jraft-rheakv/rheakv-core test
+            || mvn --projects jraft-rheakv/rheakv-core test
+            || mvn --projects jraft-rheakv/rheakv-core test)
+
+  test_rheakv_pd:
+    needs: check_format
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up JDK 17
+        uses: actions/setup-java@v3
+        with:
+          distribution: temurin
+          java-version: 17
+      - name: Maven Test
+        run: mvn clean install -DskipTests=true -Dmaven.javadoc.skip=true -B -V
+          && (mvn --projects jraft-rheakv/rheakv-pd test
+            || mvn --projects jraft-rheakv/rheakv-pd test
+            || mvn --projects jraft-rheakv/rheakv-pd test)
+
+  test_rpc_grpc_impl:
+    needs: check_format
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up JDK 17
+        uses: actions/setup-java@v3
+        with:
+          distribution: temurin
+          java-version: 17
+      - name: Maven Test
+        run: mvn clean install -DskipTests=true -Dmaven.javadoc.skip=true -B -V
+          && (mvn --projects jraft-extension/rpc-grpc-impl test
+            || mvn --projects jraft-extension/rpc-grpc-impl test
+            || mvn --projects jraft-extension/rpc-grpc-impl test)
+            
+  test_leveldb_log_storage_impl:
+    needs: check_format
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up JDK 17
+        uses: actions/setup-java@v3
+        with:
+          distribution: temurin
+          java-version: 17
+      - name: Maven Test
+        run: mvn clean install -DskipTests=true -Dmaven.javadoc.skip=true -B -V
+          && (mvn --projects jraft-extension/leveldb-log-storage-impl test
+            || mvn --projects jraft-extension/leveldb-log-storage-impl test
+            || mvn --projects jraft-extension/leveldb-log-storage-impl test)
+
+  test_h2mvstore_log_storage_impl:
+    needs: check_format
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up JDK 17
+        uses: actions/setup-java@v3
+        with:
+          distribution: temurin
+          java-version: 17
+      - name: Maven Test
+        run: mvn clean install -DskipTests=true -Dmaven.javadoc.skip=true -B -V
+          && (mvn --projects jraft-extension/h2mvstore-log-storage-impl test
+            || mvn --projects jraft-extension/h2mvstore-log-storage-impl test
+            || mvn --projects jraft-extension/h2mvstore-log-storage-impl test)
+
+  test_mapdb_log_storage_impl:
+    needs: check_format
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up JDK 17
+        uses: actions/setup-java@v3
+        with:
+          distribution: temurin
+          java-version: 17
+      - name: Maven Test
+        run: mvn clean install -DskipTests=true -Dmaven.javadoc.skip=true -B -V
+          && (mvn --projects jraft-extension/mapdb-log-storage-impl test
+            || mvn --projects jraft-extension/mapdb-log-storage-impl test
+            || mvn --projects jraft-extension/mapdb-log-storage-impl test)
+
+  test_chroniclemap_log_storage_impl:
+    needs: check_format
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up JDK 17
+        uses: actions/setup-java@v3
+        with:
+          distribution: temurin
+          java-version: 17
+      - name: Maven Test
+        run: mvn clean install -DskipTests=true -Dmaven.javadoc.skip=true -B -V
+          && (mvn --projects jraft-extension/chronicle-map-log-storage-impl test
+            || mvn --projects jraft-extension/chronicle-map-log-storage-impl test
+            || mvn --projects jraft-extension/chronicle-map-log-storage-impl test)
+
+  test_bdb_log_storage_impl:
+    needs: check_format
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up JDK 17
+        uses: actions/setup-java@v3
+        with:
+          distribution: temurin
+          java-version: 17
+      - name: Maven Test
+        run: mvn clean install -DskipTests=true -Dmaven.javadoc.skip=true -B -V
+          && (mvn --projects jraft-extension/bdb-log-storage-impl test
+            || mvn --projects jraft-extension/bdb-log-storage-impl test
+            || mvn --projects jraft-extension/bdb-log-storage-impl test)

--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -137,11 +137,11 @@ jobs:
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@v2
-      - name: Set up JDK 17
+      - name: Set up JDK 8
         uses: actions/setup-java@v3
         with:
           distribution: temurin
-          java-version: 17
+          java-version: 8
       - name: Maven Test
         run: mvn clean install -DskipTests=true -Dmaven.javadoc.skip=true -B -V
           && (mvn --projects jraft-extension/chronicle-map-log-storage-impl test

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -153,11 +153,11 @@ jobs:
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@v2
-      - name: Set up JDK 17
+      - name: Set up JDK 8
         uses: actions/setup-java@v3
         with:
           distribution: temurin
-          java-version: 17
+          java-version: 8
       - name: Maven Test
         shell: bash
         run: |

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -1,0 +1,185 @@
+name: build-windows
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  check_format:
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up JDK 17
+        uses: actions/setup-java@v3
+        with:
+          distribution: temurin
+          java-version: 17
+      - name: Check format
+        shell: bash
+        run: |
+          mvn clean install -DskipTests=true -Dmaven.javadoc.skip=true -B -V
+          sh ./tools/check_format.sh
+
+  test_jraft_core:
+    needs: check_format
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up JDK 17
+        uses: actions/setup-java@v3
+        with:
+          distribution: temurin
+          java-version: 17
+      - name: Maven Test
+        shell: bash
+        run: |
+          mvn clean install -DskipTests=true -Dmaven.javadoc.skip=true -B -V
+          (mvn --projects jraft-core test \
+          || mvn --projects jraft-core test \
+          || mvn --projects jraft-core test)
+
+  test_rheakv_core:
+    needs: check_format
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up JDK 17
+        uses: actions/setup-java@v3
+        with:
+          distribution: temurin
+          java-version: 17
+      - name: Maven Test
+        shell: bash
+        run: |
+          mvn clean install -DskipTests=true -Dmaven.javadoc.skip=true -B -V
+          (mvn --projects jraft-rheakv/rheakv-core test \
+          || mvn --projects jraft-rheakv/rheakv-core test \
+          || mvn --projects jraft-rheakv/rheakv-core test)
+
+  test_rheakv_pd:
+    needs: check_format
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up JDK 17
+        uses: actions/setup-java@v3
+        with:
+          distribution: temurin
+          java-version: 17
+      - name: Maven Test
+        shell: bash
+        run: |
+          mvn clean install -DskipTests=true -Dmaven.javadoc.skip=true -B -V
+          (mvn --projects jraft-rheakv/rheakv-pd test \
+          || mvn --projects jraft-rheakv/rheakv-pd test \
+          || mvn --projects jraft-rheakv/rheakv-pd test)
+
+  test_rpc_grpc_impl:
+    needs: check_format
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up JDK 17
+        uses: actions/setup-java@v3
+        with:
+          distribution: temurin
+          java-version: 17
+      - name: Maven Test
+        shell: bash
+        run: |
+          mvn clean install -DskipTests=true -Dmaven.javadoc.skip=true -B -V
+          (mvn --projects jraft-extension/rpc-grpc-impl test \
+          || mvn --projects jraft-extension/rpc-grpc-impl test \
+          || mvn --projects jraft-extension/rpc-grpc-impl test)
+
+  test_leveldb_log_storage_impl:
+    needs: check_format
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up JDK 17
+        uses: actions/setup-java@v3
+        with:
+          distribution: temurin
+          java-version: 17
+      - name: Maven Test
+        shell: bash
+        run: |
+          mvn clean install -DskipTests=true -Dmaven.javadoc.skip=true -B -V
+          (mvn --projects jraft-extension/leveldb-log-storage-impl test \
+          || mvn --projects jraft-extension/leveldb-log-storage-impl test \
+          || mvn --projects jraft-extension/leveldb-log-storage-impl test)
+
+  test_h2mvstore_log_storage_impl:
+    needs: check_format
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up JDK 17
+        uses: actions/setup-java@v3
+        with:
+          distribution: temurin
+          java-version: 17
+      - name: Maven Test
+        shell: bash
+        run: |
+          mvn clean install -DskipTests=true -Dmaven.javadoc.skip=true -B -V
+          (mvn --projects jraft-extension/h2mvstore-log-storage-impl test \
+          || mvn --projects jraft-extension/h2mvstore-log-storage-impl test \
+          || mvn --projects jraft-extension/h2mvstore-log-storage-impl test)
+
+  test_mapdb_log_storage_impl:
+    needs: check_format
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up JDK 17
+        uses: actions/setup-java@v3
+        with:
+          distribution: temurin
+          java-version: 17
+      - name: Maven Test
+        shell: bash
+        run: |
+          mvn clean install -DskipTests=true -Dmaven.javadoc.skip=true -B -V
+          (mvn --projects jraft-extension/mapdb-log-storage-impl test \
+          || mvn --projects jraft-extension/mapdb-log-storage-impl test \
+          || mvn --projects jraft-extension/mapdb-log-storage-impl test)
+
+  test_chroniclemap_log_storage_impl:
+    needs: check_format
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up JDK 17
+        uses: actions/setup-java@v3
+        with:
+          distribution: temurin
+          java-version: 17
+      - name: Maven Test
+        shell: bash
+        run: |
+          mvn clean install -DskipTests=true -Dmaven.javadoc.skip=true -B -V
+          (mvn --projects jraft-extension/chronicle-map-log-storage-impl test \
+          || mvn --projects jraft-extension/chronicle-map-log-storage-impl test \
+          || mvn --projects jraft-extension/chronicle-map-log-storage-impl test)
+
+  test_bdb_log_storage_impl:
+    needs: check_format
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up JDK 17
+        uses: actions/setup-java@v3
+        with:
+          distribution: temurin
+          java-version: 17
+      - name: Maven Test
+        shell: bash
+        run: |
+          mvn clean install -DskipTests=true -Dmaven.javadoc.skip=true -B -V
+          (mvn --projects jraft-extension/bdb-log-storage-impl test \
+          || mvn --projects jraft-extension/bdb-log-storage-impl test \
+          || mvn --projects jraft-extension/bdb-log-storage-impl test)

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -137,11 +137,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - name: Set up JDK 17
+      - name: Set up JDK 8
         uses: actions/setup-java@v3
         with:
           distribution: temurin
-          java-version: 17
+          java-version: 8
       - name: Maven Test
         run: mvn clean install -DskipTests=true -Dmaven.javadoc.skip=true -B -V
           && (mvn --projects jraft-extension/chronicle-map-log-storage-impl test

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -134,7 +134,7 @@ jobs:
 
   test_chroniclemap_log_storage_impl:
     needs: check_format
-    runs-on: windows-latest
+    runs-on: fedora-latest
     steps:
       - uses: actions/checkout@v2
       - name: Set up JDK 17

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -134,7 +134,7 @@ jobs:
 
   test_chroniclemap_log_storage_impl:
     needs: check_format
-    runs-on: ubuntu-latest
+    runs-on: windows-latest
     steps:
       - uses: actions/checkout@v2
       - name: Set up JDK 17

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -134,7 +134,7 @@ jobs:
 
   test_chroniclemap_log_storage_impl:
     needs: check_format
-    runs-on: fedora-latest
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
       - name: Set up JDK 17

--- a/jraft-extension/chronicle-map-log-storage-impl/pom.xml
+++ b/jraft-extension/chronicle-map-log-storage-impl/pom.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <artifactId>jraft-extension</artifactId>
+        <groupId>com.alipay.sofa</groupId>
+        <version>1.4.0</version>
+    </parent>
+
+    <artifactId>chronicle-map-log-storage-impl</artifactId>
+    <packaging>jar</packaging>
+    <name>chronicle-map-log-storage-impl ${project.version}</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.alipay.sofa</groupId>
+            <artifactId>jraft-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>net.openhft</groupId>
+            <artifactId>chronicle-map</artifactId>
+            <version>3.27ea1</version>
+        </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/jraft-extension/chronicle-map-log-storage-impl/src/main/java/com/alipay/sofa/jraft/core/ChronicleMapLogStorageJRaftServiceFactory.java
+++ b/jraft-extension/chronicle-map-log-storage-impl/src/main/java/com/alipay/sofa/jraft/core/ChronicleMapLogStorageJRaftServiceFactory.java
@@ -1,0 +1,36 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alipay.sofa.jraft.core;
+
+import com.alipay.sofa.jraft.option.RaftOptions;
+import com.alipay.sofa.jraft.storage.LogStorage;
+import com.alipay.sofa.jraft.storage.impl.ChronicleMapLogStorage;
+import com.alipay.sofa.jraft.util.SPI;
+
+/**
+ * override createLogStorage
+ *
+ * @author jiachun.fjc
+ */
+@SPI(priority = 1)
+public class ChronicleMapLogStorageJRaftServiceFactory extends DefaultJRaftServiceFactory {
+
+    @Override
+    public LogStorage createLogStorage(String uri, RaftOptions raftOptions) {
+        return new ChronicleMapLogStorage(uri, raftOptions);
+    }
+}

--- a/jraft-extension/chronicle-map-log-storage-impl/src/main/java/com/alipay/sofa/jraft/core/ChronicleMapLogStorageJRaftServiceFactory.java
+++ b/jraft-extension/chronicle-map-log-storage-impl/src/main/java/com/alipay/sofa/jraft/core/ChronicleMapLogStorageJRaftServiceFactory.java
@@ -24,7 +24,7 @@ import com.alipay.sofa.jraft.util.SPI;
 /**
  * override createLogStorage
  *
- * @author jiachun.fjc
+ * @author knightblood
  */
 @SPI(priority = 1)
 public class ChronicleMapLogStorageJRaftServiceFactory extends DefaultJRaftServiceFactory {

--- a/jraft-extension/chronicle-map-log-storage-impl/src/main/java/com/alipay/sofa/jraft/storage/impl/ChronicleMapLogStorage.java
+++ b/jraft-extension/chronicle-map-log-storage-impl/src/main/java/com/alipay/sofa/jraft/storage/impl/ChronicleMapLogStorage.java
@@ -52,7 +52,7 @@ import com.alipay.sofa.jraft.util.Utils;
 /**
  * Log storage based on Chronicle Map.
  *
- * @author jiachun.fjc
+ * @author knightblood
  */
 public class ChronicleMapLogStorage implements LogStorage, Describer {
 

--- a/jraft-extension/chronicle-map-log-storage-impl/src/main/java/com/alipay/sofa/jraft/storage/impl/ChronicleMapLogStorage.java
+++ b/jraft-extension/chronicle-map-log-storage-impl/src/main/java/com/alipay/sofa/jraft/storage/impl/ChronicleMapLogStorage.java
@@ -1,0 +1,498 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alipay.sofa.jraft.storage.impl;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReadWriteLock;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
+import java.util.Iterator;
+
+import com.alipay.sofa.jraft.util.ThreadPoolsFactory;
+import org.apache.commons.io.FileUtils;
+import org.apache.commons.io.IOUtils;
+import net.openhft.chronicle.map.ChronicleMap;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.alipay.sofa.jraft.conf.Configuration;
+import com.alipay.sofa.jraft.conf.ConfigurationEntry;
+import com.alipay.sofa.jraft.conf.ConfigurationManager;
+import com.alipay.sofa.jraft.entity.EnumOutter.EntryType;
+import com.alipay.sofa.jraft.entity.LogEntry;
+import com.alipay.sofa.jraft.entity.LogId;
+import com.alipay.sofa.jraft.entity.codec.LogEntryDecoder;
+import com.alipay.sofa.jraft.entity.codec.LogEntryEncoder;
+import com.alipay.sofa.jraft.option.LogStorageOptions;
+import com.alipay.sofa.jraft.option.RaftOptions;
+import com.alipay.sofa.jraft.storage.LogStorage;
+import com.alipay.sofa.jraft.util.Bits;
+import com.alipay.sofa.jraft.util.BytesUtil;
+import com.alipay.sofa.jraft.util.Describer;
+import com.alipay.sofa.jraft.util.Requires;
+import com.alipay.sofa.jraft.util.Utils;
+
+/**
+ * Log storage based on Chronicle Map.
+ *
+ * @author jiachun.fjc
+ */
+public class ChronicleMapLogStorage implements LogStorage, Describer {
+
+    private static final Logger          LOG               = LoggerFactory.getLogger(ChronicleMapLogStorage.class);
+    static final String                  DEFAULT_MAP_NAME  = "jraft-log";
+    static final String                  CONF_MAP_NAME     = "jraft-conf";
+
+    private String                       groupId;
+    private ChronicleMap<byte[], byte[]> defaultMap;
+    private ChronicleMap<byte[], byte[]> confMap;
+    private final String                 homePath;
+    private boolean                      opened            = false;
+
+    private LogEntryEncoder              logEntryEncoder;
+    private LogEntryDecoder              logEntryDecoder;
+
+    private final ReadWriteLock          readWriteLock     = new ReentrantReadWriteLock();
+    private final Lock                   readLock          = this.readWriteLock.readLock();
+    private final Lock                   writeLock         = this.readWriteLock.writeLock();
+
+    private final boolean                sync;
+
+    private volatile long                firstLogIndex     = 1;
+    private volatile boolean             hasLoadFirstLogIndex;
+
+    /**
+     * First log index and last log index key in configuration column family.
+     */
+    public static final byte[]           FIRST_LOG_IDX_KEY = Utils.getBytes("meta/firstLogIndex");
+
+    public ChronicleMapLogStorage(final String homePath, final RaftOptions raftOptions) {
+        super();
+        Requires.requireNonNull(homePath, "Null homePath");
+        this.homePath = homePath;
+        this.sync = raftOptions.isSync();
+    }
+
+    @Override
+    public boolean init(LogStorageOptions opts) {
+        Requires.requireNonNull(opts, "Null LogStorageOptions opts");
+        Requires.requireNonNull(opts.getConfigurationManager(), "Null conf manager");
+        Requires.requireNonNull(opts.getLogEntryCodecFactory(), "Null log entry codec factory");
+        this.groupId = opts.getGroupId();
+        this.logEntryDecoder = opts.getLogEntryCodecFactory().decoder();
+        this.logEntryEncoder = opts.getLogEntryCodecFactory().encoder();
+        this.writeLock.lock();
+        try {
+            if (this.defaultMap != null) {
+                LOG.warn("ChronicleMapLogStorage init() already.");
+                return true;
+            }
+            initAndLoad(opts.getConfigurationManager());
+            return true;
+        } catch (Exception e) {
+            LOG.error("Fail to init ChronicleMapLogStorage, path={}.", this.homePath, e);
+        } finally {
+            this.writeLock.unlock();
+        }
+        return false;
+    }
+
+    private void openDatabase() throws Exception {
+        if (this.opened) {
+            return;
+        }
+        final File databaseHomeDir = new File(homePath);
+        FileUtils.forceMkdir(databaseHomeDir);
+
+        File defaultMapFile = new File(databaseHomeDir, "chronicle-map-log.dat");
+        File confMapFile = new File(databaseHomeDir, "chronicle-map-conf.dat");
+
+        // 使用正确的Chronicle Map构建方法
+        this.defaultMap = ChronicleMap.of(byte[].class, byte[].class).name(DEFAULT_MAP_NAME).entries(1_000_000L)
+            .averageKeySize(8).averageValueSize(128).createPersistedTo(defaultMapFile);
+
+        this.confMap = ChronicleMap.of(byte[].class, byte[].class).name(CONF_MAP_NAME).entries(10_000L)
+            .averageKeySize(8).averageValueSize(128).createPersistedTo(confMapFile);
+
+        this.opened = true;
+    }
+
+    private void load(final ConfigurationManager confManager) {
+        try {
+            for (byte[] keyBytes : this.confMap.keySet()) {
+                final byte[] valueBytes = this.confMap.get(keyBytes);
+                if (keyBytes.length == Long.BYTES) {
+                    final LogEntry entry = this.logEntryDecoder.decode(valueBytes);
+                    if (entry != null) {
+                        if (entry.getType() == EntryType.ENTRY_TYPE_CONFIGURATION) {
+                            final ConfigurationEntry confEntry = new ConfigurationEntry();
+                            confEntry.setId(new LogId(entry.getId().getIndex(), entry.getId().getTerm()));
+                            confEntry.setConf(new Configuration(entry.getPeers(), entry.getLearners()));
+                            if (entry.getOldPeers() != null) {
+                                confEntry.setOldConf(new Configuration(entry.getOldPeers(), entry.getOldLearners()));
+                            }
+                            if (confManager != null) {
+                                confManager.add(confEntry);
+                            }
+                        }
+                    } else {
+                        LOG.warn("Fail to decode conf entry at index {}, the log data is: {}.",
+                            Bits.getLong(keyBytes, 0), BytesUtil.toHex(valueBytes));
+                    }
+                } else if (Arrays.equals(FIRST_LOG_IDX_KEY, keyBytes)) {
+                    // FIRST_LOG_IDX_KEY storage
+                    setFirstLogIndex(Bits.getLong(valueBytes, 0));
+                    truncatePrefixInBackground(0L, this.firstLogIndex);
+                } else {
+                    // Unknown entry
+                    LOG.warn("Unknown entry in configuration storage key={}, value={}.", BytesUtil.toHex(keyBytes),
+                        BytesUtil.toHex(valueBytes));
+                }
+            }
+        } catch (Exception e) {
+            LOG.error("Fail to load confMap.", e);
+        }
+    }
+
+    private void initAndLoad(final ConfigurationManager confManager) throws Exception {
+        this.hasLoadFirstLogIndex = false;
+        this.firstLogIndex = 1;
+        openDatabase();
+        load(confManager);
+    }
+
+    private void closeDatabase() {
+        this.opened = false;
+        try {
+            if (this.defaultMap != null) {
+                this.defaultMap.close();
+            }
+            if (this.confMap != null) {
+                this.confMap.close();
+            }
+        } catch (Exception e) {
+            // ignore
+        }
+        this.defaultMap = null;
+        this.confMap = null;
+    }
+
+    @Override
+    public void shutdown() {
+        this.writeLock.lock();
+        try {
+            closeDatabase();
+            LOG.info("ChronicleMapLogStorage shutdown, the db path is: {}.", this.homePath);
+        } finally {
+            this.writeLock.unlock();
+        }
+    }
+
+    @Override
+    public void describe(Printer out) {
+        this.readLock.lock();
+        try {
+            if (opened) {
+                out.println(String.format("Database is opened. the path: %s", this.homePath));
+                out.println("Chronicle Map storage engine");
+            } else {
+                out.println(String.format("Database not open. the path: %s", this.homePath));
+            }
+        } finally {
+            this.readLock.unlock();
+        }
+    }
+
+    private void setFirstLogIndex(long firstLogIndex) {
+        this.firstLogIndex = firstLogIndex;
+        this.hasLoadFirstLogIndex = true;
+    }
+
+    @Override
+    public long getFirstLogIndex() {
+        this.readLock.lock();
+        try {
+            if (this.hasLoadFirstLogIndex) {
+                return this.firstLogIndex;
+            }
+            checkState();
+            try {
+                // Chronicle Map doesn't provide a direct way to get the first key
+                // We need to iterate through the keys to find the minimum
+                long firstLogIndex = Long.MAX_VALUE;
+                boolean found = false;
+                for (byte[] keyBytes : this.defaultMap.keySet()) {
+                    if (keyBytes.length == Long.BYTES) {
+                        long index = Bits.getLong(keyBytes, 0);
+                        if (index < firstLogIndex) {
+                            firstLogIndex = index;
+                            found = true;
+                        }
+                    }
+                }
+                if (found) {
+                    saveFirstLogIndex(firstLogIndex);
+                    setFirstLogIndex(firstLogIndex);
+                    return firstLogIndex;
+                }
+            } catch (Exception e) {
+                LOG.error("Fail to get first log index.", e);
+            }
+        } finally {
+            this.readLock.unlock();
+        }
+        return 1L;
+    }
+
+    @Override
+    public long getLastLogIndex() {
+        this.readLock.lock();
+        try {
+            checkState();
+            try {
+                // Chronicle Map doesn't provide a direct way to get the last key
+                // We need to iterate through the keys to find the maximum
+                long lastLogIndex = 0;
+                for (byte[] keyBytes : this.defaultMap.keySet()) {
+                    if (keyBytes.length == Long.BYTES) {
+                        long index = Bits.getLong(keyBytes, 0);
+                        if (index > lastLogIndex) {
+                            lastLogIndex = index;
+                        }
+                    }
+                }
+                return lastLogIndex;
+            } catch (Exception e) {
+                LOG.error("Fail to get last log index.", e);
+            }
+        } finally {
+            this.readLock.unlock();
+        }
+        return 0L;
+    }
+
+    @Override
+    public LogEntry getEntry(long index) {
+        this.readLock.lock();
+        try {
+            checkState();
+            if (this.hasLoadFirstLogIndex && index < this.firstLogIndex) {
+                return null;
+            }
+            byte[] key = getKeyBytes(index);
+            byte[] value = this.defaultMap.get(key);
+            return toLogEntry(value);
+        } catch (Exception e) {
+            LOG.error("Fail to get log entry at index {}.", index, e);
+        } finally {
+            this.readLock.unlock();
+        }
+        return null;
+    }
+
+    @Override
+    public long getTerm(long index) {
+        final LogEntry entry = getEntry(index);
+        if (entry != null) {
+            return entry.getId().getTerm();
+        }
+        return 0;
+    }
+
+    @Override
+    public boolean appendEntry(LogEntry entry) {
+        if (entry == null) {
+            return false;
+        }
+        this.readLock.lock();
+        try {
+            checkState();
+            byte[] key = getKeyBytes(entry.getId().getIndex());
+            byte[] value = toByteArray(entry);
+            if (entry.getType() == EntryType.ENTRY_TYPE_CONFIGURATION) {
+                this.confMap.put(key, value);
+            }
+            this.defaultMap.put(key, value);
+            return true;
+        } catch (Exception e) {
+            LOG.error("Fail to append entry {}.", entry, e);
+        } finally {
+            this.readLock.unlock();
+        }
+        return false;
+    }
+
+    @Override
+    public int appendEntries(List<LogEntry> entries) {
+        if (entries == null || entries.isEmpty()) {
+            return 0;
+        }
+        final int entriesCount = entries.size();
+        this.readLock.lock();
+        try {
+            checkState();
+            for (int i = 0; i < entriesCount; i++) {
+                final LogEntry entry = entries.get(i);
+                byte[] key = getKeyBytes(entry.getId().getIndex());
+                byte[] value = toByteArray(entry);
+                if (entry.getType() == EntryType.ENTRY_TYPE_CONFIGURATION) {
+                    this.confMap.put(key, value);
+                }
+                this.defaultMap.put(key, value);
+            }
+            return entriesCount;
+        } catch (Exception e) {
+            LOG.error("Fail to appendEntries. first one = {}, entries count = {}", entries.get(0), entriesCount, e);
+        } finally {
+            this.readLock.unlock();
+        }
+        return 0;
+    }
+
+    @Override
+    public boolean truncatePrefix(long firstIndexKept) {
+        this.readLock.lock();
+        try {
+            checkState();
+            final long startIndex = getFirstLogIndex();
+            final boolean ret = saveFirstLogIndex(firstIndexKept);
+            if (ret) {
+                setFirstLogIndex(firstIndexKept);
+            }
+            truncatePrefixInBackground(startIndex, firstIndexKept);
+            return true;
+        } catch (Exception e) {
+            LOG.error("Fail to truncatePrefix {}.", firstIndexKept, e);
+        } finally {
+            this.readLock.unlock();
+        }
+        return false;
+    }
+
+    @Override
+    public boolean truncateSuffix(long lastIndexKept) {
+        this.readLock.lock();
+        try {
+            checkState();
+            final long lastLogIndex = getLastLogIndex();
+            for (long index = lastIndexKept + 1; index <= lastLogIndex; index++) {
+                byte[] key = getKeyBytes(index);
+                this.confMap.remove(key);
+                this.defaultMap.remove(key);
+            }
+            return true;
+        } catch (Exception e) {
+            LOG.error("Fail to truncateSuffix {}.", lastIndexKept, e);
+        } finally {
+            this.readLock.unlock();
+        }
+        return false;
+    }
+
+    @Override
+    public boolean reset(long nextLogIndex) {
+        if (nextLogIndex <= 0) {
+            throw new IllegalArgumentException("Invalid next log index.");
+        }
+        this.writeLock.lock();
+        try {
+            LogEntry entry = getEntry(nextLogIndex);
+            closeDatabase();
+            FileUtils.deleteDirectory(new File(this.homePath));
+            initAndLoad(null);
+            if (entry == null) {
+                entry = new LogEntry();
+                entry.setType(EntryType.ENTRY_TYPE_NO_OP);
+                entry.setId(new LogId(nextLogIndex, 0));
+                LOG.warn("Entry not found for nextLogIndex {} when reset.", nextLogIndex);
+            }
+            return appendEntry(entry);
+        } catch (Exception e) {
+            LOG.error("Fail to reset next log index.", e);
+        } finally {
+            this.writeLock.unlock();
+        }
+        return false;
+    }
+
+    protected byte[] getKeyBytes(final long index) {
+        final byte[] ks = new byte[8];
+        Bits.putLong(ks, 0, index);
+        return ks;
+    }
+
+    protected LogEntry toLogEntry(byte[] value) {
+        if (value == null || value.length == 0) {
+            return null;
+        }
+        return this.logEntryDecoder.decode(value);
+    }
+
+    protected byte[] toByteArray(LogEntry logEntry) {
+        return this.logEntryEncoder.encode(logEntry);
+    }
+
+    /**
+     * Save the first log index into confMap
+     */
+    private boolean saveFirstLogIndex(final long firstLogIndex) {
+        this.readLock.lock();
+        try {
+            checkState();
+            byte[] firstLogIndexValue = getKeyBytes(firstLogIndex);
+            this.confMap.put(FIRST_LOG_IDX_KEY, firstLogIndexValue);
+            return true;
+        } catch (Exception e) {
+            LOG.error("Fail to save first log index {}.", firstLogIndex, e);
+        } finally {
+            this.readLock.unlock();
+        }
+        return false;
+    }
+
+    /**
+     * [startIndex, firstIndexKept)
+     */
+    private void truncatePrefixInBackground(final long startIndex, final long firstIndexKept) {
+        if (startIndex > firstIndexKept) {
+            return;
+        }
+        // delete logs in background.
+        ThreadPoolsFactory.runInThread(this.groupId, () -> {
+            this.readLock.lock();
+            try {
+                checkState();
+                for (long index = startIndex; index < firstIndexKept; index++) {
+                    byte[] key = getKeyBytes(index);
+                    this.confMap.remove(key); // Delete it first; otherwise, it may never be deleted
+                    this.defaultMap.remove(key);
+                }
+            } catch (Exception e) {
+                LOG.error("Fail to truncatePrefix {}.", firstIndexKept, e);
+            } finally {
+                this.readLock.unlock();
+            }
+        });
+    }
+
+    private void checkState() {
+        Requires.requireTrue(opened, "Database not open. the path: %s", this.homePath);
+    }
+}

--- a/jraft-extension/chronicle-map-log-storage-impl/src/main/resources/META-INF/services/com.alipay.sofa.jraft.JRaftServiceFactory
+++ b/jraft-extension/chronicle-map-log-storage-impl/src/main/resources/META-INF/services/com.alipay.sofa.jraft.JRaftServiceFactory
@@ -1,0 +1,1 @@
+com.alipay.sofa.jraft.core.ChronicleMapLogStorageJRaftServiceFactory

--- a/jraft-extension/chronicle-map-log-storage-impl/src/test/java/com/alipay/sofa/jraft/storage/BaseStorageTest.java
+++ b/jraft-extension/chronicle-map-log-storage-impl/src/test/java/com/alipay/sofa/jraft/storage/BaseStorageTest.java
@@ -1,0 +1,49 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alipay.sofa.jraft.storage;
+
+import java.io.File;
+import java.io.IOException;
+
+import org.apache.commons.io.FileUtils;
+import org.junit.After;
+import org.junit.Before;
+
+import com.alipay.sofa.jraft.test.TestUtils;
+
+public class BaseStorageTest {
+
+    protected String path;
+
+    @Before
+    public void setup() throws Exception {
+        this.path = TestUtils.mkTempDir();
+        FileUtils.forceMkdir(new File(this.path));
+    }
+
+    @After
+    public void teardown() throws Exception {
+        FileUtils.deleteDirectory(new File(this.path));
+    }
+
+    protected String writeData() throws IOException {
+        File file = new File(this.path + File.separator + "data");
+        String data = "jraft is great!";
+        FileUtils.writeStringToFile(file, data);
+        return data;
+    }
+}

--- a/jraft-extension/chronicle-map-log-storage-impl/src/test/java/com/alipay/sofa/jraft/storage/impl/BaseLogStorageTest.java
+++ b/jraft-extension/chronicle-map-log-storage-impl/src/test/java/com/alipay/sofa/jraft/storage/impl/BaseLogStorageTest.java
@@ -199,7 +199,7 @@ public abstract class BaseLogStorageTest extends BaseStorageTest {
         final int batch = 100;
 
         appendLargeEntries(totalLogs, logSize, batch);
-        
+
         final long cost = Utils.monotonicMs() - start;
         System.out.println("Write " + totalLogs + " logs, cost " + cost + " ms.");
 

--- a/jraft-extension/chronicle-map-log-storage-impl/src/test/java/com/alipay/sofa/jraft/storage/impl/BaseLogStorageTest.java
+++ b/jraft-extension/chronicle-map-log-storage-impl/src/test/java/com/alipay/sofa/jraft/storage/impl/BaseLogStorageTest.java
@@ -1,0 +1,254 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alipay.sofa.jraft.storage.impl;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import com.alipay.sofa.jraft.JRaftUtils;
+import com.alipay.sofa.jraft.conf.ConfigurationEntry;
+import com.alipay.sofa.jraft.conf.ConfigurationManager;
+import com.alipay.sofa.jraft.entity.EnumOutter;
+import com.alipay.sofa.jraft.entity.LogEntry;
+import com.alipay.sofa.jraft.entity.LogId;
+import com.alipay.sofa.jraft.entity.codec.LogEntryCodecFactory;
+import com.alipay.sofa.jraft.entity.codec.v2.LogEntryV2CodecFactory;
+import com.alipay.sofa.jraft.option.LogStorageOptions;
+import com.alipay.sofa.jraft.storage.BaseStorageTest;
+import com.alipay.sofa.jraft.storage.LogStorage;
+import com.alipay.sofa.jraft.test.TestUtils;
+import com.alipay.sofa.jraft.util.Utils;
+
+public abstract class BaseLogStorageTest extends BaseStorageTest {
+    protected LogStorage         logStorage;
+    private ConfigurationManager confManager;
+    private LogEntryCodecFactory logEntryCodecFactory;
+
+    @Override
+    @Before
+    public void setup() throws Exception {
+        super.setup();
+        this.confManager = new ConfigurationManager();
+        this.logEntryCodecFactory = LogEntryV2CodecFactory.getInstance();
+        this.logStorage = newLogStorage();
+
+        final LogStorageOptions opts = newLogStorageOptions();
+
+        this.logStorage.init(opts);
+    }
+
+    protected abstract LogStorage newLogStorage();
+
+    protected LogStorageOptions newLogStorageOptions() {
+        final LogStorageOptions opts = new LogStorageOptions();
+        opts.setConfigurationManager(this.confManager);
+        opts.setLogEntryCodecFactory(this.logEntryCodecFactory);
+        return opts;
+    }
+
+    @Override
+    @After
+    public void teardown() throws Exception {
+        this.logStorage.shutdown();
+        super.teardown();
+    }
+
+    @Test
+    public void testEmptyState() {
+        assertEquals(1, this.logStorage.getFirstLogIndex());
+        assertEquals(0, this.logStorage.getLastLogIndex());
+        assertNull(this.logStorage.getEntry(100));
+    }
+
+    @Test
+    public void testAddOneEntryState() {
+        final LogEntry entry1 = TestUtils.mockEntry(100, 1);
+        assertTrue(this.logStorage.appendEntry(entry1));
+
+        assertEquals(100, this.logStorage.getFirstLogIndex());
+        assertEquals(100, this.logStorage.getLastLogIndex());
+        Assert.assertEquals(entry1, this.logStorage.getEntry(100));
+        LogEntry logEntry1 = this.logStorage.getEntry(100);
+        assertNotNull(logEntry1);
+        assertEquals(entry1, logEntry1);
+        assertEquals(1, logEntry1.getId().getTerm());
+
+        final LogEntry entry2 = TestUtils.mockEntry(200, 2);
+        assertTrue(this.logStorage.appendEntry(entry2));
+
+        assertEquals(100, this.logStorage.getFirstLogIndex());
+        assertEquals(200, this.logStorage.getLastLogIndex());
+
+        logEntry1 = this.logStorage.getEntry(100);
+        final LogEntry logEntry2 = this.logStorage.getEntry(200);
+        assertNotNull(logEntry1);
+        assertNotNull(logEntry2);
+
+        Assert.assertEquals(entry1, logEntry1);
+        Assert.assertEquals(entry2, logEntry2);
+
+        assertEquals(1, logEntry1.getId().getTerm());
+        assertEquals(2, logEntry2.getId().getTerm());
+    }
+
+    @Test
+    public void testLoadWithConfigManager() {
+        assertTrue(this.confManager.getLastConfiguration().isEmpty());
+
+        final LogEntry confEntry1 = new LogEntry(EnumOutter.EntryType.ENTRY_TYPE_CONFIGURATION);
+        confEntry1.setId(new LogId(99, 1));
+        confEntry1.setPeers(JRaftUtils.getConfiguration("localhost:8081,localhost:8082").listPeers());
+
+        final LogEntry confEntry2 = new LogEntry(EnumOutter.EntryType.ENTRY_TYPE_CONFIGURATION);
+        confEntry2.setId(new LogId(100, 2));
+        confEntry2.setPeers(JRaftUtils.getConfiguration("localhost:8081,localhost:8082,localhost:8083").listPeers());
+
+        assertTrue(this.logStorage.appendEntry(confEntry1));
+        assertEquals(1, this.logStorage.appendEntries(Arrays.asList(confEntry2)));
+
+        // reload log storage.
+        this.logStorage.shutdown();
+        this.logStorage = newLogStorage();
+        this.logStorage.init(newLogStorageOptions());
+
+        ConfigurationEntry conf = this.confManager.getLastConfiguration();
+        assertNotNull(conf);
+        assertFalse(conf.isEmpty());
+        assertEquals("localhost:8081,localhost:8082,localhost:8083", conf.getConf().toString());
+        conf = this.confManager.get(99);
+        assertNotNull(conf);
+        assertFalse(conf.isEmpty());
+        assertEquals("localhost:8081,localhost:8082", conf.getConf().toString());
+    }
+
+    @Test
+    public void testAddManyEntries() {
+        final List<LogEntry> entries = TestUtils.mockEntries();
+
+        assertEquals(10, this.logStorage.appendEntries(entries));
+
+        assertEquals(0, this.logStorage.getFirstLogIndex());
+        assertEquals(9, this.logStorage.getLastLogIndex());
+        for (int i = 0; i < 10; i++) {
+            final LogEntry entry = this.logStorage.getEntry(i);
+            assertEquals(i, entry.getId().getTerm());
+            assertNotNull(entry);
+            assertEquals(entries.get(i), entry);
+        }
+    }
+
+    @Test
+    public void testReset() {
+        testAddManyEntries();
+        this.logStorage.reset(5);
+        assertEquals(5, this.logStorage.getFirstLogIndex());
+        assertEquals(5, this.logStorage.getLastLogIndex());
+        final LogEntry logEntry = this.logStorage.getEntry(5);
+        assertNotNull(logEntry);
+        assertEquals(5, logEntry.getId().getTerm());
+    }
+
+    @Test
+    public void testTruncatePrefix() {
+        final List<LogEntry> entries = TestUtils.mockEntries();
+
+        assertEquals(10, this.logStorage.appendEntries(entries));
+        this.logStorage.truncatePrefix(5);
+        assertEquals(5, this.logStorage.getFirstLogIndex());
+        assertEquals(9, this.logStorage.getLastLogIndex());
+        for (int i = 0; i < 10; i++) {
+            if (i < 5) {
+                assertNull(this.logStorage.getEntry(i));
+            } else {
+                Assert.assertEquals(entries.get(i), this.logStorage.getEntry(i));
+            }
+        }
+    }
+
+    @Test
+    public void testAppendManyLargeEntries() {
+        final long start = Utils.monotonicMs();
+        final int totalLogs = 100000;
+        final int logSize = 16 * 1024;
+        final int batch = 100;
+
+        appendLargeEntries(totalLogs, logSize, batch);
+        
+        final long cost = Utils.monotonicMs() - start;
+        System.out.println("Write " + totalLogs + " logs, cost " + cost + " ms.");
+
+        // verify
+        for (int i = 0; i < totalLogs; i++) {
+            final LogEntry entry = this.logStorage.getEntry(i);
+            assertNotNull(entry);
+            assertEquals(logSize, entry.getData().remaining());
+            assertEquals(i, entry.getId().getIndex());
+            assertEquals(i, entry.getId().getTerm());
+        }
+    }
+
+    protected void appendLargeEntries(final int totalLogs, final int logSize, final int batch) {
+        for (int i = 0; i < totalLogs; i += batch) {
+            final List<LogEntry> entries = new ArrayList<>(batch);
+            for (int j = 0; j < batch; j++) {
+                entries.add(TestUtils.mockEntry(i + j, i + j, logSize));
+            }
+            final int nAppended = this.logStorage.appendEntries(entries);
+            assertEquals(batch, nAppended);
+        }
+    }
+
+    @Test
+    public void testTruncateSuffix() {
+        final List<LogEntry> entries = TestUtils.mockEntries();
+        assertEquals(10, this.logStorage.appendEntries(entries));
+
+        this.logStorage.truncateSuffix(5);
+        assertEquals(0, this.logStorage.getFirstLogIndex());
+        assertEquals(5, this.logStorage.getLastLogIndex());
+        for (int i = 0; i < 10; i++) {
+            if (i <= 5) {
+                Assert.assertEquals(entries.get(i), this.logStorage.getEntry(i));
+            } else {
+                assertNull(this.logStorage.getEntry(i));
+            }
+        }
+    }
+
+    @Test
+    public void testGetTerm() {
+        final List<LogEntry> entries = TestUtils.mockEntries();
+        assertEquals(10, this.logStorage.appendEntries(entries));
+
+        assertEquals(0, this.logStorage.getTerm(100));
+        for (int i = 0; i < 10; i++) {
+            assertEquals(i, this.logStorage.getTerm(i));
+        }
+    }
+}

--- a/jraft-extension/chronicle-map-log-storage-impl/src/test/java/com/alipay/sofa/jraft/storage/impl/ChronicleMapLogStorageTest.java
+++ b/jraft-extension/chronicle-map-log-storage-impl/src/test/java/com/alipay/sofa/jraft/storage/impl/ChronicleMapLogStorageTest.java
@@ -1,0 +1,28 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alipay.sofa.jraft.storage.impl;
+
+import com.alipay.sofa.jraft.option.RaftOptions;
+import com.alipay.sofa.jraft.storage.LogStorage;
+
+public class ChronicleMapLogStorageTest extends BaseLogStorageTest {
+
+    @Override
+    protected LogStorage newLogStorage() {
+        return new ChronicleMapLogStorage(this.path, new RaftOptions());
+    }
+}

--- a/jraft-extension/chronicle-map-log-storage-impl/src/test/java/com/alipay/sofa/jraft/test/TestUtils.java
+++ b/jraft-extension/chronicle-map-log-storage-impl/src/test/java/com/alipay/sofa/jraft/test/TestUtils.java
@@ -1,0 +1,137 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alipay.sofa.jraft.test;
+
+import java.lang.management.ManagementFactory;
+import java.lang.management.ThreadInfo;
+import java.lang.management.ThreadMXBean;
+import java.net.Inet4Address;
+import java.net.InetAddress;
+import java.net.NetworkInterface;
+import java.net.SocketException;
+import java.nio.ByteBuffer;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.Enumeration;
+import java.util.List;
+import java.util.concurrent.ThreadLocalRandom;
+
+import com.alipay.sofa.jraft.JRaftUtils;
+import com.alipay.sofa.jraft.conf.ConfigurationEntry;
+import com.alipay.sofa.jraft.entity.EnumOutter;
+import com.alipay.sofa.jraft.entity.LogEntry;
+import com.alipay.sofa.jraft.entity.LogId;
+import com.alipay.sofa.jraft.entity.PeerId;
+import com.alipay.sofa.jraft.rpc.RpcRequests;
+import com.alipay.sofa.jraft.util.Endpoint;
+
+/**
+ * Test helper
+ *
+ * @author boyan (boyan@alibaba-inc.com)
+ *
+ *         2018-Apr-11 10:16:07 AM
+ */
+public class TestUtils {
+
+    public static ConfigurationEntry getConfEntry(final String confStr, final String oldConfStr) {
+        ConfigurationEntry entry = new ConfigurationEntry();
+        entry.setConf(JRaftUtils.getConfiguration(confStr));
+        entry.setOldConf(JRaftUtils.getConfiguration(oldConfStr));
+        return entry;
+    }
+
+    public static void dumpThreads() {
+        try {
+            ThreadMXBean bean = ManagementFactory.getThreadMXBean();
+            ThreadInfo[] infos = bean.dumpAllThreads(true, true);
+            for (ThreadInfo info : infos) {
+                System.out.println(info);
+            }
+        } catch (Throwable t) {
+            t.printStackTrace(); // NOPMD
+        }
+    }
+
+    public static String mkTempDir() {
+        return Paths.get(System.getProperty("java.io.tmpdir", "/tmp"), "jraft_test_" + System.nanoTime()).toString();
+    }
+
+    public static LogEntry mockEntry(final int index, final int term) {
+        return mockEntry(index, term, 0);
+    }
+
+    public static LogEntry mockEntry(final int index, final int term, final int dataSize) {
+        LogEntry entry = new LogEntry(EnumOutter.EntryType.ENTRY_TYPE_NO_OP);
+        entry.setId(new LogId(index, term));
+        if (dataSize > 0) {
+            byte[] bs = new byte[dataSize];
+            ThreadLocalRandom.current().nextBytes(bs);
+            entry.setData(ByteBuffer.wrap(bs));
+        }
+        return entry;
+    }
+
+    public static List<LogEntry> mockEntries() {
+        return mockEntries(10);
+    }
+
+    public static List<LogEntry> mockEntries(final int n) {
+        List<LogEntry> entries = new ArrayList<>();
+        for (int i = 0; i < n; i++) {
+            LogEntry entry = mockEntry(i, i);
+            if (i > 0) {
+                entry.setData(ByteBuffer.wrap(String.valueOf(i).getBytes()));
+            }
+            entries.add(entry);
+        }
+        return entries;
+    }
+
+    public static String getMyIp() {
+        String ip = null;
+        try {
+            Enumeration<NetworkInterface> interfaces = NetworkInterface.getNetworkInterfaces();
+            while (interfaces.hasMoreElements()) {
+                NetworkInterface iface = interfaces.nextElement();
+                // filters out 127.0.0.1 and inactive interfaces
+                if (iface.isLoopback() || !iface.isUp()) {
+                    continue;
+                }
+                Enumeration<InetAddress> addresses = iface.getInetAddresses();
+                while (addresses.hasMoreElements()) {
+                    InetAddress addr = addresses.nextElement();
+                    if (addr instanceof Inet4Address) {
+                        ip = addr.getHostAddress();
+                        break;
+                    }
+                }
+            }
+        } catch (SocketException e) {
+            e.printStackTrace();
+        }
+        return ip;
+    }
+
+    public static List<PeerId> generatePeers(int num) {
+        List<PeerId> peers = new ArrayList<>();
+        for (int i = 0; i < num; i++) {
+            peers.add(new PeerId("localhost", 8080 + i));
+        }
+        return peers;
+    }
+}

--- a/jraft-extension/h2mvstore-log-storage-impl/pom.xml
+++ b/jraft-extension/h2mvstore-log-storage-impl/pom.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <artifactId>jraft-extension</artifactId>
+        <groupId>com.alipay.sofa</groupId>
+        <version>1.4.0</version>
+    </parent>
+
+    <artifactId>h2mvstore-log-storage-impl</artifactId>
+    <packaging>jar</packaging>
+    <name>h2mvstore-log-storage-impl ${project.version}</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.alipay.sofa</groupId>
+            <artifactId>jraft-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.h2database</groupId>
+            <artifactId>h2</artifactId>
+            <version>2.2.224</version>
+        </dependency>
+        <dependency>
+            <groupId>com.h2database</groupId>
+            <artifactId>h2-mvstore</artifactId>
+            <version>2.2.224</version>
+        </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/jraft-extension/h2mvstore-log-storage-impl/src/main/java/com/alipay/sofa/jraft/core/H2MVStoreLogStorageJRaftServiceFactory.java
+++ b/jraft-extension/h2mvstore-log-storage-impl/src/main/java/com/alipay/sofa/jraft/core/H2MVStoreLogStorageJRaftServiceFactory.java
@@ -1,0 +1,36 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alipay.sofa.jraft.core;
+
+import com.alipay.sofa.jraft.option.RaftOptions;
+import com.alipay.sofa.jraft.storage.LogStorage;
+import com.alipay.sofa.jraft.storage.impl.H2MVStoreLogStorage;
+import com.alipay.sofa.jraft.util.SPI;
+
+/**
+ * override createLogStorage
+ *
+ * @author jiachun.fjc
+ */
+@SPI(priority = 1)
+public class H2MVStoreLogStorageJRaftServiceFactory extends DefaultJRaftServiceFactory {
+
+    @Override
+    public LogStorage createLogStorage(String uri, RaftOptions raftOptions) {
+        return new H2MVStoreLogStorage(uri, raftOptions);
+    }
+}

--- a/jraft-extension/h2mvstore-log-storage-impl/src/main/java/com/alipay/sofa/jraft/core/H2MVStoreLogStorageJRaftServiceFactory.java
+++ b/jraft-extension/h2mvstore-log-storage-impl/src/main/java/com/alipay/sofa/jraft/core/H2MVStoreLogStorageJRaftServiceFactory.java
@@ -24,7 +24,7 @@ import com.alipay.sofa.jraft.util.SPI;
 /**
  * override createLogStorage
  *
- * @author jiachun.fjc
+ * @author knightblood
  */
 @SPI(priority = 1)
 public class H2MVStoreLogStorageJRaftServiceFactory extends DefaultJRaftServiceFactory {

--- a/jraft-extension/h2mvstore-log-storage-impl/src/main/java/com/alipay/sofa/jraft/storage/impl/H2MVStoreLogStorage.java
+++ b/jraft-extension/h2mvstore-log-storage-impl/src/main/java/com/alipay/sofa/jraft/storage/impl/H2MVStoreLogStorage.java
@@ -1,0 +1,480 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alipay.sofa.jraft.storage.impl;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReadWriteLock;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
+
+import com.alipay.sofa.jraft.util.ThreadPoolsFactory;
+import org.apache.commons.io.FileUtils;
+import org.apache.commons.io.IOUtils;
+import org.h2.mvstore.MVMap;
+import org.h2.mvstore.MVStore;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.alipay.sofa.jraft.conf.Configuration;
+import com.alipay.sofa.jraft.conf.ConfigurationEntry;
+import com.alipay.sofa.jraft.conf.ConfigurationManager;
+import com.alipay.sofa.jraft.entity.EnumOutter.EntryType;
+import com.alipay.sofa.jraft.entity.LogEntry;
+import com.alipay.sofa.jraft.entity.LogId;
+import com.alipay.sofa.jraft.entity.codec.LogEntryDecoder;
+import com.alipay.sofa.jraft.entity.codec.LogEntryEncoder;
+import com.alipay.sofa.jraft.option.LogStorageOptions;
+import com.alipay.sofa.jraft.option.RaftOptions;
+import com.alipay.sofa.jraft.storage.LogStorage;
+import com.alipay.sofa.jraft.util.Bits;
+import com.alipay.sofa.jraft.util.BytesUtil;
+import com.alipay.sofa.jraft.util.Describer;
+import com.alipay.sofa.jraft.util.Requires;
+import com.alipay.sofa.jraft.util.Utils;
+
+/**
+ * Log storage based on H2 MVStore.
+ *
+ * @author jiachun.fjc
+ */
+public class H2MVStoreLogStorage implements LogStorage, Describer {
+
+    private static final Logger   LOG               = LoggerFactory.getLogger(H2MVStoreLogStorage.class);
+    static final String           DEFAULT_MAP_NAME  = "jraft-log";
+    static final String           CONF_MAP_NAME     = "jraft-conf";
+
+    private String                groupId;
+    private MVMap<byte[], byte[]> defaultMap;
+    private MVMap<byte[], byte[]> confMap;
+    private MVStore               db;
+    private final String          homePath;
+    private boolean               opened            = false;
+
+    private LogEntryEncoder       logEntryEncoder;
+    private LogEntryDecoder       logEntryDecoder;
+
+    private final ReadWriteLock   readWriteLock     = new ReentrantReadWriteLock();
+    private final Lock            readLock          = this.readWriteLock.readLock();
+    private final Lock            writeLock         = this.readWriteLock.writeLock();
+
+    private final boolean         sync;
+
+    private volatile long         firstLogIndex     = 1;
+    private volatile boolean      hasLoadFirstLogIndex;
+
+    /**
+     * First log index and last log index key in configuration column family.
+     */
+    public static final byte[]    FIRST_LOG_IDX_KEY = Utils.getBytes("meta/firstLogIndex");
+
+    public H2MVStoreLogStorage(final String homePath, final RaftOptions raftOptions) {
+        super();
+        Requires.requireNonNull(homePath, "Null homePath");
+        this.homePath = homePath;
+        this.sync = raftOptions.isSync();
+    }
+
+    @Override
+    public boolean init(LogStorageOptions opts) {
+        Requires.requireNonNull(opts, "Null LogStorageOptions opts");
+        Requires.requireNonNull(opts.getConfigurationManager(), "Null conf manager");
+        Requires.requireNonNull(opts.getLogEntryCodecFactory(), "Null log entry codec factory");
+        this.groupId = opts.getGroupId();
+        this.logEntryDecoder = opts.getLogEntryCodecFactory().decoder();
+        this.logEntryEncoder = opts.getLogEntryCodecFactory().encoder();
+        this.writeLock.lock();
+        try {
+            if (this.db != null) {
+                LOG.warn("H2MVStoreLogStorage init() already.");
+                return true;
+            }
+            initAndLoad(opts.getConfigurationManager());
+            return true;
+        } catch (Exception e) {
+            LOG.error("Fail to init H2MVStoreLogStorage, path={}.", this.homePath, e);
+        } finally {
+            this.writeLock.unlock();
+        }
+        return false;
+    }
+
+    private void openDatabase() throws Exception {
+        if (this.opened) {
+            return;
+        }
+        final File databaseHomeDir = new File(homePath);
+        FileUtils.forceMkdir(databaseHomeDir);
+
+        MVStore.Builder builder = new MVStore.Builder();
+        builder.fileName(new File(databaseHomeDir, "h2-mvstore-log.db").getAbsolutePath());
+        builder.autoCommitDisabled();
+        // For H2 MVStore, we control the commit manually, so no need to set autoCommitDelay
+        this.db = builder.open();
+        this.defaultMap = this.db.openMap(DEFAULT_MAP_NAME);
+        this.confMap = this.db.openMap(CONF_MAP_NAME);
+        this.opened = true;
+    }
+
+    private void load(final ConfigurationManager confManager) {
+        try {
+            for (byte[] keyBytes : this.confMap.keyList()) {
+                final byte[] valueBytes = this.confMap.get(keyBytes);
+                if (keyBytes.length == Long.BYTES) {
+                    final LogEntry entry = this.logEntryDecoder.decode(valueBytes);
+                    if (entry != null) {
+                        if (entry.getType() == EntryType.ENTRY_TYPE_CONFIGURATION) {
+                            final ConfigurationEntry confEntry = new ConfigurationEntry();
+                            confEntry.setId(new LogId(entry.getId().getIndex(), entry.getId().getTerm()));
+                            confEntry.setConf(new Configuration(entry.getPeers(), entry.getLearners()));
+                            if (entry.getOldPeers() != null) {
+                                confEntry.setOldConf(new Configuration(entry.getOldPeers(), entry.getOldLearners()));
+                            }
+                            if (confManager != null) {
+                                confManager.add(confEntry);
+                            }
+                        }
+                    } else {
+                        LOG.warn("Fail to decode conf entry at index {}, the log data is: {}.",
+                            Bits.getLong(keyBytes, 0), BytesUtil.toHex(valueBytes));
+                    }
+                } else if (Arrays.equals(FIRST_LOG_IDX_KEY, keyBytes)) {
+                    // FIRST_LOG_IDX_KEY storage
+                    setFirstLogIndex(Bits.getLong(valueBytes, 0));
+                    truncatePrefixInBackground(0L, this.firstLogIndex);
+                } else {
+                    // Unknown entry
+                    LOG.warn("Unknown entry in configuration storage key={}, value={}.", BytesUtil.toHex(keyBytes),
+                        BytesUtil.toHex(valueBytes));
+                }
+            }
+        } catch (Exception e) {
+            LOG.error("Fail to load confMap.", e);
+        }
+    }
+
+    private void initAndLoad(final ConfigurationManager confManager) throws Exception {
+        this.hasLoadFirstLogIndex = false;
+        this.firstLogIndex = 1;
+        openDatabase();
+        load(confManager);
+    }
+
+    private void closeDatabase() {
+        this.opened = false;
+        try {
+            if (this.db != null) {
+                this.db.close();
+            }
+        } catch (Exception e) {
+            // ignore
+        }
+        this.db = null;
+        this.defaultMap = null;
+        this.confMap = null;
+    }
+
+    @Override
+    public void shutdown() {
+        this.writeLock.lock();
+        try {
+            closeDatabase();
+            LOG.info("H2MVStoreLogStorage shutdown, the db path is: {}.", this.homePath);
+        } finally {
+            this.writeLock.unlock();
+        }
+    }
+
+    @Override
+    public void describe(Printer out) {
+        this.readLock.lock();
+        try {
+            if (opened) {
+                out.println(String.format("Database is opened. the path: %s", this.homePath));
+                out.println("H2 MVStore storage engine");
+            } else {
+                out.println(String.format("Database not open. the path: %s", this.homePath));
+            }
+        } finally {
+            this.readLock.unlock();
+        }
+    }
+
+    private void setFirstLogIndex(long firstLogIndex) {
+        this.firstLogIndex = firstLogIndex;
+        this.hasLoadFirstLogIndex = true;
+    }
+
+    @Override
+    public long getFirstLogIndex() {
+        this.readLock.lock();
+        try {
+            if (this.hasLoadFirstLogIndex) {
+                return this.firstLogIndex;
+            }
+            checkState();
+            try {
+                byte[] firstKey = this.defaultMap.firstKey();
+                if (firstKey != null) {
+                    final long firstLogIndex = Bits.getLong(firstKey, 0);
+                    saveFirstLogIndex(firstLogIndex);
+                    setFirstLogIndex(firstLogIndex);
+                    return firstLogIndex;
+                }
+            } catch (Exception e) {
+                LOG.error("Fail to get first log index.", e);
+            }
+        } finally {
+            this.readLock.unlock();
+        }
+        return 1L;
+    }
+
+    @Override
+    public long getLastLogIndex() {
+        this.readLock.lock();
+        try {
+            checkState();
+            try {
+                byte[] lastKey = this.defaultMap.lastKey();
+                if (lastKey != null) {
+                    return Bits.getLong(lastKey, 0);
+                }
+            } catch (Exception e) {
+                LOG.error("Fail to get last log index.", e);
+            }
+        } finally {
+            this.readLock.unlock();
+        }
+        return 0L;
+    }
+
+    @Override
+    public LogEntry getEntry(long index) {
+        this.readLock.lock();
+        try {
+            checkState();
+            if (this.hasLoadFirstLogIndex && index < this.firstLogIndex) {
+                return null;
+            }
+            byte[] key = getKeyBytes(index);
+            byte[] value = this.defaultMap.get(key);
+            return toLogEntry(value);
+        } catch (Exception e) {
+            LOG.error("Fail to get log entry at index {}.", index, e);
+        } finally {
+            this.readLock.unlock();
+        }
+        return null;
+    }
+
+    @Override
+    public long getTerm(long index) {
+        final LogEntry entry = getEntry(index);
+        if (entry != null) {
+            return entry.getId().getTerm();
+        }
+        return 0;
+    }
+
+    @Override
+    public boolean appendEntry(LogEntry entry) {
+        if (entry == null) {
+            return false;
+        }
+        this.readLock.lock();
+        try {
+            checkState();
+            byte[] key = getKeyBytes(entry.getId().getIndex());
+            byte[] value = toByteArray(entry);
+            if (entry.getType() == EntryType.ENTRY_TYPE_CONFIGURATION) {
+                this.confMap.put(key, value);
+            }
+            this.defaultMap.put(key, value);
+            this.db.commit();
+            return true;
+        } catch (Exception e) {
+            LOG.error("Fail to append entry {}.", entry, e);
+        } finally {
+            this.readLock.unlock();
+        }
+        return false;
+    }
+
+    @Override
+    public int appendEntries(List<LogEntry> entries) {
+        if (entries == null || entries.isEmpty()) {
+            return 0;
+        }
+        final int entriesCount = entries.size();
+        this.readLock.lock();
+        try {
+            checkState();
+            for (int i = 0; i < entriesCount; i++) {
+                final LogEntry entry = entries.get(i);
+                byte[] key = getKeyBytes(entry.getId().getIndex());
+                byte[] value = toByteArray(entry);
+                if (entry.getType() == EntryType.ENTRY_TYPE_CONFIGURATION) {
+                    this.confMap.put(key, value);
+                }
+                this.defaultMap.put(key, value);
+            }
+            this.db.commit();
+            return entriesCount;
+        } catch (Exception e) {
+            LOG.error("Fail to appendEntries. first one = {}, entries count = {}", entries.get(0), entriesCount, e);
+        } finally {
+            this.readLock.unlock();
+        }
+        return 0;
+    }
+
+    @Override
+    public boolean truncatePrefix(long firstIndexKept) {
+        this.readLock.lock();
+        try {
+            checkState();
+            final long startIndex = getFirstLogIndex();
+            final boolean ret = saveFirstLogIndex(firstIndexKept);
+            if (ret) {
+                setFirstLogIndex(firstIndexKept);
+            }
+            truncatePrefixInBackground(startIndex, firstIndexKept);
+            return true;
+        } catch (Exception e) {
+            LOG.error("Fail to truncatePrefix {}.", firstIndexKept, e);
+        } finally {
+            this.readLock.unlock();
+        }
+        return false;
+    }
+
+    @Override
+    public boolean truncateSuffix(long lastIndexKept) {
+        this.readLock.lock();
+        try {
+            checkState();
+            final long lastLogIndex = getLastLogIndex();
+            for (long index = lastIndexKept + 1; index <= lastLogIndex; index++) {
+                byte[] key = getKeyBytes(index);
+                this.confMap.remove(key);
+                this.defaultMap.remove(key);
+            }
+            this.db.commit();
+            return true;
+        } catch (Exception e) {
+            LOG.error("Fail to truncateSuffix {}.", lastIndexKept, e);
+        } finally {
+            this.readLock.unlock();
+        }
+        return false;
+    }
+
+    @Override
+    public boolean reset(long nextLogIndex) {
+        if (nextLogIndex <= 0) {
+            throw new IllegalArgumentException("Invalid next log index.");
+        }
+        this.writeLock.lock();
+        try {
+            LogEntry entry = getEntry(nextLogIndex);
+            closeDatabase();
+            FileUtils.deleteDirectory(new File(this.homePath));
+            initAndLoad(null);
+            if (entry == null) {
+                entry = new LogEntry();
+                entry.setType(EntryType.ENTRY_TYPE_NO_OP);
+                entry.setId(new LogId(nextLogIndex, 0));
+                LOG.warn("Entry not found for nextLogIndex {} when reset.", nextLogIndex);
+            }
+            return appendEntry(entry);
+        } catch (Exception e) {
+            LOG.error("Fail to reset next log index.", e);
+        } finally {
+            this.writeLock.unlock();
+        }
+        return false;
+    }
+
+    protected byte[] getKeyBytes(final long index) {
+        final byte[] ks = new byte[8];
+        Bits.putLong(ks, 0, index);
+        return ks;
+    }
+
+    protected LogEntry toLogEntry(byte[] value) {
+        if (value == null || value.length == 0) {
+            return null;
+        }
+        return this.logEntryDecoder.decode(value);
+    }
+
+    protected byte[] toByteArray(LogEntry logEntry) {
+        return this.logEntryEncoder.encode(logEntry);
+    }
+
+    /**
+     * Save the first log index into confMap
+     */
+    private boolean saveFirstLogIndex(final long firstLogIndex) {
+        this.readLock.lock();
+        try {
+            checkState();
+            byte[] firstLogIndexValue = getKeyBytes(firstLogIndex);
+            this.confMap.put(FIRST_LOG_IDX_KEY, firstLogIndexValue);
+            this.db.commit();
+            return true;
+        } catch (Exception e) {
+            LOG.error("Fail to save first log index {}.", firstLogIndex, e);
+        } finally {
+            this.readLock.unlock();
+        }
+        return false;
+    }
+
+    /**
+     * [startIndex, firstIndexKept)
+     */
+    private void truncatePrefixInBackground(final long startIndex, final long firstIndexKept) {
+        if (startIndex > firstIndexKept) {
+            return;
+        }
+        // delete logs in background.
+        ThreadPoolsFactory.runInThread(this.groupId, () -> {
+            this.readLock.lock();
+            try {
+                checkState();
+                for (long index = startIndex; index < firstIndexKept; index++) {
+                    byte[] key = getKeyBytes(index);
+                    this.confMap.remove(key); // Delete it first; otherwise, it may never be deleted
+                    this.defaultMap.remove(key);
+                }
+                this.db.commit();
+            } catch (Exception e) {
+                LOG.error("Fail to truncatePrefix {}.", firstIndexKept, e);
+            } finally {
+                this.readLock.unlock();
+            }
+        });
+    }
+
+    private void checkState() {
+        Requires.requireTrue(opened, "Database not open. the path: %s", this.homePath);
+    }
+}

--- a/jraft-extension/h2mvstore-log-storage-impl/src/main/java/com/alipay/sofa/jraft/storage/impl/H2MVStoreLogStorage.java
+++ b/jraft-extension/h2mvstore-log-storage-impl/src/main/java/com/alipay/sofa/jraft/storage/impl/H2MVStoreLogStorage.java
@@ -52,7 +52,7 @@ import com.alipay.sofa.jraft.util.Utils;
 /**
  * Log storage based on H2 MVStore.
  *
- * @author jiachun.fjc
+ * @author knightblood
  */
 public class H2MVStoreLogStorage implements LogStorage, Describer {
 

--- a/jraft-extension/h2mvstore-log-storage-impl/src/main/resources/META-INF/services/com.alipay.sofa.jraft.JRaftServiceFactory
+++ b/jraft-extension/h2mvstore-log-storage-impl/src/main/resources/META-INF/services/com.alipay.sofa.jraft.JRaftServiceFactory
@@ -1,0 +1,1 @@
+com.alipay.sofa.jraft.core.H2MVStoreLogStorageJRaftServiceFactory

--- a/jraft-extension/h2mvstore-log-storage-impl/src/test/java/com/alipay/sofa/jraft/storage/BaseStorageTest.java
+++ b/jraft-extension/h2mvstore-log-storage-impl/src/test/java/com/alipay/sofa/jraft/storage/BaseStorageTest.java
@@ -1,0 +1,49 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alipay.sofa.jraft.storage;
+
+import java.io.File;
+import java.io.IOException;
+
+import org.apache.commons.io.FileUtils;
+import org.junit.After;
+import org.junit.Before;
+
+import com.alipay.sofa.jraft.test.TestUtils;
+
+public class BaseStorageTest {
+
+    protected String path;
+
+    @Before
+    public void setup() throws Exception {
+        this.path = TestUtils.mkTempDir();
+        FileUtils.forceMkdir(new File(this.path));
+    }
+
+    @After
+    public void teardown() throws Exception {
+        FileUtils.deleteDirectory(new File(this.path));
+    }
+
+    protected String writeData() throws IOException {
+        File file = new File(this.path + File.separator + "data");
+        String data = "jraft is great!";
+        FileUtils.writeStringToFile(file, data);
+        return data;
+    }
+}

--- a/jraft-extension/h2mvstore-log-storage-impl/src/test/java/com/alipay/sofa/jraft/storage/impl/BaseLogStorageTest.java
+++ b/jraft-extension/h2mvstore-log-storage-impl/src/test/java/com/alipay/sofa/jraft/storage/impl/BaseLogStorageTest.java
@@ -199,7 +199,7 @@ public abstract class BaseLogStorageTest extends BaseStorageTest {
         final int batch = 100;
 
         appendLargeEntries(totalLogs, logSize, batch);
-        
+
         final long cost = Utils.monotonicMs() - start;
         System.out.println("Write " + totalLogs + " logs, cost " + cost + " ms.");
 

--- a/jraft-extension/h2mvstore-log-storage-impl/src/test/java/com/alipay/sofa/jraft/storage/impl/BaseLogStorageTest.java
+++ b/jraft-extension/h2mvstore-log-storage-impl/src/test/java/com/alipay/sofa/jraft/storage/impl/BaseLogStorageTest.java
@@ -1,0 +1,254 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alipay.sofa.jraft.storage.impl;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import com.alipay.sofa.jraft.JRaftUtils;
+import com.alipay.sofa.jraft.conf.ConfigurationEntry;
+import com.alipay.sofa.jraft.conf.ConfigurationManager;
+import com.alipay.sofa.jraft.entity.EnumOutter;
+import com.alipay.sofa.jraft.entity.LogEntry;
+import com.alipay.sofa.jraft.entity.LogId;
+import com.alipay.sofa.jraft.entity.codec.LogEntryCodecFactory;
+import com.alipay.sofa.jraft.entity.codec.v2.LogEntryV2CodecFactory;
+import com.alipay.sofa.jraft.option.LogStorageOptions;
+import com.alipay.sofa.jraft.storage.BaseStorageTest;
+import com.alipay.sofa.jraft.storage.LogStorage;
+import com.alipay.sofa.jraft.test.TestUtils;
+import com.alipay.sofa.jraft.util.Utils;
+
+public abstract class BaseLogStorageTest extends BaseStorageTest {
+    protected LogStorage         logStorage;
+    private ConfigurationManager confManager;
+    private LogEntryCodecFactory logEntryCodecFactory;
+
+    @Override
+    @Before
+    public void setup() throws Exception {
+        super.setup();
+        this.confManager = new ConfigurationManager();
+        this.logEntryCodecFactory = LogEntryV2CodecFactory.getInstance();
+        this.logStorage = newLogStorage();
+
+        final LogStorageOptions opts = newLogStorageOptions();
+
+        this.logStorage.init(opts);
+    }
+
+    protected abstract LogStorage newLogStorage();
+
+    protected LogStorageOptions newLogStorageOptions() {
+        final LogStorageOptions opts = new LogStorageOptions();
+        opts.setConfigurationManager(this.confManager);
+        opts.setLogEntryCodecFactory(this.logEntryCodecFactory);
+        return opts;
+    }
+
+    @Override
+    @After
+    public void teardown() throws Exception {
+        this.logStorage.shutdown();
+        super.teardown();
+    }
+
+    @Test
+    public void testEmptyState() {
+        assertEquals(1, this.logStorage.getFirstLogIndex());
+        assertEquals(0, this.logStorage.getLastLogIndex());
+        assertNull(this.logStorage.getEntry(100));
+    }
+
+    @Test
+    public void testAddOneEntryState() {
+        final LogEntry entry1 = TestUtils.mockEntry(100, 1);
+        assertTrue(this.logStorage.appendEntry(entry1));
+
+        assertEquals(100, this.logStorage.getFirstLogIndex());
+        assertEquals(100, this.logStorage.getLastLogIndex());
+        Assert.assertEquals(entry1, this.logStorage.getEntry(100));
+        LogEntry logEntry1 = this.logStorage.getEntry(100);
+        assertNotNull(logEntry1);
+        assertEquals(entry1, logEntry1);
+        assertEquals(1, logEntry1.getId().getTerm());
+
+        final LogEntry entry2 = TestUtils.mockEntry(200, 2);
+        assertTrue(this.logStorage.appendEntry(entry2));
+
+        assertEquals(100, this.logStorage.getFirstLogIndex());
+        assertEquals(200, this.logStorage.getLastLogIndex());
+
+        logEntry1 = this.logStorage.getEntry(100);
+        final LogEntry logEntry2 = this.logStorage.getEntry(200);
+        assertNotNull(logEntry1);
+        assertNotNull(logEntry2);
+
+        Assert.assertEquals(entry1, logEntry1);
+        Assert.assertEquals(entry2, logEntry2);
+
+        assertEquals(1, logEntry1.getId().getTerm());
+        assertEquals(2, logEntry2.getId().getTerm());
+    }
+
+    @Test
+    public void testLoadWithConfigManager() {
+        assertTrue(this.confManager.getLastConfiguration().isEmpty());
+
+        final LogEntry confEntry1 = new LogEntry(EnumOutter.EntryType.ENTRY_TYPE_CONFIGURATION);
+        confEntry1.setId(new LogId(99, 1));
+        confEntry1.setPeers(JRaftUtils.getConfiguration("localhost:8081,localhost:8082").listPeers());
+
+        final LogEntry confEntry2 = new LogEntry(EnumOutter.EntryType.ENTRY_TYPE_CONFIGURATION);
+        confEntry2.setId(new LogId(100, 2));
+        confEntry2.setPeers(JRaftUtils.getConfiguration("localhost:8081,localhost:8082,localhost:8083").listPeers());
+
+        assertTrue(this.logStorage.appendEntry(confEntry1));
+        assertEquals(1, this.logStorage.appendEntries(Arrays.asList(confEntry2)));
+
+        // reload log storage.
+        this.logStorage.shutdown();
+        this.logStorage = newLogStorage();
+        this.logStorage.init(newLogStorageOptions());
+
+        ConfigurationEntry conf = this.confManager.getLastConfiguration();
+        assertNotNull(conf);
+        assertFalse(conf.isEmpty());
+        assertEquals("localhost:8081,localhost:8082,localhost:8083", conf.getConf().toString());
+        conf = this.confManager.get(99);
+        assertNotNull(conf);
+        assertFalse(conf.isEmpty());
+        assertEquals("localhost:8081,localhost:8082", conf.getConf().toString());
+    }
+
+    @Test
+    public void testAddManyEntries() {
+        final List<LogEntry> entries = TestUtils.mockEntries();
+
+        assertEquals(10, this.logStorage.appendEntries(entries));
+
+        assertEquals(0, this.logStorage.getFirstLogIndex());
+        assertEquals(9, this.logStorage.getLastLogIndex());
+        for (int i = 0; i < 10; i++) {
+            final LogEntry entry = this.logStorage.getEntry(i);
+            assertEquals(i, entry.getId().getTerm());
+            assertNotNull(entry);
+            assertEquals(entries.get(i), entry);
+        }
+    }
+
+    @Test
+    public void testReset() {
+        testAddManyEntries();
+        this.logStorage.reset(5);
+        assertEquals(5, this.logStorage.getFirstLogIndex());
+        assertEquals(5, this.logStorage.getLastLogIndex());
+        final LogEntry logEntry = this.logStorage.getEntry(5);
+        assertNotNull(logEntry);
+        assertEquals(5, logEntry.getId().getTerm());
+    }
+
+    @Test
+    public void testTruncatePrefix() {
+        final List<LogEntry> entries = TestUtils.mockEntries();
+
+        assertEquals(10, this.logStorage.appendEntries(entries));
+        this.logStorage.truncatePrefix(5);
+        assertEquals(5, this.logStorage.getFirstLogIndex());
+        assertEquals(9, this.logStorage.getLastLogIndex());
+        for (int i = 0; i < 10; i++) {
+            if (i < 5) {
+                assertNull(this.logStorage.getEntry(i));
+            } else {
+                Assert.assertEquals(entries.get(i), this.logStorage.getEntry(i));
+            }
+        }
+    }
+
+    @Test
+    public void testAppendManyLargeEntries() {
+        final long start = Utils.monotonicMs();
+        final int totalLogs = 100000;
+        final int logSize = 16 * 1024;
+        final int batch = 100;
+
+        appendLargeEntries(totalLogs, logSize, batch);
+        
+        final long cost = Utils.monotonicMs() - start;
+        System.out.println("Write " + totalLogs + " logs, cost " + cost + " ms.");
+
+        // verify
+        for (int i = 0; i < totalLogs; i++) {
+            final LogEntry entry = this.logStorage.getEntry(i);
+            assertNotNull(entry);
+            assertEquals(logSize, entry.getData().remaining());
+            assertEquals(i, entry.getId().getIndex());
+            assertEquals(i, entry.getId().getTerm());
+        }
+    }
+
+    protected void appendLargeEntries(final int totalLogs, final int logSize, final int batch) {
+        for (int i = 0; i < totalLogs; i += batch) {
+            final List<LogEntry> entries = new ArrayList<>(batch);
+            for (int j = 0; j < batch; j++) {
+                entries.add(TestUtils.mockEntry(i + j, i + j, logSize));
+            }
+            final int nAppended = this.logStorage.appendEntries(entries);
+            assertEquals(batch, nAppended);
+        }
+    }
+
+    @Test
+    public void testTruncateSuffix() {
+        final List<LogEntry> entries = TestUtils.mockEntries();
+        assertEquals(10, this.logStorage.appendEntries(entries));
+
+        this.logStorage.truncateSuffix(5);
+        assertEquals(0, this.logStorage.getFirstLogIndex());
+        assertEquals(5, this.logStorage.getLastLogIndex());
+        for (int i = 0; i < 10; i++) {
+            if (i <= 5) {
+                Assert.assertEquals(entries.get(i), this.logStorage.getEntry(i));
+            } else {
+                assertNull(this.logStorage.getEntry(i));
+            }
+        }
+    }
+
+    @Test
+    public void testGetTerm() {
+        final List<LogEntry> entries = TestUtils.mockEntries();
+        assertEquals(10, this.logStorage.appendEntries(entries));
+
+        assertEquals(0, this.logStorage.getTerm(100));
+        for (int i = 0; i < 10; i++) {
+            assertEquals(i, this.logStorage.getTerm(i));
+        }
+    }
+}

--- a/jraft-extension/h2mvstore-log-storage-impl/src/test/java/com/alipay/sofa/jraft/storage/impl/H2MVStoreLogStorageTest.java
+++ b/jraft-extension/h2mvstore-log-storage-impl/src/test/java/com/alipay/sofa/jraft/storage/impl/H2MVStoreLogStorageTest.java
@@ -1,0 +1,28 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alipay.sofa.jraft.storage.impl;
+
+import com.alipay.sofa.jraft.option.RaftOptions;
+import com.alipay.sofa.jraft.storage.LogStorage;
+
+public class H2MVStoreLogStorageTest extends BaseLogStorageTest {
+
+    @Override
+    protected LogStorage newLogStorage() {
+        return new H2MVStoreLogStorage(this.path, new RaftOptions());
+    }
+}

--- a/jraft-extension/h2mvstore-log-storage-impl/src/test/java/com/alipay/sofa/jraft/test/TestUtils.java
+++ b/jraft-extension/h2mvstore-log-storage-impl/src/test/java/com/alipay/sofa/jraft/test/TestUtils.java
@@ -1,0 +1,137 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alipay.sofa.jraft.test;
+
+import java.lang.management.ManagementFactory;
+import java.lang.management.ThreadInfo;
+import java.lang.management.ThreadMXBean;
+import java.net.Inet4Address;
+import java.net.InetAddress;
+import java.net.NetworkInterface;
+import java.net.SocketException;
+import java.nio.ByteBuffer;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.Enumeration;
+import java.util.List;
+import java.util.concurrent.ThreadLocalRandom;
+
+import com.alipay.sofa.jraft.JRaftUtils;
+import com.alipay.sofa.jraft.conf.ConfigurationEntry;
+import com.alipay.sofa.jraft.entity.EnumOutter;
+import com.alipay.sofa.jraft.entity.LogEntry;
+import com.alipay.sofa.jraft.entity.LogId;
+import com.alipay.sofa.jraft.entity.PeerId;
+import com.alipay.sofa.jraft.rpc.RpcRequests;
+import com.alipay.sofa.jraft.util.Endpoint;
+
+/**
+ * Test helper
+ *
+ * @author boyan (boyan@alibaba-inc.com)
+ *
+ *         2018-Apr-11 10:16:07 AM
+ */
+public class TestUtils {
+
+    public static ConfigurationEntry getConfEntry(final String confStr, final String oldConfStr) {
+        ConfigurationEntry entry = new ConfigurationEntry();
+        entry.setConf(JRaftUtils.getConfiguration(confStr));
+        entry.setOldConf(JRaftUtils.getConfiguration(oldConfStr));
+        return entry;
+    }
+
+    public static void dumpThreads() {
+        try {
+            ThreadMXBean bean = ManagementFactory.getThreadMXBean();
+            ThreadInfo[] infos = bean.dumpAllThreads(true, true);
+            for (ThreadInfo info : infos) {
+                System.out.println(info);
+            }
+        } catch (Throwable t) {
+            t.printStackTrace(); // NOPMD
+        }
+    }
+
+    public static String mkTempDir() {
+        return Paths.get(System.getProperty("java.io.tmpdir", "/tmp"), "jraft_test_" + System.nanoTime()).toString();
+    }
+
+    public static LogEntry mockEntry(final int index, final int term) {
+        return mockEntry(index, term, 0);
+    }
+
+    public static LogEntry mockEntry(final int index, final int term, final int dataSize) {
+        LogEntry entry = new LogEntry(EnumOutter.EntryType.ENTRY_TYPE_NO_OP);
+        entry.setId(new LogId(index, term));
+        if (dataSize > 0) {
+            byte[] bs = new byte[dataSize];
+            ThreadLocalRandom.current().nextBytes(bs);
+            entry.setData(ByteBuffer.wrap(bs));
+        }
+        return entry;
+    }
+
+    public static List<LogEntry> mockEntries() {
+        return mockEntries(10);
+    }
+
+    public static List<LogEntry> mockEntries(final int n) {
+        List<LogEntry> entries = new ArrayList<>();
+        for (int i = 0; i < n; i++) {
+            LogEntry entry = mockEntry(i, i);
+            if (i > 0) {
+                entry.setData(ByteBuffer.wrap(String.valueOf(i).getBytes()));
+            }
+            entries.add(entry);
+        }
+        return entries;
+    }
+
+    public static String getMyIp() {
+        String ip = null;
+        try {
+            Enumeration<NetworkInterface> interfaces = NetworkInterface.getNetworkInterfaces();
+            while (interfaces.hasMoreElements()) {
+                NetworkInterface iface = interfaces.nextElement();
+                // filters out 127.0.0.1 and inactive interfaces
+                if (iface.isLoopback() || !iface.isUp()) {
+                    continue;
+                }
+                Enumeration<InetAddress> addresses = iface.getInetAddresses();
+                while (addresses.hasMoreElements()) {
+                    InetAddress addr = addresses.nextElement();
+                    if (addr instanceof Inet4Address) {
+                        ip = addr.getHostAddress();
+                        break;
+                    }
+                }
+            }
+        } catch (SocketException e) {
+            e.printStackTrace();
+        }
+        return ip;
+    }
+
+    public static List<PeerId> generatePeers(int num) {
+        List<PeerId> peers = new ArrayList<>();
+        for (int i = 0; i < num; i++) {
+            peers.add(new PeerId("localhost", 8080 + i));
+        }
+        return peers;
+    }
+}

--- a/jraft-extension/leveldb-log-storage-impl/pom.xml
+++ b/jraft-extension/leveldb-log-storage-impl/pom.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <artifactId>jraft-extension</artifactId>
+        <groupId>com.alipay.sofa</groupId>
+        <version>1.4.0</version>
+    </parent>
+    <artifactId>leveldb-log-storage-impl</artifactId>
+    <name>leveldb-log-storage-impl ${project.version}</name>
+    <url>http://maven.apache.org</url>
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+    <dependencies>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>jraft-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.iq80.leveldb</groupId>
+            <artifactId>leveldb</artifactId>
+            <version>0.12</version>
+        </dependency>
+        <dependency>
+            <groupId>org.iq80.leveldb</groupId>
+            <artifactId>leveldb-api</artifactId>
+            <version>0.12</version>
+        </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/jraft-extension/leveldb-log-storage-impl/src/main/java/com/alipay/sofa/jraft/core/LevelDBLogStorageJRaftServiceFactory.java
+++ b/jraft-extension/leveldb-log-storage-impl/src/main/java/com/alipay/sofa/jraft/core/LevelDBLogStorageJRaftServiceFactory.java
@@ -1,0 +1,37 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alipay.sofa.jraft.core;
+
+import com.alipay.sofa.jraft.core.DefaultJRaftServiceFactory;
+import com.alipay.sofa.jraft.option.RaftOptions;
+import com.alipay.sofa.jraft.storage.LogStorage;
+import com.alipay.sofa.jraft.storage.impl.LevelDBLogStorage;
+import com.alipay.sofa.jraft.util.SPI;
+
+/**
+ * override createLogStorage
+ * @author jiachun.fjc
+ *
+ */
+@SPI(priority = 1)
+public class LevelDBLogStorageJRaftServiceFactory extends DefaultJRaftServiceFactory {
+
+    @Override
+    public LogStorage createLogStorage(String uri, RaftOptions raftOptions) {
+        return new LevelDBLogStorage(uri, raftOptions);
+    }
+}

--- a/jraft-extension/leveldb-log-storage-impl/src/main/java/com/alipay/sofa/jraft/core/LevelDBLogStorageJRaftServiceFactory.java
+++ b/jraft-extension/leveldb-log-storage-impl/src/main/java/com/alipay/sofa/jraft/core/LevelDBLogStorageJRaftServiceFactory.java
@@ -24,7 +24,7 @@ import com.alipay.sofa.jraft.util.SPI;
 
 /**
  * override createLogStorage
- * @author jiachun.fjc
+ * @author knightblood
  *
  */
 @SPI(priority = 1)

--- a/jraft-extension/leveldb-log-storage-impl/src/main/java/com/alipay/sofa/jraft/storage/impl/LevelDBLogStorage.java
+++ b/jraft-extension/leveldb-log-storage-impl/src/main/java/com/alipay/sofa/jraft/storage/impl/LevelDBLogStorage.java
@@ -1,0 +1,517 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alipay.sofa.jraft.storage.impl;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReadWriteLock;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
+
+import com.alipay.sofa.jraft.util.ThreadPoolsFactory;
+import org.apache.commons.io.FileUtils;
+import org.apache.commons.io.IOUtils;
+import org.iq80.leveldb.DB;
+import org.iq80.leveldb.DBException;
+import org.iq80.leveldb.DBIterator;
+import org.iq80.leveldb.Options;
+import org.iq80.leveldb.WriteBatch;
+import org.iq80.leveldb.WriteOptions;
+import org.iq80.leveldb.impl.Iq80DBFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.alipay.sofa.jraft.conf.Configuration;
+import com.alipay.sofa.jraft.conf.ConfigurationEntry;
+import com.alipay.sofa.jraft.conf.ConfigurationManager;
+import com.alipay.sofa.jraft.entity.EnumOutter.EntryType;
+import com.alipay.sofa.jraft.entity.LogEntry;
+import com.alipay.sofa.jraft.entity.LogId;
+import com.alipay.sofa.jraft.entity.codec.LogEntryDecoder;
+import com.alipay.sofa.jraft.entity.codec.LogEntryEncoder;
+import com.alipay.sofa.jraft.option.LogStorageOptions;
+import com.alipay.sofa.jraft.option.RaftOptions;
+import com.alipay.sofa.jraft.storage.LogStorage;
+import com.alipay.sofa.jraft.util.Bits;
+import com.alipay.sofa.jraft.util.BytesUtil;
+import com.alipay.sofa.jraft.util.Describer;
+import com.alipay.sofa.jraft.util.Requires;
+import com.alipay.sofa.jraft.util.Utils;
+
+/**
+ * Log storage based on leveldb.
+ *
+ * @author jiachun.fjc
+ */
+public class LevelDBLogStorage implements LogStorage, Describer {
+
+    private static final Logger LOG                   = LoggerFactory.getLogger(LevelDBLogStorage.class);
+    static final String         DEFAULT_DATABASE_NAME = "jraft-log";
+    static final String         CONF_DATABASE_NAME    = "jraft-conf";
+
+    private String              groupId;
+    private DB                  defaultDB;
+    private DB                  confDB;
+    private final String        homePath;
+    private boolean             opened                = false;
+
+    private LogEntryEncoder     logEntryEncoder;
+    private LogEntryDecoder     logEntryDecoder;
+
+    private final ReadWriteLock readWriteLock         = new ReentrantReadWriteLock();
+    private final Lock          readLock              = this.readWriteLock.readLock();
+    private final Lock          writeLock             = this.readWriteLock.writeLock();
+
+    private final boolean       sync;
+
+    private volatile long       firstLogIndex         = 1;
+    private volatile boolean    hasLoadFirstLogIndex;
+
+    /**
+     * First log index and last log index key in configuration column family.
+     */
+    public static final byte[]  FIRST_LOG_IDX_KEY     = Utils.getBytes("meta/firstLogIndex");
+
+    public LevelDBLogStorage(final String homePath, final RaftOptions raftOptions) {
+        super();
+        Requires.requireNonNull(homePath, "Null homePath");
+        this.homePath = homePath;
+        this.sync = raftOptions.isSync();
+    }
+
+    @Override
+    public boolean init(LogStorageOptions opts) {
+        Requires.requireNonNull(opts, "Null LogStorageOptions opts");
+        Requires.requireNonNull(opts.getConfigurationManager(), "Null conf manager");
+        Requires.requireNonNull(opts.getLogEntryCodecFactory(), "Null log entry codec factory");
+        this.groupId = opts.getGroupId();
+        this.logEntryDecoder = opts.getLogEntryCodecFactory().decoder();
+        this.logEntryEncoder = opts.getLogEntryCodecFactory().encoder();
+        this.writeLock.lock();
+        try {
+            if (this.defaultDB != null) {
+                LOG.warn("LevelDBLogStorage init() already.");
+                return true;
+            }
+            initAndLoad(opts.getConfigurationManager());
+            return true;
+        } catch (IOException | DBException e) {
+            LOG.error("Fail to init LevelDBLogStorage, path={}.", this.homePath, e);
+        } finally {
+            this.writeLock.unlock();
+        }
+        return false;
+    }
+
+    private void openDatabase() throws DBException, IOException {
+        if (this.opened) {
+            return;
+        }
+        final File databaseHomeDir = new File(homePath);
+        FileUtils.forceMkdir(databaseHomeDir);
+
+        Options options = new Options();
+        options.createIfMissing(true);
+
+        File defaultDBFile = new File(databaseHomeDir, DEFAULT_DATABASE_NAME);
+        File confDBFile = new File(databaseHomeDir, CONF_DATABASE_NAME);
+
+        this.defaultDB = Iq80DBFactory.factory.open(defaultDBFile, options);
+        this.confDB = Iq80DBFactory.factory.open(confDBFile, options);
+        this.opened = true;
+    }
+
+    private void load(final ConfigurationManager confManager) {
+        try (DBIterator iterator = this.confDB.iterator()) {
+            for (iterator.seekToFirst(); iterator.hasNext(); iterator.next()) {
+                final byte[] keyBytes = iterator.peekNext().getKey();
+                final byte[] valueBytes = iterator.peekNext().getValue();
+                if (keyBytes.length == Long.BYTES) {
+                    final LogEntry entry = this.logEntryDecoder.decode(valueBytes);
+                    if (entry != null) {
+                        if (entry.getType() == EntryType.ENTRY_TYPE_CONFIGURATION) {
+                            final ConfigurationEntry confEntry = new ConfigurationEntry();
+                            confEntry.setId(new LogId(entry.getId().getIndex(), entry.getId().getTerm()));
+                            confEntry.setConf(new Configuration(entry.getPeers(), entry.getLearners()));
+                            if (entry.getOldPeers() != null) {
+                                confEntry.setOldConf(new Configuration(entry.getOldPeers(), entry.getOldLearners()));
+                            }
+                            if (confManager != null) {
+                                confManager.add(confEntry);
+                            }
+                        }
+                    } else {
+                        LOG.warn("Fail to decode conf entry at index {}, the log data is: {}.",
+                            Bits.getLong(keyBytes, 0), BytesUtil.toHex(valueBytes));
+                    }
+                } else if (Arrays.equals(FIRST_LOG_IDX_KEY, keyBytes)) {
+                    // FIRST_LOG_IDX_KEY storage
+                    setFirstLogIndex(Bits.getLong(valueBytes, 0));
+                    truncatePrefixInBackground(0L, this.firstLogIndex);
+                } else {
+                    // Unknown entry
+                    LOG.warn("Unknown entry in configuration storage key={}, value={}.", BytesUtil.toHex(keyBytes),
+                        BytesUtil.toHex(valueBytes));
+                }
+            }
+        } catch (IOException e) {
+            LOG.error("Fail to load confDB.", e);
+        }
+    }
+
+    private void initAndLoad(final ConfigurationManager confManager) throws DBException, IOException {
+        this.hasLoadFirstLogIndex = false;
+        this.firstLogIndex = 1;
+        openDatabase();
+        load(confManager);
+    }
+
+    private void closeDatabase() {
+        this.opened = false;
+        try {
+            IOUtils.closeQuietly(this.defaultDB);
+            IOUtils.closeQuietly(this.confDB);
+        } catch (Exception e) {
+            // ignore
+        }
+        this.defaultDB = null;
+        this.confDB = null;
+    }
+
+    @Override
+    public void shutdown() {
+        this.writeLock.lock();
+        try {
+            closeDatabase();
+            LOG.info("LevelDBLogStorage shutdown, the db path is: {}.", this.homePath);
+        } finally {
+            this.writeLock.unlock();
+        }
+    }
+
+    @Override
+    public void describe(Printer out) {
+        this.readLock.lock();
+        try {
+            if (opened) {
+                out.println(String.format("Database is opened. the path: %s", this.homePath));
+                out.println("LevelDB storage engine");
+            } else {
+                out.println(String.format("Database not open. the path: %s", this.homePath));
+            }
+        } finally {
+            this.readLock.unlock();
+        }
+    }
+
+    private void setFirstLogIndex(long firstLogIndex) {
+        this.firstLogIndex = firstLogIndex;
+        this.hasLoadFirstLogIndex = true;
+    }
+
+    @Override
+    public long getFirstLogIndex() {
+        this.readLock.lock();
+        try {
+            if (this.hasLoadFirstLogIndex) {
+                return this.firstLogIndex;
+            }
+            checkState();
+            try (DBIterator iterator = this.defaultDB.iterator()) {
+                iterator.seekToFirst();
+                if (iterator.hasNext()) {
+                    final byte[] keyBytes = iterator.peekNext().getKey();
+                    final long firstLogIndex = Bits.getLong(keyBytes, 0);
+                    saveFirstLogIndex(firstLogIndex);
+                    setFirstLogIndex(firstLogIndex);
+                    return firstLogIndex;
+                }
+            } catch (IOException e) {
+                LOG.error("Fail to get first log index.", e);
+            }
+        } finally {
+            this.readLock.unlock();
+        }
+        return 1L;
+    }
+
+    @Override
+    public long getLastLogIndex() {
+        this.readLock.lock();
+        try {
+            checkState();
+            try (DBIterator iterator = this.defaultDB.iterator()) {
+                iterator.seekToLast();
+                if (iterator.hasNext()) {
+                    final byte[] keyBytes = iterator.peekNext().getKey();
+                    return Bits.getLong(keyBytes, 0);
+                }
+            } catch (IOException e) {
+                LOG.error("Fail to get last log index.", e);
+            }
+        } finally {
+            this.readLock.unlock();
+        }
+        return 0L;
+    }
+
+    @Override
+    public LogEntry getEntry(long index) {
+        this.readLock.lock();
+        try {
+            checkState();
+            if (this.hasLoadFirstLogIndex && index < this.firstLogIndex) {
+                return null;
+            }
+            byte[] key = getKeyBytes(index);
+            byte[] value = this.defaultDB.get(key);
+            return toLogEntry(value);
+        } catch (DBException e) {
+            LOG.error("Fail to get log entry at index {}.", index, e);
+        } finally {
+            this.readLock.unlock();
+        }
+        return null;
+    }
+
+    @Override
+    public long getTerm(long index) {
+        final LogEntry entry = getEntry(index);
+        if (entry != null) {
+            return entry.getId().getTerm();
+        }
+        return 0;
+    }
+
+    @Override
+    public boolean appendEntry(LogEntry entry) {
+        if (entry == null) {
+            return false;
+        }
+        this.readLock.lock();
+        try {
+            checkState();
+            byte[] key = getKeyBytes(entry.getId().getIndex());
+            byte[] value = toByteArray(entry);
+            WriteBatch batch = this.defaultDB.createWriteBatch();
+            try {
+                if (entry.getType() == EntryType.ENTRY_TYPE_CONFIGURATION) {
+                    this.confDB.put(key, value);
+                }
+                batch.put(key, value);
+                WriteOptions writeOpts = new WriteOptions();
+                writeOpts.sync(this.sync);
+                this.defaultDB.write(batch, writeOpts);
+                return true;
+            } finally {
+                IOUtils.closeQuietly(batch);
+            }
+        } catch (DBException e) {
+            LOG.error("Fail to append entry {}.", entry, e);
+        } finally {
+            this.readLock.unlock();
+        }
+        return false;
+    }
+
+    @Override
+    public int appendEntries(List<LogEntry> entries) {
+        if (entries == null || entries.isEmpty()) {
+            return 0;
+        }
+        final int entriesCount = entries.size();
+        this.readLock.lock();
+        try {
+            checkState();
+            WriteBatch batch = this.defaultDB.createWriteBatch();
+            try {
+                for (int i = 0; i < entriesCount; i++) {
+                    final LogEntry entry = entries.get(i);
+                    byte[] key = getKeyBytes(entry.getId().getIndex());
+                    byte[] value = toByteArray(entry);
+                    if (entry.getType() == EntryType.ENTRY_TYPE_CONFIGURATION) {
+                        this.confDB.put(key, value);
+                    }
+                    batch.put(key, value);
+                }
+                WriteOptions writeOpts = new WriteOptions();
+                writeOpts.sync(this.sync);
+                this.defaultDB.write(batch, writeOpts);
+                return entriesCount;
+            } finally {
+                IOUtils.closeQuietly(batch);
+            }
+        } catch (DBException e) {
+            LOG.error("Fail to appendEntries. first one = {}, entries count = {}", entries.get(0), entriesCount, e);
+        } finally {
+            this.readLock.unlock();
+        }
+        return 0;
+    }
+
+    @Override
+    public boolean truncatePrefix(long firstIndexKept) {
+        this.readLock.lock();
+        try {
+            checkState();
+            final long startIndex = getFirstLogIndex();
+            final boolean ret = saveFirstLogIndex(firstIndexKept);
+            if (ret) {
+                setFirstLogIndex(firstIndexKept);
+            }
+            truncatePrefixInBackground(startIndex, firstIndexKept);
+            return true;
+        } catch (DBException e) {
+            LOG.error("Fail to truncatePrefix {}.", firstIndexKept, e);
+        } finally {
+            this.readLock.unlock();
+        }
+        return false;
+    }
+
+    @Override
+    public boolean truncateSuffix(long lastIndexKept) {
+        this.readLock.lock();
+        try {
+            checkState();
+            final long lastLogIndex = getLastLogIndex();
+            WriteBatch defaultBatch = this.defaultDB.createWriteBatch();
+            try {
+                for (long index = lastIndexKept + 1; index <= lastLogIndex; index++) {
+                    byte[] key = getKeyBytes(index);
+                    this.confDB.delete(key);
+                    defaultBatch.delete(key);
+                }
+                WriteOptions writeOpts = new WriteOptions();
+                writeOpts.sync(this.sync);
+                this.defaultDB.write(defaultBatch, writeOpts);
+                return true;
+            } finally {
+                IOUtils.closeQuietly(defaultBatch);
+            }
+        } catch (DBException e) {
+            LOG.error("Fail to truncateSuffix {}.", lastIndexKept, e);
+        } finally {
+            this.readLock.unlock();
+        }
+        return false;
+    }
+
+    @Override
+    public boolean reset(long nextLogIndex) {
+        if (nextLogIndex <= 0) {
+            throw new IllegalArgumentException("Invalid next log index.");
+        }
+        this.writeLock.lock();
+        try {
+            LogEntry entry = getEntry(nextLogIndex);
+            closeDatabase();
+            FileUtils.deleteDirectory(new File(this.homePath));
+            initAndLoad(null);
+            if (entry == null) {
+                entry = new LogEntry();
+                entry.setType(EntryType.ENTRY_TYPE_NO_OP);
+                entry.setId(new LogId(nextLogIndex, 0));
+                LOG.warn("Entry not found for nextLogIndex {} when reset.", nextLogIndex);
+            }
+            return appendEntry(entry);
+        } catch (IOException | DBException e) {
+            LOG.error("Fail to reset next log index.", e);
+        } finally {
+            this.writeLock.unlock();
+        }
+        return false;
+    }
+
+    protected byte[] getKeyBytes(final long index) {
+        final byte[] ks = new byte[8];
+        Bits.putLong(ks, 0, index);
+        return ks;
+    }
+
+    protected boolean isSuccess(Object status) {
+        return status == null || status.equals(Boolean.TRUE);
+    }
+
+    protected LogEntry toLogEntry(byte[] value) {
+        if (value == null || value.length == 0) {
+            return null;
+        }
+        return this.logEntryDecoder.decode(value);
+    }
+
+    protected byte[] toByteArray(LogEntry logEntry) {
+        return this.logEntryEncoder.encode(logEntry);
+    }
+
+    /**
+     * Save the first log index into confDB
+     */
+    private boolean saveFirstLogIndex(final long firstLogIndex) {
+        this.readLock.lock();
+        try {
+            checkState();
+            byte[] firstLogIndexValue = getKeyBytes(firstLogIndex);
+            this.confDB.put(FIRST_LOG_IDX_KEY, firstLogIndexValue);
+            return true;
+        } catch (DBException e) {
+            LOG.error("Fail to save first log index {}.", firstLogIndex, e);
+        } finally {
+            this.readLock.unlock();
+        }
+        return false;
+    }
+
+    /**
+     * [startIndex, firstIndexKept)
+     */
+    private void truncatePrefixInBackground(final long startIndex, final long firstIndexKept) {
+        if (startIndex > firstIndexKept) {
+            return;
+        }
+        // delete logs in background.
+        ThreadPoolsFactory.runInThread(this.groupId, () -> {
+            this.readLock.lock();
+            try {
+                checkState();
+                WriteBatch batch = this.defaultDB.createWriteBatch();
+                try {
+                    for (long index = startIndex; index < firstIndexKept; index++) {
+                        byte[] key = getKeyBytes(index);
+                        this.confDB.delete(key); // Delete it first; otherwise, it may never be deleted
+                        batch.delete(key);
+                    }
+                    WriteOptions writeOpts = new WriteOptions();
+                    writeOpts.sync(this.sync);
+                    this.defaultDB.write(batch, writeOpts);
+                } finally {
+                    IOUtils.closeQuietly(batch);
+                }
+            } catch (DBException e) {
+                LOG.error("Fail to truncatePrefix {}.", firstIndexKept, e);
+            } finally {
+                this.readLock.unlock();
+            }
+        });
+    }
+
+    private void checkState() {
+        Requires.requireTrue(opened, "Database not open. the path: %s", this.homePath);
+    }
+}

--- a/jraft-extension/leveldb-log-storage-impl/src/main/java/com/alipay/sofa/jraft/storage/impl/LevelDBLogStorage.java
+++ b/jraft-extension/leveldb-log-storage-impl/src/main/java/com/alipay/sofa/jraft/storage/impl/LevelDBLogStorage.java
@@ -57,7 +57,7 @@ import com.alipay.sofa.jraft.util.Utils;
 /**
  * Log storage based on leveldb.
  *
- * @author jiachun.fjc
+ * @author knightblood
  */
 public class LevelDBLogStorage implements LogStorage, Describer {
 

--- a/jraft-extension/leveldb-log-storage-impl/src/main/resources/META-INF/services/com.alipay.sofa.jraft.JRaftServiceFactory
+++ b/jraft-extension/leveldb-log-storage-impl/src/main/resources/META-INF/services/com.alipay.sofa.jraft.JRaftServiceFactory
@@ -1,0 +1,1 @@
+com.alipay.sofa.jraft.core.LevelDBLogStorageJRaftServiceFactory

--- a/jraft-extension/leveldb-log-storage-impl/src/test/java/com/alipay/sofa/jraft/storage/BaseStorageTest.java
+++ b/jraft-extension/leveldb-log-storage-impl/src/test/java/com/alipay/sofa/jraft/storage/BaseStorageTest.java
@@ -1,0 +1,49 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alipay.sofa.jraft.storage;
+
+import java.io.File;
+import java.io.IOException;
+
+import org.apache.commons.io.FileUtils;
+import org.junit.After;
+import org.junit.Before;
+
+import com.alipay.sofa.jraft.test.TestUtils;
+
+public class BaseStorageTest {
+
+    protected String path;
+
+    @Before
+    public void setup() throws Exception {
+        this.path = TestUtils.mkTempDir();
+        FileUtils.forceMkdir(new File(this.path));
+    }
+
+    @After
+    public void teardown() throws Exception {
+        FileUtils.deleteDirectory(new File(this.path));
+    }
+
+    protected String writeData() throws IOException {
+        File file = new File(this.path + File.separator + "data");
+        String data = "jraft is great!";
+        FileUtils.writeStringToFile(file, data);
+        return data;
+    }
+}

--- a/jraft-extension/leveldb-log-storage-impl/src/test/java/com/alipay/sofa/jraft/storage/impl/BaseLogStorageTest.java
+++ b/jraft-extension/leveldb-log-storage-impl/src/test/java/com/alipay/sofa/jraft/storage/impl/BaseLogStorageTest.java
@@ -1,0 +1,255 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alipay.sofa.jraft.storage.impl;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import com.alipay.sofa.jraft.JRaftUtils;
+import com.alipay.sofa.jraft.conf.ConfigurationEntry;
+import com.alipay.sofa.jraft.conf.ConfigurationManager;
+import com.alipay.sofa.jraft.entity.EnumOutter;
+import com.alipay.sofa.jraft.entity.LogEntry;
+import com.alipay.sofa.jraft.entity.LogId;
+import com.alipay.sofa.jraft.entity.codec.LogEntryCodecFactory;
+import com.alipay.sofa.jraft.entity.codec.v2.LogEntryV2CodecFactory;
+import com.alipay.sofa.jraft.option.LogStorageOptions;
+import com.alipay.sofa.jraft.storage.BaseStorageTest;
+import com.alipay.sofa.jraft.storage.LogStorage;
+import com.alipay.sofa.jraft.test.TestUtils;
+import com.alipay.sofa.jraft.util.Utils;
+
+public abstract class BaseLogStorageTest extends BaseStorageTest {
+
+    protected LogStorage         logStorage;
+    private ConfigurationManager confManager;
+    private LogEntryCodecFactory logEntryCodecFactory;
+
+    @Override
+    @Before
+    public void setup() throws Exception {
+        super.setup();
+        this.confManager = new ConfigurationManager();
+        this.logEntryCodecFactory = LogEntryV2CodecFactory.getInstance();
+        this.logStorage = newLogStorage();
+
+        final LogStorageOptions opts = newLogStorageOptions();
+
+        this.logStorage.init(opts);
+    }
+
+    protected abstract LogStorage newLogStorage();
+
+    protected LogStorageOptions newLogStorageOptions() {
+        final LogStorageOptions opts = new LogStorageOptions();
+        opts.setConfigurationManager(this.confManager);
+        opts.setLogEntryCodecFactory(this.logEntryCodecFactory);
+        return opts;
+    }
+
+    @Override
+    @After
+    public void teardown() throws Exception {
+        this.logStorage.shutdown();
+        super.teardown();
+    }
+
+    @Test
+    public void testEmptyState() {
+        assertEquals(1, this.logStorage.getFirstLogIndex());
+        assertEquals(0, this.logStorage.getLastLogIndex());
+        assertNull(this.logStorage.getEntry(100));
+    }
+
+    @Test
+    public void testAddOneEntryState() {
+        final LogEntry entry1 = TestUtils.mockEntry(100, 1);
+        assertTrue(this.logStorage.appendEntry(entry1));
+
+        assertEquals(100, this.logStorage.getFirstLogIndex());
+        assertEquals(100, this.logStorage.getLastLogIndex());
+        Assert.assertEquals(entry1, this.logStorage.getEntry(100));
+        LogEntry logEntry1 = this.logStorage.getEntry(100);
+        assertNotNull(logEntry1);
+        assertEquals(entry1, logEntry1);
+        assertEquals(1, logEntry1.getId().getTerm());
+
+        final LogEntry entry2 = TestUtils.mockEntry(200, 2);
+        assertTrue(this.logStorage.appendEntry(entry2));
+
+        assertEquals(100, this.logStorage.getFirstLogIndex());
+        assertEquals(200, this.logStorage.getLastLogIndex());
+
+        logEntry1 = this.logStorage.getEntry(100);
+        final LogEntry logEntry2 = this.logStorage.getEntry(200);
+        assertNotNull(logEntry1);
+        assertNotNull(logEntry2);
+
+        Assert.assertEquals(entry1, logEntry1);
+        Assert.assertEquals(entry2, logEntry2);
+
+        assertEquals(1, logEntry1.getId().getTerm());
+        assertEquals(2, logEntry2.getId().getTerm());
+    }
+
+    @Test
+    public void testLoadWithConfigManager() {
+        assertTrue(this.confManager.getLastConfiguration().isEmpty());
+
+        final LogEntry confEntry1 = new LogEntry(EnumOutter.EntryType.ENTRY_TYPE_CONFIGURATION);
+        confEntry1.setId(new LogId(99, 1));
+        confEntry1.setPeers(JRaftUtils.getConfiguration("localhost:8081,localhost:8082").listPeers());
+
+        final LogEntry confEntry2 = new LogEntry(EnumOutter.EntryType.ENTRY_TYPE_CONFIGURATION);
+        confEntry2.setId(new LogId(100, 2));
+        confEntry2.setPeers(JRaftUtils.getConfiguration("localhost:8081,localhost:8082,localhost:8083").listPeers());
+
+        assertTrue(this.logStorage.appendEntry(confEntry1));
+        assertEquals(1, this.logStorage.appendEntries(Arrays.asList(confEntry2)));
+
+        // reload log storage.
+        this.logStorage.shutdown();
+        this.logStorage = newLogStorage();
+        this.logStorage.init(newLogStorageOptions());
+
+        ConfigurationEntry conf = this.confManager.getLastConfiguration();
+        assertNotNull(conf);
+        assertFalse(conf.isEmpty());
+        assertEquals("localhost:8081,localhost:8082,localhost:8083", conf.getConf().toString());
+        conf = this.confManager.get(99);
+        assertNotNull(conf);
+        assertFalse(conf.isEmpty());
+        assertEquals("localhost:8081,localhost:8082", conf.getConf().toString());
+    }
+
+    @Test
+    public void testAddManyEntries() {
+        final List<LogEntry> entries = TestUtils.mockEntries();
+
+        assertEquals(10, this.logStorage.appendEntries(entries));
+
+        assertEquals(0, this.logStorage.getFirstLogIndex());
+        assertEquals(9, this.logStorage.getLastLogIndex());
+        for (int i = 0; i < 10; i++) {
+            final LogEntry entry = this.logStorage.getEntry(i);
+            assertEquals(i, entry.getId().getTerm());
+            assertNotNull(entry);
+            assertEquals(entries.get(i), entry);
+        }
+    }
+
+    @Test
+    public void testReset() {
+        testAddManyEntries();
+        this.logStorage.reset(5);
+        assertEquals(5, this.logStorage.getFirstLogIndex());
+        assertEquals(5, this.logStorage.getLastLogIndex());
+        final LogEntry logEntry = this.logStorage.getEntry(5);
+        assertNotNull(logEntry);
+        assertEquals(5, logEntry.getId().getTerm());
+    }
+
+    @Test
+    public void testTruncatePrefix() {
+        final List<LogEntry> entries = TestUtils.mockEntries();
+
+        assertEquals(10, this.logStorage.appendEntries(entries));
+        this.logStorage.truncatePrefix(5);
+        assertEquals(5, this.logStorage.getFirstLogIndex());
+        assertEquals(9, this.logStorage.getLastLogIndex());
+        for (int i = 0; i < 10; i++) {
+            if (i < 5) {
+                assertNull(this.logStorage.getEntry(i));
+            } else {
+                Assert.assertEquals(entries.get(i), this.logStorage.getEntry(i));
+            }
+        }
+    }
+
+    @Test
+    public void testAppendManyLargeEntries() {
+        final long start = Utils.monotonicMs();
+        final int totalLogs = 100000;
+        final int logSize = 16 * 1024;
+        final int batch = 100;
+
+        appendLargeEntries(totalLogs, logSize, batch);
+        
+        final long cost = Utils.monotonicMs() - start;
+        System.out.println("Write " + totalLogs + " logs, cost " + cost + " ms.");
+
+        // verify
+        for (int i = 0; i < totalLogs; i++) {
+            final LogEntry entry = this.logStorage.getEntry(i);
+            assertNotNull(entry);
+            assertEquals(logSize, entry.getData().remaining());
+            assertEquals(i, entry.getId().getIndex());
+            assertEquals(i, entry.getId().getTerm());
+        }
+    }
+
+    protected void appendLargeEntries(final int totalLogs, final int logSize, final int batch) {
+        for (int i = 0; i < totalLogs; i += batch) {
+            final List<LogEntry> entries = new ArrayList<>(batch);
+            for (int j = 0; j < batch; j++) {
+                entries.add(TestUtils.mockEntry(i + j, i + j, logSize));
+            }
+            final int nAppended = this.logStorage.appendEntries(entries);
+            assertEquals(batch, nAppended);
+        }
+    }
+
+    @Test
+    public void testTruncateSuffix() {
+        final List<LogEntry> entries = TestUtils.mockEntries();
+        assertEquals(10, this.logStorage.appendEntries(entries));
+
+        this.logStorage.truncateSuffix(5);
+        assertEquals(0, this.logStorage.getFirstLogIndex());
+        assertEquals(5, this.logStorage.getLastLogIndex());
+        for (int i = 0; i < 10; i++) {
+            if (i <= 5) {
+                Assert.assertEquals(entries.get(i), this.logStorage.getEntry(i));
+            } else {
+                assertNull(this.logStorage.getEntry(i));
+            }
+        }
+    }
+
+    @Test
+    public void testGetTerm() {
+        final List<LogEntry> entries = TestUtils.mockEntries();
+        assertEquals(10, this.logStorage.appendEntries(entries));
+
+        assertEquals(0, this.logStorage.getTerm(100));
+        for (int i = 0; i < 10; i++) {
+            assertEquals(i, this.logStorage.getTerm(i));
+        }
+    }
+}

--- a/jraft-extension/leveldb-log-storage-impl/src/test/java/com/alipay/sofa/jraft/storage/impl/BaseLogStorageTest.java
+++ b/jraft-extension/leveldb-log-storage-impl/src/test/java/com/alipay/sofa/jraft/storage/impl/BaseLogStorageTest.java
@@ -200,7 +200,7 @@ public abstract class BaseLogStorageTest extends BaseStorageTest {
         final int batch = 100;
 
         appendLargeEntries(totalLogs, logSize, batch);
-        
+
         final long cost = Utils.monotonicMs() - start;
         System.out.println("Write " + totalLogs + " logs, cost " + cost + " ms.");
 

--- a/jraft-extension/leveldb-log-storage-impl/src/test/java/com/alipay/sofa/jraft/storage/impl/LevelDBLogStorageTest.java
+++ b/jraft-extension/leveldb-log-storage-impl/src/test/java/com/alipay/sofa/jraft/storage/impl/LevelDBLogStorageTest.java
@@ -1,0 +1,28 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alipay.sofa.jraft.storage.impl;
+
+import com.alipay.sofa.jraft.option.RaftOptions;
+import com.alipay.sofa.jraft.storage.LogStorage;
+
+public class LevelDBLogStorageTest extends BaseLogStorageTest {
+
+    @Override
+    protected LogStorage newLogStorage() {
+        return new LevelDBLogStorage(this.path, new RaftOptions());
+    }
+}

--- a/jraft-extension/leveldb-log-storage-impl/src/test/java/com/alipay/sofa/jraft/test/TestUtils.java
+++ b/jraft-extension/leveldb-log-storage-impl/src/test/java/com/alipay/sofa/jraft/test/TestUtils.java
@@ -1,0 +1,137 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alipay.sofa.jraft.test;
+
+import java.lang.management.ManagementFactory;
+import java.lang.management.ThreadInfo;
+import java.lang.management.ThreadMXBean;
+import java.net.Inet4Address;
+import java.net.InetAddress;
+import java.net.NetworkInterface;
+import java.net.SocketException;
+import java.nio.ByteBuffer;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.Enumeration;
+import java.util.List;
+import java.util.concurrent.ThreadLocalRandom;
+
+import com.alipay.sofa.jraft.JRaftUtils;
+import com.alipay.sofa.jraft.conf.ConfigurationEntry;
+import com.alipay.sofa.jraft.entity.EnumOutter;
+import com.alipay.sofa.jraft.entity.LogEntry;
+import com.alipay.sofa.jraft.entity.LogId;
+import com.alipay.sofa.jraft.entity.PeerId;
+import com.alipay.sofa.jraft.rpc.RpcRequests;
+import com.alipay.sofa.jraft.util.Endpoint;
+
+/**
+ * Test helper
+ *
+ * @author boyan (boyan@alibaba-inc.com)
+ *
+ *         2018-Apr-11 10:16:07 AM
+ */
+public class TestUtils {
+
+    public static ConfigurationEntry getConfEntry(final String confStr, final String oldConfStr) {
+        ConfigurationEntry entry = new ConfigurationEntry();
+        entry.setConf(JRaftUtils.getConfiguration(confStr));
+        entry.setOldConf(JRaftUtils.getConfiguration(oldConfStr));
+        return entry;
+    }
+
+    public static void dumpThreads() {
+        try {
+            ThreadMXBean bean = ManagementFactory.getThreadMXBean();
+            ThreadInfo[] infos = bean.dumpAllThreads(true, true);
+            for (ThreadInfo info : infos) {
+                System.out.println(info);
+            }
+        } catch (Throwable t) {
+            t.printStackTrace(); // NOPMD
+        }
+    }
+
+    public static String mkTempDir() {
+        return Paths.get(System.getProperty("java.io.tmpdir", "/tmp"), "jraft_test_" + System.nanoTime()).toString();
+    }
+
+    public static LogEntry mockEntry(final int index, final int term) {
+        return mockEntry(index, term, 0);
+    }
+
+    public static LogEntry mockEntry(final int index, final int term, final int dataSize) {
+        LogEntry entry = new LogEntry(EnumOutter.EntryType.ENTRY_TYPE_NO_OP);
+        entry.setId(new LogId(index, term));
+        if (dataSize > 0) {
+            byte[] bs = new byte[dataSize];
+            ThreadLocalRandom.current().nextBytes(bs);
+            entry.setData(ByteBuffer.wrap(bs));
+        }
+        return entry;
+    }
+
+    public static List<LogEntry> mockEntries() {
+        return mockEntries(10);
+    }
+
+    public static List<LogEntry> mockEntries(final int n) {
+        List<LogEntry> entries = new ArrayList<>();
+        for (int i = 0; i < n; i++) {
+            LogEntry entry = mockEntry(i, i);
+            if (i > 0) {
+                entry.setData(ByteBuffer.wrap(String.valueOf(i).getBytes()));
+            }
+            entries.add(entry);
+        }
+        return entries;
+    }
+
+    public static String getMyIp() {
+        String ip = null;
+        try {
+            Enumeration<NetworkInterface> interfaces = NetworkInterface.getNetworkInterfaces();
+            while (interfaces.hasMoreElements()) {
+                NetworkInterface iface = interfaces.nextElement();
+                // filters out 127.0.0.1 and inactive interfaces
+                if (iface.isLoopback() || !iface.isUp()) {
+                    continue;
+                }
+                Enumeration<InetAddress> addresses = iface.getInetAddresses();
+                while (addresses.hasMoreElements()) {
+                    InetAddress addr = addresses.nextElement();
+                    if (addr instanceof Inet4Address) {
+                        ip = addr.getHostAddress();
+                        break;
+                    }
+                }
+            }
+        } catch (SocketException e) {
+            e.printStackTrace();
+        }
+        return ip;
+    }
+
+    public static List<PeerId> generatePeers(int num) {
+        List<PeerId> peers = new ArrayList<>();
+        for (int i = 0; i < num; i++) {
+            peers.add(new PeerId("localhost", 8080 + i));
+        }
+        return peers;
+    }
+}

--- a/jraft-extension/mapdb-log-storage-impl/pom.xml
+++ b/jraft-extension/mapdb-log-storage-impl/pom.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <artifactId>jraft-extension</artifactId>
+        <groupId>com.alipay.sofa</groupId>
+        <version>1.4.0</version>
+    </parent>
+
+    <artifactId>mapdb-log-storage-impl</artifactId>
+    <packaging>jar</packaging>
+    <name>mapdb-log-storage-impl ${project.version}</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.alipay.sofa</groupId>
+            <artifactId>jraft-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.mapdb</groupId>
+            <artifactId>mapdb</artifactId>
+            <version>3.1.0</version>
+        </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/jraft-extension/mapdb-log-storage-impl/src/main/java/com/alipay/sofa/jraft/core/MapDBLogStorageJRaftServiceFactory.java
+++ b/jraft-extension/mapdb-log-storage-impl/src/main/java/com/alipay/sofa/jraft/core/MapDBLogStorageJRaftServiceFactory.java
@@ -1,0 +1,36 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alipay.sofa.jraft.core;
+
+import com.alipay.sofa.jraft.option.RaftOptions;
+import com.alipay.sofa.jraft.storage.LogStorage;
+import com.alipay.sofa.jraft.storage.impl.MapDBLogStorage;
+import com.alipay.sofa.jraft.util.SPI;
+
+/**
+ * override createLogStorage
+ *
+ * @author jiachun.fjc
+ */
+@SPI(priority = 1)
+public class MapDBLogStorageJRaftServiceFactory extends DefaultJRaftServiceFactory {
+
+    @Override
+    public LogStorage createLogStorage(String uri, RaftOptions raftOptions) {
+        return new MapDBLogStorage(uri, raftOptions);
+    }
+}

--- a/jraft-extension/mapdb-log-storage-impl/src/main/java/com/alipay/sofa/jraft/core/MapDBLogStorageJRaftServiceFactory.java
+++ b/jraft-extension/mapdb-log-storage-impl/src/main/java/com/alipay/sofa/jraft/core/MapDBLogStorageJRaftServiceFactory.java
@@ -24,7 +24,7 @@ import com.alipay.sofa.jraft.util.SPI;
 /**
  * override createLogStorage
  *
- * @author jiachun.fjc
+ * @author knightblood
  */
 @SPI(priority = 1)
 public class MapDBLogStorageJRaftServiceFactory extends DefaultJRaftServiceFactory {

--- a/jraft-extension/mapdb-log-storage-impl/src/main/java/com/alipay/sofa/jraft/storage/impl/MapDBLogStorage.java
+++ b/jraft-extension/mapdb-log-storage-impl/src/main/java/com/alipay/sofa/jraft/storage/impl/MapDBLogStorage.java
@@ -55,7 +55,7 @@ import com.alipay.sofa.jraft.util.Utils;
 /**
  * Log storage based on MapDB.
  *
- * @author jiachun.fjc
+ * @author knightblood
  */
 public class MapDBLogStorage implements LogStorage, Describer {
 

--- a/jraft-extension/mapdb-log-storage-impl/src/main/java/com/alipay/sofa/jraft/storage/impl/MapDBLogStorage.java
+++ b/jraft-extension/mapdb-log-storage-impl/src/main/java/com/alipay/sofa/jraft/storage/impl/MapDBLogStorage.java
@@ -21,10 +21,15 @@ import java.io.IOException;
 import java.util.Arrays;
 import java.util.Iterator;
 import java.util.List;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReadWriteLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 
+import com.alipay.sofa.jraft.util.NamedThreadFactory;
+import com.alipay.sofa.jraft.util.ThreadPoolUtil;
 import com.alipay.sofa.jraft.util.ThreadPoolsFactory;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
@@ -52,6 +57,11 @@ import com.alipay.sofa.jraft.util.Describer;
 import com.alipay.sofa.jraft.util.Requires;
 import com.alipay.sofa.jraft.util.Utils;
 
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
+import java.util.ArrayList;
+import java.util.concurrent.atomic.AtomicBoolean;
+
 /**
  * Log storage based on MapDB.
  *
@@ -69,6 +79,7 @@ public class MapDBLogStorage implements LogStorage, Describer {
     private DB                       db;
     private final String             homePath;
     private boolean                  opened            = false;
+    private final boolean            sync;
 
     private LogEntryEncoder          logEntryEncoder;
     private LogEntryDecoder          logEntryDecoder;
@@ -77,15 +88,34 @@ public class MapDBLogStorage implements LogStorage, Describer {
     private final Lock               readLock          = this.readWriteLock.readLock();
     private final Lock               writeLock         = this.readWriteLock.writeLock();
 
-    private final boolean            sync;
-
     private volatile long            firstLogIndex     = 1;
     private volatile boolean         hasLoadFirstLogIndex;
+
+    private ScheduledExecutorService flushExecutorService;
+    private ScheduledFuture<?>       flushScheduledFuture;
+    private volatile boolean         needFlush         = false;
+    private final int                flushIntervalMs   = 100;                                           // 定期flush间隔（毫秒）
+
+    // 添加批量写入相关字段
+    private final int                batchSize         = 100;                                           // 批量提交大小
+    private final List<LogEntry>     writeBuffer       = new ArrayList<>();                             // 写缓冲区
+    private final Object             bufferLock        = new Object();                                  // 缓冲区锁
 
     /**
      * First log index and last log index key in configuration column family.
      */
     public static final byte[]       FIRST_LOG_IDX_KEY = Utils.getBytes("meta/firstLogIndex");
+
+    /**
+     * 检查当前 JVM 是否为 64 位。
+     */
+    private boolean is64BitJVM() {
+        String model = System.getProperty("sun.arch.data.model");
+        if (model != null && model.equals("64")) {
+            return true;
+        }
+        return false;
+    }
 
     public MapDBLogStorage(final String homePath, final RaftOptions raftOptions) {
         super();
@@ -127,14 +157,96 @@ public class MapDBLogStorage implements LogStorage, Describer {
 
         File dbFile = new File(databaseHomeDir, "mapdb-log.db");
         DBMaker.Maker maker = DBMaker.fileDB(dbFile);
-        if (this.sync) {
+        
+        // 启用性能优化选项
+        if (!this.sync) {
+            // 非同步模式下启用JVM关闭时自动关闭
+            maker = maker.closeOnJvmShutdown();
+        } else {
+            // 同步模式下启用事务支持
             maker = maker.transactionEnable();
         }
+        
+        // 启用内存映射文件以提高性能（仅在64位系统上）
+        maker = maker.fileMmapEnable().fileMmapEnableIfSupported().fileMmapPreclearDisable();
+        
+        // 启用文件通道以提高性能
+        maker = maker.fileChannelEnable();
+        
+        // 在64位JVM上启用cleaner hack以提高性能
+        maker = maker.cleanerHackEnable();
+        
         this.db = maker.make();
         this.defaultMap = this.db.hashMap(DEFAULT_MAP_NAME, Serializer.BYTE_ARRAY, Serializer.BYTE_ARRAY)
             .createOrOpen();
         this.confMap = this.db.hashMap(CONF_MAP_NAME, Serializer.BYTE_ARRAY, Serializer.BYTE_ARRAY).createOrOpen();
         this.opened = true;
+        
+        // 初始化flush executor并启动定期flush任务
+        if (!this.sync) {
+            this.flushExecutorService = ThreadPoolUtil.newScheduledBuilder()
+                .poolName("mapdb-flush-executor")
+                .enableMetric(true)
+                .coreThreads(1)
+                .threadFactory(new NamedThreadFactory("MapDB-Flush-Thread-", true))
+                .build();
+            this.flushScheduledFuture = this.flushExecutorService.scheduleWithFixedDelay(this::flushDatabase, 
+                flushIntervalMs, flushIntervalMs, TimeUnit.MILLISECONDS);
+        }
+    }
+
+    /**
+     * Flush数据库以确保数据持久化
+     */
+    private void flushDatabase() {
+        // 在非同步模式下定期flush数据
+        if (!this.sync && needFlush) {
+            this.writeLock.lock();
+            try {
+                synchronized (bufferLock) {
+                    if (needFlush) {
+                        // 提交缓冲区中的数据
+                        if (!writeBuffer.isEmpty()) {
+                            commitBuffer();
+                        }
+                        // 提交数据库
+                        this.db.commit();
+                        needFlush = false;
+                    }
+                }
+            } catch (Exception e) {
+                LOG.error("Fail to flush mapdb.", e);
+            } finally {
+                this.writeLock.unlock();
+            }
+        }
+    }
+
+    /**
+     * 提交缓冲区中的数据到MapDB
+     */
+    private void commitBuffer() {
+        if (writeBuffer.isEmpty()) {
+            return;
+        }
+
+        synchronized (bufferLock) {
+            if (writeBuffer.isEmpty()) {
+                return;
+            }
+
+            // 批量处理缓冲区中的日志条目
+            for (LogEntry entry : writeBuffer) {
+                byte[] key = getKeyBytes(entry.getId().getIndex());
+                byte[] value = toByteArray(entry);
+                if (entry.getType() == EntryType.ENTRY_TYPE_CONFIGURATION) {
+                    this.confMap.put(key, value);
+                }
+                this.defaultMap.put(key, value);
+            }
+
+            writeBuffer.clear();
+        }
     }
 
     private void load(final ConfigurationManager confManager) {
@@ -183,16 +295,50 @@ public class MapDBLogStorage implements LogStorage, Describer {
 
     private void closeDatabase() {
         this.opened = false;
+
+        // 提交缓冲区中的剩余数据
+        if (!this.sync && !writeBuffer.isEmpty()) {
+            try {
+                commitBuffer();
+                if (this.db != null) {
+                    this.db.commit();
+                }
+            } catch (Exception e) {
+                LOG.error("Fail to commit remaining buffer data.", e);
+            }
+        }
+
+        // 关闭定期flush任务
+        if (this.flushScheduledFuture != null) {
+            this.flushScheduledFuture.cancel(true);
+        }
+
+        if (this.flushExecutorService != null) {
+            this.flushExecutorService.shutdown();
+            try {
+                if (!this.flushExecutorService.awaitTermination(5, TimeUnit.SECONDS)) {
+                    this.flushExecutorService.shutdownNow();
+                }
+            } catch (InterruptedException e) {
+                this.flushExecutorService.shutdownNow();
+                Thread.currentThread().interrupt();
+            }
+        }
+
         try {
             if (this.db != null) {
+                this.db.commit();
                 this.db.close();
             }
         } catch (Exception e) {
-            // ignore
+            LOG.error("Fail to close mapdb.", e);
         }
         this.db = null;
         this.defaultMap = null;
         this.confMap = null;
+
+        // 强制垃圾回收以释放可能被占用的文件句柄
+        System.gc();
     }
 
     @Override
@@ -240,11 +386,24 @@ public class MapDBLogStorage implements LogStorage, Describer {
             try {
                 Iterator<byte[]> iterator = this.defaultMap.getKeys().iterator();
                 byte[] firstKey = null;
-                if (iterator.hasNext()) {
-                    firstKey = iterator.next();
+                long minIndex = Long.MAX_VALUE;
+                boolean hasKey = false;
+
+                // 遍历所有键，找到最小的索引值
+                while (iterator.hasNext()) {
+                    hasKey = true;
+                    byte[] key = iterator.next();
+                    if (key != null && key.length == Long.BYTES) {
+                        long index = Bits.getLong(key, 0);
+                        if (index < minIndex) {
+                            minIndex = index;
+                            firstKey = key;
+                        }
+                    }
                 }
-                if (firstKey != null) {
-                    final long firstLogIndex = Bits.getLong(firstKey, 0);
+
+                if (hasKey && firstKey != null) {
+                    final long firstLogIndex = minIndex;
                     saveFirstLogIndex(firstLogIndex);
                     setFirstLogIndex(firstLogIndex);
                     return firstLogIndex;
@@ -266,11 +425,24 @@ public class MapDBLogStorage implements LogStorage, Describer {
             try {
                 Iterator<byte[]> iterator = this.defaultMap.getKeys().iterator();
                 byte[] lastKey = null;
+                long maxIndex = Long.MIN_VALUE;
+                boolean hasKey = false;
+
+                // 遍历所有键，找到最大的索引值
                 while (iterator.hasNext()) {
-                    lastKey = iterator.next();
+                    hasKey = true;
+                    byte[] key = iterator.next();
+                    if (key != null && key.length == Long.BYTES) {
+                        long index = Bits.getLong(key, 0);
+                        if (index > maxIndex) {
+                            maxIndex = index;
+                            lastKey = key;
+                        }
+                    }
                 }
-                if (lastKey != null) {
-                    return Bits.getLong(lastKey, 0);
+
+                if (hasKey && lastKey != null) {
+                    return maxIndex;
                 }
             } catch (Exception e) {
                 LOG.error("Fail to get last log index.", e);
@@ -317,20 +489,58 @@ public class MapDBLogStorage implements LogStorage, Describer {
         this.readLock.lock();
         try {
             checkState();
-            byte[] key = getKeyBytes(entry.getId().getIndex());
-            byte[] value = toByteArray(entry);
-            if (entry.getType() == EntryType.ENTRY_TYPE_CONFIGURATION) {
-                this.confMap.put(key, value);
+
+            // 如果是同步模式直接写入并提交
+            if (this.sync) {
+                // 直接写入单个条目
+                return writeEntryDirectly(entry);
             }
-            this.defaultMap.put(key, value);
-            this.db.commit();
-            return true;
+            // 非同步模式下使用缓冲区
+            else {
+                // 将单个条目添加到缓冲区
+                return bufferEntry(entry);
+            }
         } catch (Exception e) {
             LOG.error("Fail to append entry {}.", entry, e);
         } finally {
             this.readLock.unlock();
         }
         return false;
+    }
+
+    /**
+     * 直接写入单个日志条目并立即提交
+     */
+    private boolean writeEntryDirectly(LogEntry entry) {
+        byte[] key = getKeyBytes(entry.getId().getIndex());
+        byte[] value = toByteArray(entry);
+        if (entry.getType() == EntryType.ENTRY_TYPE_CONFIGURATION) {
+            this.confMap.put(key, value);
+        }
+        this.defaultMap.put(key, value);
+
+        this.db.commit(); // 同步提交
+        return true;
+    }
+
+    /**
+     * 将单个日志条目添加到缓冲区
+     */
+    private boolean bufferEntry(LogEntry entry) {
+        synchronized (bufferLock) {
+            writeBuffer.add(entry);
+
+            // 如果达到批处理大小，立即提交
+            if (writeBuffer.size() >= batchSize) {
+                commitBuffer();
+                this.db.commit();
+                return true;
+            }
+        }
+
+        // 标记需要定期刷新
+        needFlush = true;
+        return true;
     }
 
     @Override
@@ -342,25 +552,69 @@ public class MapDBLogStorage implements LogStorage, Describer {
         this.readLock.lock();
         try {
             checkState();
-            boolean needsCommit = false;
-            for (int i = 0; i < entriesCount; i++) {
-                final LogEntry entry = entries.get(i);
-                byte[] key = getKeyBytes(entry.getId().getIndex());
-                byte[] value = toByteArray(entry);
-                if (entry.getType() == EntryType.ENTRY_TYPE_CONFIGURATION) {
-                    this.confMap.put(key, value);
-                }
-                this.defaultMap.put(key, value);
-                needsCommit = true;
+
+            // 如果是同步模式直接写入并提交
+            if (this.sync) {
+                return writeEntriesDirectly(entries);
             }
-            this.db.commit();
-            return entriesCount;
+            // 非同步模式下使用缓冲区
+            else {
+                return bufferEntries(entries);
+            }
         } catch (Exception e) {
             LOG.error("Fail to appendEntries. first one = {}, entries count = {}", entries.get(0), entriesCount, e);
         } finally {
             this.readLock.unlock();
         }
         return 0;
+    }
+
+    /**
+     * 直接写入日志条目列表并立即提交
+     */
+    private int writeEntriesDirectly(List<LogEntry> entries) {
+        for (LogEntry entry : entries) {
+            byte[] key = getKeyBytes(entry.getId().getIndex());
+            byte[] value = toByteArray(entry);
+            if (entry.getType() == EntryType.ENTRY_TYPE_CONFIGURATION) {
+                this.confMap.put(key, value);
+            }
+            this.defaultMap.put(key, value);
+        }
+
+        this.db.commit(); // 同步提交
+        return entries.size();
+    }
+
+    /**
+     * 将日志条目列表添加到缓冲区
+     */
+    private int bufferEntries(List<LogEntry> entries) {
+        synchronized (writeBuffer) {
+            int totalAdded = 0;
+            int bufferSize = writeBuffer.size();
+            for (LogEntry entry : entries) {
+                writeBuffer.add(entry);
+                totalAdded++;
+                bufferSize++;
+
+                // 如果达到批处理大小，立即提交
+                if (bufferSize >= batchSize) {
+                    commitBuffer();
+                    bufferSize = 0;
+                }
+            }
+
+            // 最后提交一次剩余的日志
+            if (bufferSize > 0) {
+                commitBuffer();
+                this.db.commit();
+            } else {
+                this.db.commit();
+            }
+
+            return totalAdded;
+        }
     }
 
     @Override

--- a/jraft-extension/mapdb-log-storage-impl/src/main/java/com/alipay/sofa/jraft/storage/impl/MapDBLogStorage.java
+++ b/jraft-extension/mapdb-log-storage-impl/src/main/java/com/alipay/sofa/jraft/storage/impl/MapDBLogStorage.java
@@ -1,0 +1,499 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alipay.sofa.jraft.storage.impl;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Iterator;
+import java.util.List;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReadWriteLock;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
+
+import com.alipay.sofa.jraft.util.ThreadPoolsFactory;
+import org.apache.commons.io.FileUtils;
+import org.apache.commons.io.IOUtils;
+import org.mapdb.DB;
+import org.mapdb.DBMaker;
+import org.mapdb.HTreeMap;
+import org.mapdb.Serializer;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.alipay.sofa.jraft.conf.Configuration;
+import com.alipay.sofa.jraft.conf.ConfigurationEntry;
+import com.alipay.sofa.jraft.conf.ConfigurationManager;
+import com.alipay.sofa.jraft.entity.EnumOutter.EntryType;
+import com.alipay.sofa.jraft.entity.LogEntry;
+import com.alipay.sofa.jraft.entity.LogId;
+import com.alipay.sofa.jraft.entity.codec.LogEntryDecoder;
+import com.alipay.sofa.jraft.entity.codec.LogEntryEncoder;
+import com.alipay.sofa.jraft.option.LogStorageOptions;
+import com.alipay.sofa.jraft.option.RaftOptions;
+import com.alipay.sofa.jraft.storage.LogStorage;
+import com.alipay.sofa.jraft.util.Bits;
+import com.alipay.sofa.jraft.util.BytesUtil;
+import com.alipay.sofa.jraft.util.Describer;
+import com.alipay.sofa.jraft.util.Requires;
+import com.alipay.sofa.jraft.util.Utils;
+
+/**
+ * Log storage based on MapDB.
+ *
+ * @author jiachun.fjc
+ */
+public class MapDBLogStorage implements LogStorage, Describer {
+
+    private static final Logger      LOG               = LoggerFactory.getLogger(MapDBLogStorage.class);
+    static final String              DEFAULT_MAP_NAME  = "jraft-log";
+    static final String              CONF_MAP_NAME     = "jraft-conf";
+
+    private String                   groupId;
+    private HTreeMap<byte[], byte[]> defaultMap;
+    private HTreeMap<byte[], byte[]> confMap;
+    private DB                       db;
+    private final String             homePath;
+    private boolean                  opened            = false;
+
+    private LogEntryEncoder          logEntryEncoder;
+    private LogEntryDecoder          logEntryDecoder;
+
+    private final ReadWriteLock      readWriteLock     = new ReentrantReadWriteLock();
+    private final Lock               readLock          = this.readWriteLock.readLock();
+    private final Lock               writeLock         = this.readWriteLock.writeLock();
+
+    private final boolean            sync;
+
+    private volatile long            firstLogIndex     = 1;
+    private volatile boolean         hasLoadFirstLogIndex;
+
+    /**
+     * First log index and last log index key in configuration column family.
+     */
+    public static final byte[]       FIRST_LOG_IDX_KEY = Utils.getBytes("meta/firstLogIndex");
+
+    public MapDBLogStorage(final String homePath, final RaftOptions raftOptions) {
+        super();
+        Requires.requireNonNull(homePath, "Null homePath");
+        this.homePath = homePath;
+        this.sync = raftOptions.isSync();
+    }
+
+    @Override
+    public boolean init(LogStorageOptions opts) {
+        Requires.requireNonNull(opts, "Null LogStorageOptions opts");
+        Requires.requireNonNull(opts.getConfigurationManager(), "Null conf manager");
+        Requires.requireNonNull(opts.getLogEntryCodecFactory(), "Null log entry codec factory");
+        this.groupId = opts.getGroupId();
+        this.logEntryDecoder = opts.getLogEntryCodecFactory().decoder();
+        this.logEntryEncoder = opts.getLogEntryCodecFactory().encoder();
+        this.writeLock.lock();
+        try {
+            if (this.db != null) {
+                LOG.warn("MapDBLogStorage init() already.");
+                return true;
+            }
+            initAndLoad(opts.getConfigurationManager());
+            return true;
+        } catch (Exception e) {
+            LOG.error("Fail to init MapDBLogStorage, path={}.", this.homePath, e);
+        } finally {
+            this.writeLock.unlock();
+        }
+        return false;
+    }
+
+    private void openDatabase() throws Exception {
+        if (this.opened) {
+            return;
+        }
+        final File databaseHomeDir = new File(homePath);
+        FileUtils.forceMkdir(databaseHomeDir);
+
+        File dbFile = new File(databaseHomeDir, "mapdb-log.db");
+        DBMaker.Maker maker = DBMaker.fileDB(dbFile);
+        if (this.sync) {
+            maker = maker.transactionEnable();
+        }
+        this.db = maker.make();
+        this.defaultMap = this.db.hashMap(DEFAULT_MAP_NAME, Serializer.BYTE_ARRAY, Serializer.BYTE_ARRAY)
+            .createOrOpen();
+        this.confMap = this.db.hashMap(CONF_MAP_NAME, Serializer.BYTE_ARRAY, Serializer.BYTE_ARRAY).createOrOpen();
+        this.opened = true;
+    }
+
+    private void load(final ConfigurationManager confManager) {
+        try {
+            for (byte[] keyBytes : this.confMap.getKeys()) {
+                final byte[] valueBytes = this.confMap.get(keyBytes);
+                if (keyBytes.length == Long.BYTES) {
+                    final LogEntry entry = this.logEntryDecoder.decode(valueBytes);
+                    if (entry != null) {
+                        if (entry.getType() == EntryType.ENTRY_TYPE_CONFIGURATION) {
+                            final ConfigurationEntry confEntry = new ConfigurationEntry();
+                            confEntry.setId(new LogId(entry.getId().getIndex(), entry.getId().getTerm()));
+                            confEntry.setConf(new Configuration(entry.getPeers(), entry.getLearners()));
+                            if (entry.getOldPeers() != null) {
+                                confEntry.setOldConf(new Configuration(entry.getOldPeers(), entry.getOldLearners()));
+                            }
+                            if (confManager != null) {
+                                confManager.add(confEntry);
+                            }
+                        }
+                    } else {
+                        LOG.warn("Fail to decode conf entry at index {}, the log data is: {}.",
+                            Bits.getLong(keyBytes, 0), BytesUtil.toHex(valueBytes));
+                    }
+                } else if (Arrays.equals(FIRST_LOG_IDX_KEY, keyBytes)) {
+                    // FIRST_LOG_IDX_KEY storage
+                    setFirstLogIndex(Bits.getLong(valueBytes, 0));
+                    truncatePrefixInBackground(0L, this.firstLogIndex);
+                } else {
+                    // Unknown entry
+                    LOG.warn("Unknown entry in configuration storage key={}, value={}.", BytesUtil.toHex(keyBytes),
+                        BytesUtil.toHex(valueBytes));
+                }
+            }
+        } catch (Exception e) {
+            LOG.error("Fail to load confMap.", e);
+        }
+    }
+
+    private void initAndLoad(final ConfigurationManager confManager) throws Exception {
+        this.hasLoadFirstLogIndex = false;
+        this.firstLogIndex = 1;
+        openDatabase();
+        load(confManager);
+    }
+
+    private void closeDatabase() {
+        this.opened = false;
+        try {
+            if (this.db != null) {
+                this.db.close();
+            }
+        } catch (Exception e) {
+            // ignore
+        }
+        this.db = null;
+        this.defaultMap = null;
+        this.confMap = null;
+    }
+
+    @Override
+    public void shutdown() {
+        this.writeLock.lock();
+        try {
+            closeDatabase();
+            LOG.info("MapDBLogStorage shutdown, the db path is: {}.", this.homePath);
+        } finally {
+            this.writeLock.unlock();
+        }
+    }
+
+    @Override
+    public void describe(Printer out) {
+        this.readLock.lock();
+        try {
+            if (opened) {
+                out.println(String.format("Database is opened. the path: %s", this.homePath));
+                out.println("MapDB storage engine");
+            } else {
+                out.println(String.format("Database not open. the path: %s", this.homePath));
+            }
+        } finally {
+            this.readLock.unlock();
+        }
+    }
+
+    private void setFirstLogIndex(long firstLogIndex) {
+        this.firstLogIndex = firstLogIndex;
+        this.hasLoadFirstLogIndex = true;
+    }
+
+    @Override
+    public long getFirstLogIndex() {
+        if (this.hasLoadFirstLogIndex) {
+            return this.firstLogIndex;
+        }
+        this.readLock.lock();
+        try {
+            if (this.hasLoadFirstLogIndex) {
+                return this.firstLogIndex;
+            }
+            checkState();
+            try {
+                Iterator<byte[]> iterator = this.defaultMap.getKeys().iterator();
+                byte[] firstKey = null;
+                if (iterator.hasNext()) {
+                    firstKey = iterator.next();
+                }
+                if (firstKey != null) {
+                    final long firstLogIndex = Bits.getLong(firstKey, 0);
+                    saveFirstLogIndex(firstLogIndex);
+                    setFirstLogIndex(firstLogIndex);
+                    return firstLogIndex;
+                }
+            } catch (Exception e) {
+                LOG.error("Fail to get first log index.", e);
+            }
+        } finally {
+            this.readLock.unlock();
+        }
+        return 1L;
+    }
+
+    @Override
+    public long getLastLogIndex() {
+        this.readLock.lock();
+        try {
+            checkState();
+            try {
+                Iterator<byte[]> iterator = this.defaultMap.getKeys().iterator();
+                byte[] lastKey = null;
+                while (iterator.hasNext()) {
+                    lastKey = iterator.next();
+                }
+                if (lastKey != null) {
+                    return Bits.getLong(lastKey, 0);
+                }
+            } catch (Exception e) {
+                LOG.error("Fail to get last log index.", e);
+            }
+        } finally {
+            this.readLock.unlock();
+        }
+        return 0L;
+    }
+
+    @Override
+    public LogEntry getEntry(long index) {
+        this.readLock.lock();
+        try {
+            checkState();
+            if (this.hasLoadFirstLogIndex && index < this.firstLogIndex) {
+                return null;
+            }
+            byte[] key = getKeyBytes(index);
+            byte[] value = this.defaultMap.get(key);
+            return toLogEntry(value);
+        } catch (Exception e) {
+            LOG.error("Fail to get log entry at index {}.", index, e);
+        } finally {
+            this.readLock.unlock();
+        }
+        return null;
+    }
+
+    @Override
+    public long getTerm(long index) {
+        final LogEntry entry = getEntry(index);
+        if (entry != null) {
+            return entry.getId().getTerm();
+        }
+        return 0;
+    }
+
+    @Override
+    public boolean appendEntry(LogEntry entry) {
+        if (entry == null) {
+            return false;
+        }
+        this.readLock.lock();
+        try {
+            checkState();
+            byte[] key = getKeyBytes(entry.getId().getIndex());
+            byte[] value = toByteArray(entry);
+            if (entry.getType() == EntryType.ENTRY_TYPE_CONFIGURATION) {
+                this.confMap.put(key, value);
+            }
+            this.defaultMap.put(key, value);
+            this.db.commit();
+            return true;
+        } catch (Exception e) {
+            LOG.error("Fail to append entry {}.", entry, e);
+        } finally {
+            this.readLock.unlock();
+        }
+        return false;
+    }
+
+    @Override
+    public int appendEntries(List<LogEntry> entries) {
+        if (entries == null || entries.isEmpty()) {
+            return 0;
+        }
+        final int entriesCount = entries.size();
+        this.readLock.lock();
+        try {
+            checkState();
+            boolean needsCommit = false;
+            for (int i = 0; i < entriesCount; i++) {
+                final LogEntry entry = entries.get(i);
+                byte[] key = getKeyBytes(entry.getId().getIndex());
+                byte[] value = toByteArray(entry);
+                if (entry.getType() == EntryType.ENTRY_TYPE_CONFIGURATION) {
+                    this.confMap.put(key, value);
+                }
+                this.defaultMap.put(key, value);
+                needsCommit = true;
+            }
+            this.db.commit();
+            return entriesCount;
+        } catch (Exception e) {
+            LOG.error("Fail to appendEntries. first one = {}, entries count = {}", entries.get(0), entriesCount, e);
+        } finally {
+            this.readLock.unlock();
+        }
+        return 0;
+    }
+
+    @Override
+    public boolean truncatePrefix(long firstIndexKept) {
+        this.readLock.lock();
+        try {
+            checkState();
+            final long startIndex = getFirstLogIndex();
+            final boolean ret = saveFirstLogIndex(firstIndexKept);
+            if (ret) {
+                setFirstLogIndex(firstIndexKept);
+            }
+            truncatePrefixInBackground(startIndex, firstIndexKept);
+            return true;
+        } catch (Exception e) {
+            LOG.error("Fail to truncatePrefix {}.", firstIndexKept, e);
+        } finally {
+            this.readLock.unlock();
+        }
+        return false;
+    }
+
+    @Override
+    public boolean truncateSuffix(long lastIndexKept) {
+        this.readLock.lock();
+        try {
+            checkState();
+            final long lastLogIndex = getLastLogIndex();
+            for (long index = lastIndexKept + 1; index <= lastLogIndex; index++) {
+                byte[] key = getKeyBytes(index);
+                // Delete it first; otherwise, it may never be deleted
+                this.confMap.remove(key); // Delete it first; otherwise, it may never be deleted
+                this.defaultMap.remove(key);
+            }
+            this.db.commit();
+            return true;
+        } catch (Exception e) {
+            LOG.error("Fail to truncateSuffix {}.", lastIndexKept, e);
+        } finally {
+            this.readLock.unlock();
+        }
+        return false;
+    }
+
+    @Override
+    public boolean reset(long nextLogIndex) {
+        if (nextLogIndex <= 0) {
+            throw new IllegalArgumentException("Invalid next log index.");
+        }
+        this.writeLock.lock();
+        try {
+            LogEntry entry = getEntry(nextLogIndex);
+            closeDatabase();
+            FileUtils.deleteDirectory(new File(this.homePath));
+            initAndLoad(null);
+            if (entry == null) {
+                entry = new LogEntry();
+                entry.setType(EntryType.ENTRY_TYPE_NO_OP);
+                entry.setId(new LogId(nextLogIndex, 0));
+                LOG.warn("Entry not found for nextLogIndex {} when reset.", nextLogIndex);
+            }
+            return appendEntry(entry);
+        } catch (Exception e) {
+            LOG.error("Fail to reset next log index.", e);
+        } finally {
+            this.writeLock.unlock();
+        }
+        return false;
+    }
+
+    protected byte[] getKeyBytes(final long index) {
+        final byte[] ks = new byte[8];
+        Bits.putLong(ks, 0, index);
+        return ks;
+    }
+
+    protected LogEntry toLogEntry(byte[] value) {
+        if (value == null || value.length == 0) {
+            return null;
+        }
+        return this.logEntryDecoder.decode(value);
+    }
+
+    protected byte[] toByteArray(LogEntry logEntry) {
+        return this.logEntryEncoder.encode(logEntry);
+    }
+
+    /**
+     * Save the first log index into confMap
+     */
+    private boolean saveFirstLogIndex(final long firstLogIndex) {
+        this.readLock.lock();
+        try {
+            checkState();
+            byte[] firstLogIndexValue = getKeyBytes(firstLogIndex);
+            this.confMap.put(FIRST_LOG_IDX_KEY, firstLogIndexValue);
+            this.db.commit();
+            return true;
+        } catch (Exception e) {
+            LOG.error("Fail to save first log index {}.", firstLogIndex, e);
+        } finally {
+            this.readLock.unlock();
+        }
+        return false;
+    }
+
+    /**
+     * [startIndex, firstIndexKept)
+     */
+    private void truncatePrefixInBackground(final long startIndex, final long firstIndexKept) {
+        if (startIndex > firstIndexKept) {
+            return;
+        }
+        // delete logs in background.
+        ThreadPoolsFactory.runInThread(this.groupId, () -> {
+            this.writeLock.lock();
+            try {
+                checkState();
+                for (long index = startIndex; index < firstIndexKept; index++) {
+                    byte[] key = getKeyBytes(index);
+                    this.confMap.remove(key);
+                    this.defaultMap.remove(key);
+                }
+                this.db.commit();
+            } catch (Exception e) {
+                LOG.error("Fail to truncatePrefix {}.", firstIndexKept, e);
+            } finally {
+                this.writeLock.unlock();
+            }
+        });
+    }
+
+    private void checkState() {
+        Requires.requireTrue(opened, "Database not open. the path: %s", this.homePath);
+    }
+}

--- a/jraft-extension/mapdb-log-storage-impl/src/main/resources/META-INF/services/com.alipay.sofa.jraft.JRaftServiceFactory
+++ b/jraft-extension/mapdb-log-storage-impl/src/main/resources/META-INF/services/com.alipay.sofa.jraft.JRaftServiceFactory
@@ -1,0 +1,1 @@
+com.alipay.sofa.jraft.core.MapDBLogStorageJRaftServiceFactory

--- a/jraft-extension/mapdb-log-storage-impl/src/test/java/com/alipay/sofa/jraft/storage/BaseStorageTest.java
+++ b/jraft-extension/mapdb-log-storage-impl/src/test/java/com/alipay/sofa/jraft/storage/BaseStorageTest.java
@@ -1,0 +1,49 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alipay.sofa.jraft.storage;
+
+import java.io.File;
+import java.io.IOException;
+
+import org.apache.commons.io.FileUtils;
+import org.junit.After;
+import org.junit.Before;
+
+import com.alipay.sofa.jraft.test.TestUtils;
+
+public class BaseStorageTest {
+
+    protected String path;
+
+    @Before
+    public void setup() throws Exception {
+        this.path = TestUtils.mkTempDir();
+        FileUtils.forceMkdir(new File(this.path));
+    }
+
+    @After
+    public void teardown() throws Exception {
+        FileUtils.deleteDirectory(new File(this.path));
+    }
+
+    protected String writeData() throws IOException {
+        File file = new File(this.path + File.separator + "data");
+        String data = "jraft is great!";
+        FileUtils.writeStringToFile(file, data);
+        return data;
+    }
+}

--- a/jraft-extension/mapdb-log-storage-impl/src/test/java/com/alipay/sofa/jraft/storage/impl/BaseLogStorageTest.java
+++ b/jraft-extension/mapdb-log-storage-impl/src/test/java/com/alipay/sofa/jraft/storage/impl/BaseLogStorageTest.java
@@ -1,0 +1,255 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alipay.sofa.jraft.storage.impl;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import com.alipay.sofa.jraft.JRaftUtils;
+import com.alipay.sofa.jraft.conf.ConfigurationEntry;
+import com.alipay.sofa.jraft.conf.ConfigurationManager;
+import com.alipay.sofa.jraft.entity.EnumOutter;
+import com.alipay.sofa.jraft.entity.LogEntry;
+import com.alipay.sofa.jraft.entity.LogId;
+import com.alipay.sofa.jraft.entity.codec.LogEntryCodecFactory;
+import com.alipay.sofa.jraft.entity.codec.v2.LogEntryV2CodecFactory;
+import com.alipay.sofa.jraft.option.LogStorageOptions;
+import com.alipay.sofa.jraft.storage.BaseStorageTest;
+import com.alipay.sofa.jraft.storage.LogStorage;
+import com.alipay.sofa.jraft.test.TestUtils;
+import com.alipay.sofa.jraft.util.Utils;
+
+public abstract class BaseLogStorageTest extends BaseStorageTest {
+
+    protected LogStorage         logStorage;
+    private ConfigurationManager confManager;
+    private LogEntryCodecFactory logEntryCodecFactory;
+
+    @Override
+    @Before
+    public void setup() throws Exception {
+        super.setup();
+        this.confManager = new ConfigurationManager();
+        this.logEntryCodecFactory = LogEntryV2CodecFactory.getInstance();
+        this.logStorage = newLogStorage();
+
+        final LogStorageOptions opts = newLogStorageOptions();
+
+        this.logStorage.init(opts);
+    }
+
+    protected abstract LogStorage newLogStorage();
+
+    protected LogStorageOptions newLogStorageOptions() {
+        final LogStorageOptions opts = new LogStorageOptions();
+        opts.setConfigurationManager(this.confManager);
+        opts.setLogEntryCodecFactory(this.logEntryCodecFactory);
+        return opts;
+    }
+
+    @Override
+    @After
+    public void teardown() throws Exception {
+        this.logStorage.shutdown();
+        super.teardown();
+    }
+
+    @Test
+    public void testEmptyState() {
+        assertEquals(1, this.logStorage.getFirstLogIndex());
+        assertEquals(0, this.logStorage.getLastLogIndex());
+        assertNull(this.logStorage.getEntry(100));
+    }
+
+    @Test
+    public void testAddOneEntryState() {
+        final LogEntry entry1 = TestUtils.mockEntry(100, 1);
+        assertTrue(this.logStorage.appendEntry(entry1));
+
+        assertEquals(100, this.logStorage.getFirstLogIndex());
+        assertEquals(100, this.logStorage.getLastLogIndex());
+        Assert.assertEquals(entry1, this.logStorage.getEntry(100));
+        LogEntry logEntry1 = this.logStorage.getEntry(100);
+        assertNotNull(logEntry1);
+        assertEquals(entry1, logEntry1);
+        assertEquals(1, logEntry1.getId().getTerm());
+
+        final LogEntry entry2 = TestUtils.mockEntry(200, 2);
+        assertTrue(this.logStorage.appendEntry(entry2));
+
+        assertEquals(100, this.logStorage.getFirstLogIndex());
+        assertEquals(200, this.logStorage.getLastLogIndex());
+
+        logEntry1 = this.logStorage.getEntry(100);
+        final LogEntry logEntry2 = this.logStorage.getEntry(200);
+        assertNotNull(logEntry1);
+        assertNotNull(logEntry2);
+
+        Assert.assertEquals(entry1, logEntry1);
+        Assert.assertEquals(entry2, logEntry2);
+
+        assertEquals(1, logEntry1.getId().getTerm());
+        assertEquals(2, logEntry2.getId().getTerm());
+    }
+
+    @Test
+    public void testLoadWithConfigManager() {
+        assertTrue(this.confManager.getLastConfiguration().isEmpty());
+
+        final LogEntry confEntry1 = new LogEntry(EnumOutter.EntryType.ENTRY_TYPE_CONFIGURATION);
+        confEntry1.setId(new LogId(99, 1));
+        confEntry1.setPeers(JRaftUtils.getConfiguration("localhost:8081,localhost:8082").listPeers());
+
+        final LogEntry confEntry2 = new LogEntry(EnumOutter.EntryType.ENTRY_TYPE_CONFIGURATION);
+        confEntry2.setId(new LogId(100, 2));
+        confEntry2.setPeers(JRaftUtils.getConfiguration("localhost:8081,localhost:8082,localhost:8083").listPeers());
+
+        assertTrue(this.logStorage.appendEntry(confEntry1));
+        assertEquals(1, this.logStorage.appendEntries(Arrays.asList(confEntry2)));
+
+        // reload log storage.
+        this.logStorage.shutdown();
+        this.logStorage = newLogStorage();
+        this.logStorage.init(newLogStorageOptions());
+
+        ConfigurationEntry conf = this.confManager.getLastConfiguration();
+        assertNotNull(conf);
+        assertFalse(conf.isEmpty());
+        assertEquals("localhost:8081,localhost:8082,localhost:8083", conf.getConf().toString());
+        conf = this.confManager.get(99);
+        assertNotNull(conf);
+        assertFalse(conf.isEmpty());
+        assertEquals("localhost:8081,localhost:8082", conf.getConf().toString());
+    }
+
+    @Test
+    public void testAddManyEntries() {
+        final List<LogEntry> entries = TestUtils.mockEntries();
+
+        assertEquals(10, this.logStorage.appendEntries(entries));
+
+        assertEquals(0, this.logStorage.getFirstLogIndex());
+        assertEquals(9, this.logStorage.getLastLogIndex());
+        for (int i = 0; i < 10; i++) {
+            final LogEntry entry = this.logStorage.getEntry(i);
+            assertEquals(i, entry.getId().getTerm());
+            assertNotNull(entry);
+            assertEquals(entries.get(i), entry);
+        }
+    }
+
+    @Test
+    public void testReset() {
+        testAddManyEntries();
+        this.logStorage.reset(5);
+        assertEquals(5, this.logStorage.getFirstLogIndex());
+        assertEquals(5, this.logStorage.getLastLogIndex());
+        final LogEntry logEntry = this.logStorage.getEntry(5);
+        assertNotNull(logEntry);
+        assertEquals(5, logEntry.getId().getTerm());
+    }
+
+    @Test
+    public void testTruncatePrefix() {
+        final List<LogEntry> entries = TestUtils.mockEntries();
+
+        assertEquals(10, this.logStorage.appendEntries(entries));
+        this.logStorage.truncatePrefix(5);
+        assertEquals(5, this.logStorage.getFirstLogIndex());
+        assertEquals(9, this.logStorage.getLastLogIndex());
+        for (int i = 0; i < 10; i++) {
+            if (i < 5) {
+                assertNull(this.logStorage.getEntry(i));
+            } else {
+                Assert.assertEquals(entries.get(i), this.logStorage.getEntry(i));
+            }
+        }
+    }
+
+    @Test
+    public void testAppendManyLargeEntries() {
+        final long start = Utils.monotonicMs();
+        final int totalLogs = 100000;
+        final int logSize = 16 * 1024;
+        final int batch = 100;
+
+        appendLargeEntries(totalLogs, logSize, batch);
+        
+        final long cost = Utils.monotonicMs() - start;
+        System.out.println("Write " + totalLogs + " logs, cost " + cost + " ms.");
+
+        // verify
+        for (int i = 0; i < totalLogs; i++) {
+            final LogEntry entry = this.logStorage.getEntry(i);
+            assertNotNull(entry);
+            assertEquals(logSize, entry.getData().remaining());
+            assertEquals(i, entry.getId().getIndex());
+            assertEquals(i, entry.getId().getTerm());
+        }
+    }
+
+    protected void appendLargeEntries(final int totalLogs, final int logSize, final int batch) {
+        for (int i = 0; i < totalLogs; i += batch) {
+            final List<LogEntry> entries = new ArrayList<>(batch);
+            for (int j = 0; j < batch; j++) {
+                entries.add(TestUtils.mockEntry(i + j, i + j, logSize));
+            }
+            final int nAppended = this.logStorage.appendEntries(entries);
+            assertEquals(batch, nAppended);
+        }
+    }
+
+    @Test
+    public void testTruncateSuffix() {
+        final List<LogEntry> entries = TestUtils.mockEntries();
+        assertEquals(10, this.logStorage.appendEntries(entries));
+
+        this.logStorage.truncateSuffix(5);
+        assertEquals(0, this.logStorage.getFirstLogIndex());
+        assertEquals(5, this.logStorage.getLastLogIndex());
+        for (int i = 0; i < 10; i++) {
+            if (i <= 5) {
+                Assert.assertEquals(entries.get(i), this.logStorage.getEntry(i));
+            } else {
+                assertNull(this.logStorage.getEntry(i));
+            }
+        }
+    }
+
+    @Test
+    public void testGetTerm() {
+        final List<LogEntry> entries = TestUtils.mockEntries();
+        assertEquals(10, this.logStorage.appendEntries(entries));
+
+        assertEquals(0, this.logStorage.getTerm(100));
+        for (int i = 0; i < 10; i++) {
+            assertEquals(i, this.logStorage.getTerm(i));
+        }
+    }
+}

--- a/jraft-extension/mapdb-log-storage-impl/src/test/java/com/alipay/sofa/jraft/storage/impl/BaseLogStorageTest.java
+++ b/jraft-extension/mapdb-log-storage-impl/src/test/java/com/alipay/sofa/jraft/storage/impl/BaseLogStorageTest.java
@@ -200,7 +200,7 @@ public abstract class BaseLogStorageTest extends BaseStorageTest {
         final int batch = 100;
 
         appendLargeEntries(totalLogs, logSize, batch);
-        
+
         final long cost = Utils.monotonicMs() - start;
         System.out.println("Write " + totalLogs + " logs, cost " + cost + " ms.");
 

--- a/jraft-extension/mapdb-log-storage-impl/src/test/java/com/alipay/sofa/jraft/storage/impl/MapDBLogStorageTest.java
+++ b/jraft-extension/mapdb-log-storage-impl/src/test/java/com/alipay/sofa/jraft/storage/impl/MapDBLogStorageTest.java
@@ -1,0 +1,28 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alipay.sofa.jraft.storage.impl;
+
+import com.alipay.sofa.jraft.option.RaftOptions;
+import com.alipay.sofa.jraft.storage.LogStorage;
+
+public class MapDBLogStorageTest extends BaseLogStorageTest {
+
+    @Override
+    protected LogStorage newLogStorage() {
+        return new MapDBLogStorage(this.path, new RaftOptions());
+    }
+}

--- a/jraft-extension/mapdb-log-storage-impl/src/test/java/com/alipay/sofa/jraft/test/TestUtils.java
+++ b/jraft-extension/mapdb-log-storage-impl/src/test/java/com/alipay/sofa/jraft/test/TestUtils.java
@@ -1,0 +1,137 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alipay.sofa.jraft.test;
+
+import java.lang.management.ManagementFactory;
+import java.lang.management.ThreadInfo;
+import java.lang.management.ThreadMXBean;
+import java.net.Inet4Address;
+import java.net.InetAddress;
+import java.net.NetworkInterface;
+import java.net.SocketException;
+import java.nio.ByteBuffer;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.Enumeration;
+import java.util.List;
+import java.util.concurrent.ThreadLocalRandom;
+
+import com.alipay.sofa.jraft.JRaftUtils;
+import com.alipay.sofa.jraft.conf.ConfigurationEntry;
+import com.alipay.sofa.jraft.entity.EnumOutter;
+import com.alipay.sofa.jraft.entity.LogEntry;
+import com.alipay.sofa.jraft.entity.LogId;
+import com.alipay.sofa.jraft.entity.PeerId;
+import com.alipay.sofa.jraft.rpc.RpcRequests;
+import com.alipay.sofa.jraft.util.Endpoint;
+
+/**
+ * Test helper
+ *
+ * @author boyan (boyan@alibaba-inc.com)
+ *
+ *         2018-Apr-11 10:16:07 AM
+ */
+public class TestUtils {
+
+    public static ConfigurationEntry getConfEntry(final String confStr, final String oldConfStr) {
+        ConfigurationEntry entry = new ConfigurationEntry();
+        entry.setConf(JRaftUtils.getConfiguration(confStr));
+        entry.setOldConf(JRaftUtils.getConfiguration(oldConfStr));
+        return entry;
+    }
+
+    public static void dumpThreads() {
+        try {
+            ThreadMXBean bean = ManagementFactory.getThreadMXBean();
+            ThreadInfo[] infos = bean.dumpAllThreads(true, true);
+            for (ThreadInfo info : infos) {
+                System.out.println(info);
+            }
+        } catch (Throwable t) {
+            t.printStackTrace(); // NOPMD
+        }
+    }
+
+    public static String mkTempDir() {
+        return Paths.get(System.getProperty("java.io.tmpdir", "/tmp"), "jraft_test_" + System.nanoTime()).toString();
+    }
+
+    public static LogEntry mockEntry(final int index, final int term) {
+        return mockEntry(index, term, 0);
+    }
+
+    public static LogEntry mockEntry(final int index, final int term, final int dataSize) {
+        LogEntry entry = new LogEntry(EnumOutter.EntryType.ENTRY_TYPE_NO_OP);
+        entry.setId(new LogId(index, term));
+        if (dataSize > 0) {
+            byte[] bs = new byte[dataSize];
+            ThreadLocalRandom.current().nextBytes(bs);
+            entry.setData(ByteBuffer.wrap(bs));
+        }
+        return entry;
+    }
+
+    public static List<LogEntry> mockEntries() {
+        return mockEntries(10);
+    }
+
+    public static List<LogEntry> mockEntries(final int n) {
+        List<LogEntry> entries = new ArrayList<>();
+        for (int i = 0; i < n; i++) {
+            LogEntry entry = mockEntry(i, i);
+            if (i > 0) {
+                entry.setData(ByteBuffer.wrap(String.valueOf(i).getBytes()));
+            }
+            entries.add(entry);
+        }
+        return entries;
+    }
+
+    public static String getMyIp() {
+        String ip = null;
+        try {
+            Enumeration<NetworkInterface> interfaces = NetworkInterface.getNetworkInterfaces();
+            while (interfaces.hasMoreElements()) {
+                NetworkInterface iface = interfaces.nextElement();
+                // filters out 127.0.0.1 and inactive interfaces
+                if (iface.isLoopback() || !iface.isUp()) {
+                    continue;
+                }
+                Enumeration<InetAddress> addresses = iface.getInetAddresses();
+                while (addresses.hasMoreElements()) {
+                    InetAddress addr = addresses.nextElement();
+                    if (addr instanceof Inet4Address) {
+                        ip = addr.getHostAddress();
+                        break;
+                    }
+                }
+            }
+        } catch (SocketException e) {
+            e.printStackTrace();
+        }
+        return ip;
+    }
+
+    public static List<PeerId> generatePeers(int num) {
+        List<PeerId> peers = new ArrayList<>();
+        for (int i = 0; i < num; i++) {
+            peers.add(new PeerId("localhost", 8080 + i));
+        }
+        return peers;
+    }
+}

--- a/jraft-extension/pom.xml
+++ b/jraft-extension/pom.xml
@@ -13,6 +13,10 @@
     <modules>
         <module>rpc-grpc-impl</module>
         <module>bdb-log-storage-impl</module>
+        <module>leveldb-log-storage-impl</module>
+        <module>h2mvstore-log-storage-impl</module>
+        <module>mapdb-log-storage-impl</module>
+        <module>chronicle-map-log-storage-impl</module>
     </modules>
 
 </project>


### PR DESCRIPTION
### Motivation:

由于Nacos引用了sofa-jraft,在申威平台上运行时发现RocksDB无法执行，在参考了BDBLogStorage， 增加了基于ChronicleMap、MapDB、H2MVStore、LevelDB-Java实现的日志存储 

### Modification:

1、在AI（qwen3-coder）的帮助下，参考BDBLogStorage 基于ChronicleMap、MapDB、H2MVStore、LevelDB-Java实现
2、通过单元测试

### Result:
目前几个实现都动同过了测试，但是ChronicleMapLogStorage只能在jdk8上通过测试（需要帮助，希望能在jdk17以上版本测试通过）


以下是写入性能

Ubuntu

ChronicleMapLogStorage
Write 100000 logs, cost 4472 ms.

MapDBLogStorage
Write 100000 logs, cost 27631 ms.

H2MVStoreLogStorage
Write 100000 logs, cost 4330 ms.

LevelDBLogStorage
Write 100000 logs, cost 7730 ms.


MacOS

ChronicleMapLogStorage
（github Action MacOS上没有JDK8））

MapDBLogStorage
Write 100000 logs, cost 20340 ms.

H2MVStoreLogStorage
Write 100000 logs, cost 3403 ms.

LevelDBLogStorage
Write 100000 logs, cost 5077 ms.


Windows

ChronicleMapLogStorage
Write 100000 logs, cost 4054 ms.

MapDBLogStorage
Write 100000 logs, cost 226473 ms.

H2MVStoreLogStorage
Write 100000 logs, cost 3295 ms.

LevelDBLogStorage
Write 100000 logs, cost 39628 ms.

