### PR TITLE
[AI-8th] Cleanup unused imports for issue #1173

### DIFF
--- a/jraft-core/src/main/java/com/alipay/sofa/jraft/core/ReadOnlyServiceImpl.java
+++ b/jraft-core/src/main/java/com/alipay/sofa/jraft/core/ReadOnlyServiceImpl.java
@@ -29,7 +29,6 @@ import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
 import java.util.stream.Collectors;
 
-import com.alipay.sofa.jraft.entity.EnumOutter;
 import com.alipay.sofa.jraft.option.ReadOnlyOption;
 import com.alipay.sofa.jraft.util.ThreadPoolsFactory;
 import org.slf4j.Logger;

--- a/jraft-core/src/main/java/com/alipay/sofa/jraft/rpc/impl/AbstractClientService.java
+++ b/jraft-core/src/main/java/com/alipay/sofa/jraft/rpc/impl/AbstractClientService.java
@@ -45,7 +45,6 @@ import com.alipay.sofa.jraft.util.NamedThreadFactory;
 import com.alipay.sofa.jraft.util.RpcFactoryHelper;
 import com.alipay.sofa.jraft.util.ThreadPoolMetricSet;
 import com.alipay.sofa.jraft.util.ThreadPoolUtil;
-import com.alipay.sofa.jraft.util.Utils;
 import com.google.protobuf.Descriptors;
 import com.google.protobuf.Message;
 

--- a/jraft-core/src/test/java/com/alipay/sofa/jraft/closure/ClosureQueueTest.java
+++ b/jraft-core/src/test/java/com/alipay/sofa/jraft/closure/ClosureQueueTest.java
@@ -20,8 +20,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.CountDownLatch;
 
-import com.alipay.sofa.jraft.util.ThreadPoolsFactory;
-import com.codahale.metrics.MetricRegistry;
 import org.junit.Before;
 import org.junit.Test;
 

--- a/jraft-core/src/test/java/com/alipay/sofa/jraft/core/IteratorTest.java
+++ b/jraft-core/src/test/java/com/alipay/sofa/jraft/core/IteratorTest.java
@@ -21,7 +21,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicLong;
 
-import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;

--- a/jraft-core/src/test/java/com/alipay/sofa/jraft/util/ThreadPoolsFactoryTest.java
+++ b/jraft-core/src/test/java/com/alipay/sofa/jraft/util/ThreadPoolsFactoryTest.java
@@ -21,7 +21,6 @@ import java.util.concurrent.SynchronousQueue;
 import java.util.concurrent.ThreadPoolExecutor;
 
 import org.junit.Assert;
-import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.runners.MockitoJUnitRunner;

--- a/jraft-core/src/test/java/com/alipay/sofa/jraft/util/UtilsTest.java
+++ b/jraft-core/src/test/java/com/alipay/sofa/jraft/util/UtilsTest.java
@@ -17,19 +17,12 @@
 package com.alipay.sofa.jraft.util;
 
 import java.nio.ByteBuffer;
-import java.util.concurrent.CountDownLatch;
 
 import org.junit.Assert;
 import org.junit.Test;
 
-import com.alipay.sofa.jraft.Closure;
-import com.alipay.sofa.jraft.Status;
-import com.alipay.sofa.jraft.error.RaftError;
-
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertTrue;
 
 /**
  * 

--- a/jraft-test/src/main/java/com/alipay/sofa/jraft/test/atomic/server/AtomicStateMachine.java
+++ b/jraft-test/src/main/java/com/alipay/sofa/jraft/test/atomic/server/AtomicStateMachine.java
@@ -47,7 +47,6 @@ import com.alipay.sofa.jraft.test.atomic.command.GetCommand;
 import com.alipay.sofa.jraft.test.atomic.command.IncrementAndGetCommand;
 import com.alipay.sofa.jraft.test.atomic.command.SetCommand;
 import com.alipay.sofa.jraft.test.atomic.command.ValueCommand;
-import com.alipay.sofa.jraft.util.Utils;
 
 /**
  * Atomic state machine


### PR DESCRIPTION
## Summary
- clean up unused imports reported in issue #1173
- keep the change scoped to import removal only, with no behavior changes
- update only the files that still contain confirmed unused imports on the current branch

Closes #1173

## Files Updated
- `jraft-core/src/main/java/com/alipay/sofa/jraft/rpc/impl/AbstractClientService.java`
- `jraft-test/src/main/java/com/alipay/sofa/jraft/test/atomic/server/AtomicStateMachine.java`
- `jraft-core/src/test/java/com/alipay/sofa/jraft/closure/ClosureQueueTest.java`
- `jraft-core/src/test/java/com/alipay/sofa/jraft/core/IteratorTest.java`
- `jraft-core/src/main/java/com/alipay/sofa/jraft/core/ReadOnlyServiceImpl.java`
- `jraft-core/src/test/java/com/alipay/sofa/jraft/util/ThreadPoolsFactoryTest.java`
- `jraft-core/src/test/java/com/alipay/sofa/jraft/util/UtilsTest.java`

## Verification
- IntelliJ incremental build on touched files: passed
- `mvn -pl jraft-core -Dtest=ClosureQueueTest,IteratorTest,ThreadPoolsFactoryTest,UtilsTest -DfailIfNoTests=false test`: passed
- full `mvn test` was also attempted, but the current Windows environment still has existing unrelated failures in baseline tests such as `NodeTest` and storage tests involving `madvise` JNI

## AI Collaboration Record
- Used AI agent to inspect issue context and compare it with the current repository state
- Used IDE inspections to confirm which imports are actually unused on the current branch instead of blindly applying the original issue list
- Applied a minimal patch that only removes unused imports
- Performed targeted verification after the change

## Prompting Notes
- Ask the agent to validate the issue list against the current branch before editing
- Keep the patch minimal and avoid mixing unrelated warning cleanups into a beginner-friendly task
- Separate baseline environment failures from regressions introduced by the patch