### PR TITLE
feat: make LIST_ARRAY_GETTER optional

### DIFF
--- a/jraft-core/src/main/java/com/alipay/sofa/jraft/util/SegmentList.java
+++ b/jraft-core/src/main/java/com/alipay/sofa/jraft/util/SegmentList.java
@@ -427,10 +427,15 @@ public class SegmentList<T extends SegmentList.EstimatedSize> {
         }
     }
 
-    private static final ReferenceFieldUpdater<ArrayList<?>, Object[]> LIST_ARRAY_GETTER = Updaters
-                                                                                             .newReferenceFieldUpdater(
-                                                                                                 ArrayList.class,
-                                                                                                 "elementData");
+    private static ReferenceFieldUpdater<ArrayList<?>, Object[]> LIST_ARRAY_GETTER = null;
+
+    static {
+        try {
+            LIST_ARRAY_GETTER = Updaters.newReferenceFieldUpdater(ArrayList.class, "elementData");
+        } catch (Throwable t) {
+            //ignore
+        }
+    }
 
     @SuppressWarnings("unchecked")
     public void addAll(final Collection<T> coll) {
@@ -457,7 +462,7 @@ public class SegmentList<T extends SegmentList.EstimatedSize> {
 
     private Object[] coll2Array(final Collection<T> coll) {
         Object[] src;
-        if (coll instanceof ArrayList && UnsafeUtil.hasUnsafe()) {
+        if (LIST_ARRAY_GETTER != null && coll instanceof ArrayList && UnsafeUtil.hasUnsafe()) {
             src = LIST_ARRAY_GETTER.get((ArrayList<T>) coll);
         } else {
             src = coll.toArray();

--- a/jraft-core/src/main/java/com/alipay/sofa/jraft/util/internal/ThrowUtil.java
+++ b/jraft-core/src/main/java/com/alipay/sofa/jraft/util/internal/ThrowUtil.java
@@ -23,9 +23,6 @@ package com.alipay.sofa.jraft.util.internal;
  */
 public final class ThrowUtil {
 
-    private static final ReferenceFieldUpdater<Throwable, Throwable> causeUpdater = Updaters.newReferenceFieldUpdater(
-                                                                                      Throwable.class, "cause");
-
     /**
      * Raises an exception bypassing compiler checks for checked exceptions.
      */
@@ -51,19 +48,6 @@ public final class ThrowUtil {
     @SuppressWarnings("unchecked")
     private static <E extends Throwable> void throwException0(final Throwable t) throws E {
         throw (E) t;
-    }
-
-    public static <T extends Throwable> T cutCause(final T cause) {
-        Throwable rootCause = cause;
-        while (rootCause.getCause() != null) {
-            rootCause = rootCause.getCause();
-        }
-
-        if (rootCause != cause) {
-            cause.setStackTrace(rootCause.getStackTrace());
-            causeUpdater.set(cause, rootCause);
-        }
-        return cause;
     }
 
     public static Throwable getRootCause(final Throwable cause) {


### PR DESCRIPTION
### Motivation:

Explain the context, and why you're making that change.
To make others understand what is the problem you're trying to solve.

### Modification:

Make the `LIST_ARRAY_GETTER` optional to avoid compilation error in latest jdk.

### Result:

Fixes #<GitHub issue number>.

If there is no issue then describe the changes introduced by this PR.
