### PR TITLE
[AI-8th] fix vulnerable dependency versions for issue 1218

### DIFF
--- a/jraft-core/pom.xml
+++ b/jraft-core/pom.xml
@@ -101,8 +101,8 @@
             <artifactId>commons-io</artifactId>
         </dependency>
         <dependency>
-            <groupId>commons-lang</groupId>
-            <artifactId>commons-lang</artifactId>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
         </dependency>
         <!-- bolt -->
         <dependency>

--- a/jraft-core/src/main/java/com/alipay/sofa/jraft/JRaftUtils.java
+++ b/jraft-core/src/main/java/com/alipay/sofa/jraft/JRaftUtils.java
@@ -21,7 +21,7 @@ import java.util.concurrent.SynchronousQueue;
 import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.ThreadPoolExecutor;
 
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 
 import com.alipay.sofa.jraft.conf.Configuration;
 import com.alipay.sofa.jraft.core.NodeImpl;

--- a/jraft-core/src/main/java/com/alipay/sofa/jraft/RaftGroupService.java
+++ b/jraft-core/src/main/java/com/alipay/sofa/jraft/RaftGroupService.java
@@ -16,7 +16,7 @@
  */
 package com.alipay.sofa.jraft;
 
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/jraft-core/src/main/java/com/alipay/sofa/jraft/RouteTable.java
+++ b/jraft-core/src/main/java/com/alipay/sofa/jraft/RouteTable.java
@@ -24,7 +24,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.locks.StampedLock;
 
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/jraft-core/src/main/java/com/alipay/sofa/jraft/conf/Configuration.java
+++ b/jraft-core/src/main/java/com/alipay/sofa/jraft/conf/Configuration.java
@@ -24,7 +24,7 @@ import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
 
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/jraft-core/src/main/java/com/alipay/sofa/jraft/core/CliServiceImpl.java
+++ b/jraft-core/src/main/java/com/alipay/sofa/jraft/core/CliServiceImpl.java
@@ -28,7 +28,7 @@ import java.util.Set;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/jraft-core/src/main/java/com/alipay/sofa/jraft/core/DefaultJRaftServiceFactory.java
+++ b/jraft-core/src/main/java/com/alipay/sofa/jraft/core/DefaultJRaftServiceFactory.java
@@ -17,7 +17,7 @@
 package com.alipay.sofa.jraft.core;
 
 import com.alipay.sofa.jraft.option.NodeOptions;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 
 import com.alipay.sofa.jraft.JRaftServiceFactory;
 import com.alipay.sofa.jraft.entity.codec.LogEntryCodecFactory;

--- a/jraft-core/src/main/java/com/alipay/sofa/jraft/core/NodeImpl.java
+++ b/jraft-core/src/main/java/com/alipay/sofa/jraft/core/NodeImpl.java
@@ -34,7 +34,7 @@ import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReadWriteLock;
 import java.util.stream.Collectors;
 
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/jraft-core/src/main/java/com/alipay/sofa/jraft/entity/PeerId.java
+++ b/jraft-core/src/main/java/com/alipay/sofa/jraft/entity/PeerId.java
@@ -18,7 +18,7 @@ package com.alipay.sofa.jraft.entity;
 
 import java.io.Serializable;
 
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/jraft-core/src/main/java/com/alipay/sofa/jraft/rpc/ProtobufMsgFactory.java
+++ b/jraft-core/src/main/java/com/alipay/sofa/jraft/rpc/ProtobufMsgFactory.java
@@ -23,7 +23,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import org.apache.commons.lang.SerializationException;
+import org.apache.commons.lang3.SerializationException;
 
 import com.alipay.sofa.jraft.error.MessageClassNotFoundException;
 import com.alipay.sofa.jraft.storage.io.ProtoBufFile;

--- a/jraft-core/src/main/java/com/alipay/sofa/jraft/rpc/impl/cli/BaseCliRequestProcessor.java
+++ b/jraft-core/src/main/java/com/alipay/sofa/jraft/rpc/impl/cli/BaseCliRequestProcessor.java
@@ -19,7 +19,7 @@ package com.alipay.sofa.jraft.rpc.impl.cli;
 import java.util.List;
 import java.util.concurrent.Executor;
 
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/jraft-core/src/main/java/com/alipay/sofa/jraft/storage/snapshot/SnapshotExecutorImpl.java
+++ b/jraft-core/src/main/java/com/alipay/sofa/jraft/storage/snapshot/SnapshotExecutorImpl.java
@@ -25,7 +25,7 @@ import java.util.concurrent.locks.ReentrantLock;
 
 import com.alipay.sofa.jraft.option.NodeOptions;
 import com.alipay.sofa.jraft.util.ThreadPoolsFactory;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/jraft-core/src/main/java/com/alipay/sofa/jraft/storage/snapshot/local/LocalSnapshotStorage.java
+++ b/jraft-core/src/main/java/com/alipay/sofa/jraft/storage/snapshot/local/LocalSnapshotStorage.java
@@ -29,7 +29,7 @@ import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
 
 import org.apache.commons.io.FileUtils;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/jraft-core/src/main/java/com/alipay/sofa/jraft/util/Utils.java
+++ b/jraft-core/src/main/java/com/alipay/sofa/jraft/util/Utils.java
@@ -38,7 +38,7 @@ import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 import java.util.regex.Pattern;
 
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/jraft-example/src/main/java/com/alipay/sofa/jraft/example/counter/CounterServiceImpl.java
+++ b/jraft-example/src/main/java/com/alipay/sofa/jraft/example/counter/CounterServiceImpl.java
@@ -19,7 +19,7 @@ package com.alipay.sofa.jraft.example.counter;
 import java.nio.ByteBuffer;
 import java.util.concurrent.Executor;
 
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/jraft-example/src/main/java/com/alipay/sofa/jraft/example/counter/snapshot/CounterSnapshotFile.java
+++ b/jraft-example/src/main/java/com/alipay/sofa/jraft/example/counter/snapshot/CounterSnapshotFile.java
@@ -20,7 +20,7 @@ import java.io.File;
 import java.io.IOException;
 
 import org.apache.commons.io.FileUtils;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/jraft-test/src/main/java/com/alipay/sofa/jraft/test/atomic/server/StartupConf.java
+++ b/jraft-test/src/main/java/com/alipay/sofa/jraft/test/atomic/server/StartupConf.java
@@ -21,7 +21,7 @@ import java.io.FileInputStream;
 import java.io.IOException;
 import java.util.Properties;
 
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 
 import com.alipay.sofa.jraft.JRaftUtils;
 import com.alipay.sofa.jraft.conf.Configuration;

--- a/pom.xml
+++ b/pom.xml
@@ -52,11 +52,11 @@
         <asm.version>6.0</asm.version>
         <bolt.version>1.6.7</bolt.version>
         <commons.compress.version>1.21</commons.compress.version>
-        <commons.io.version>2.8.0</commons.io.version>
-        <commons.lang.version>2.6</commons.lang.version>
+        <commons.io.version>2.20.0</commons.io.version>
+        <commons.lang3.version>3.18.0</commons.lang3.version>
         <disruptor.version>3.3.7</disruptor.version>
         <hamcrest.version>1.3</hamcrest.version>
-        <hessian.version>3.3.6</hessian.version>
+        <hessian.version>4.0.4</hessian.version>
         <jacoco.path>${project.build.directory}/jacoco.exec</jacoco.path>
         <jacoco.skip>true</jacoco.skip>
         <java.source.version>1.8</java.source.version>
@@ -186,9 +186,9 @@
                 <version>${commons.compress.version}</version>
             </dependency>
             <dependency>
-                <groupId>commons-lang</groupId>
-                <artifactId>commons-lang</artifactId>
-                <version>${commons.lang.version}</version>
+                <groupId>org.apache.commons</groupId>
+                <artifactId>commons-lang3</artifactId>
+                <version>${commons.lang3.version}</version>
             </dependency>
             <!-- protobuf -->
             <dependency>


### PR DESCRIPTION
## Summary
- upgrade `commons-io` from `2.8.0` to `2.20.0`
- replace `commons-lang:commons-lang` with `org.apache.commons:commons-lang3:3.18.0`
- migrate `StringUtils` and `SerializationException` imports to `commons-lang3`
- upgrade `com.alipay.sofa:hessian` from `3.3.6` to `4.0.4`

## Verification
- ran `mvn test` in the workspace: compilation and dependency resolution for the updated artifacts succeeded
- the full test suite still fails on Windows in existing native/environment-sensitive tests, including `madvise`-related storage tests and a batch of `NodeTest` cluster cases

## AI Collaboration Record
- used Codex as the AI agent to inspect issue #1218, locate dependency declarations, and identify all `commons-lang` import sites
- let the agent update the Maven coordinates and migrate the Java imports from `commons-lang` to `commons-lang3`
- manually reviewed the final diff, confirmed the change scope was limited to dependency declarations and import rewrites, then validated with Maven in the local environment

## Prompt Notes
- first constrained the task to the issue scope: vulnerable dependencies only, no unrelated refactors
- then asked the agent to verify whether `commons-lang` could be bumped directly or required an artifact migration to `commons-lang3`
- kept the validation goal explicit: dependency resolution, compilation, and clear reporting of environment-specific test failures

Closes #1218