### PR TITLE
[AI-8th] upgrade rocksdb and slf4j with Java 8 compatibility fixes

### DIFF
--- a/jraft-core/pom.xml
+++ b/jraft-core/pom.xml
@@ -79,7 +79,7 @@
         </dependency>
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
-            <artifactId>log4j-slf4j-impl</artifactId>
+            <artifactId>log4j-slf4j2-impl</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/jraft-core/src/main/java/com/alipay/sofa/common/log/factory/LoggerSpaceFactory4Log4j2Builder.java
+++ b/jraft-core/src/main/java/com/alipay/sofa/common/log/factory/LoggerSpaceFactory4Log4j2Builder.java
@@ -1,0 +1,216 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alipay.sofa.common.log.factory;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Method;
+import java.net.URI;
+import java.net.URL;
+import java.util.Map;
+import java.util.Properties;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+
+import org.slf4j.Logger;
+
+import com.alipay.sofa.common.log.SpaceInfo;
+import com.alipay.sofa.common.log.adapter.level.AdapterLevel;
+
+/**
+ * Compatibility override for Java 8 projects upgrading to slf4j 2.x.
+ * sofa-common-tools 1.0.12 hardcodes the old Log4jLogger constructor removed by log4j-slf4j2-impl.
+ */
+public class LoggerSpaceFactory4Log4j2Builder extends AbstractLoggerSpaceFactoryBuilder {
+
+    public LoggerSpaceFactory4Log4j2Builder(final SpaceInfo spaceInfo) {
+        super(spaceInfo);
+    }
+
+    @Override
+    protected String getLoggingToolName() {
+        return "log4j2";
+    }
+
+    @Override
+    public AbstractLoggerSpaceFactory doBuild(final String spaceName, final ClassLoader classLoader, final URL url) {
+        try {
+            final Object context = newLoggerContext(spaceName, url.toURI());
+            final Object configuration = getConfiguration(spaceName, classLoader, url.toURI(), context);
+            if (configuration == null) {
+                throw new RuntimeException("No log4j2 configuration are found.");
+            }
+
+            mergeProperties(configuration, getProperties());
+            mergeProperties(configuration, System.getProperties());
+            invoke(context, "start", new Class<?>[] { configurationClass() }, configuration);
+
+            return new AbstractLoggerSpaceFactory(getLoggingToolName()) {
+                private final ConcurrentMap<String, Logger> loggerMap     = new ConcurrentHashMap<>();
+                private final Object                        markerFactory = newLog4jMarkerFactory();
+
+                @Override
+                public Logger setLevel(final String loggerName, final AdapterLevel level) {
+                    final String actualLoggerName = "ROOT".equals(loggerName) ? "" : loggerName;
+                    final Object logger = invoke(context, "getLogger", new Class<?>[] { String.class },
+                        actualLoggerName);
+                    invoke(logger, "setLevel", new Class<?>[] { levelClass() }, toLog4j2Level(level));
+                    return getLogger(loggerName);
+                }
+
+                @Override
+                public Logger getLogger(final String loggerName) {
+                    final String actualLoggerName = "ROOT".equals(loggerName) ? "" : loggerName;
+                    final Logger existing = this.loggerMap.get(actualLoggerName);
+                    if (existing != null) {
+                        return existing;
+                    }
+
+                    final Object extendedLogger = invoke(context, "getLogger", new Class<?>[] { String.class },
+                        actualLoggerName);
+                    final Logger created = newLog4jLogger(this.markerFactory, extendedLogger, actualLoggerName);
+                    final Logger raced = this.loggerMap.putIfAbsent(actualLoggerName, created);
+                    return raced == null ? created : raced;
+                }
+
+                private Object toLog4j2Level(final AdapterLevel level) {
+                    if (level == null) {
+                        return enumValue("org.apache.logging.log4j.Level", "INFO");
+                    }
+                    switch (level) {
+                        case ERROR:
+                            return enumValue("org.apache.logging.log4j.Level", "ERROR");
+                        case WARN:
+                            return enumValue("org.apache.logging.log4j.Level", "WARN");
+                        case INFO:
+                            return enumValue("org.apache.logging.log4j.Level", "INFO");
+                        case DEBUG:
+                            return enumValue("org.apache.logging.log4j.Level", "DEBUG");
+                        case TRACE:
+                            return enumValue("org.apache.logging.log4j.Level", "TRACE");
+                        default:
+                            return enumValue("org.apache.logging.log4j.Level", "INFO");
+                    }
+                }
+            };
+        } catch (final Throwable t) {
+            throw new IllegalStateException("Log4j2 loggerSpaceFactory build error!", t);
+        }
+    }
+
+    private static Object getConfiguration(final String spaceName, final ClassLoader classLoader, final URI uri,
+                                           final Object context) throws Exception {
+        final Object configurationFactory = invokeStatic(configurationFactoryClass(), "getInstance", new Class<?>[0]);
+        try {
+            final Method method = configurationFactory.getClass().getMethod("getConfiguration", String.class,
+                URI.class, ClassLoader.class);
+            return method.invoke(configurationFactory, spaceName, uri, classLoader);
+        } catch (final NoSuchMethodException ignored) {
+            final Method method = configurationFactory.getClass().getMethod("getConfiguration", loggerContextClass(),
+                String.class, URI.class, ClassLoader.class);
+            return method.invoke(configurationFactory, context, spaceName, uri, classLoader);
+        }
+    }
+
+    private static void mergeProperties(final Object configuration, final Properties properties) {
+        @SuppressWarnings("unchecked")
+        final Map<String, String> configurationProperties = (Map<String, String>) invoke(configuration,
+            "getProperties", new Class<?>[0]);
+        for (final Map.Entry<Object, Object> entry : properties.entrySet()) {
+            configurationProperties.put(String.valueOf(entry.getKey()), String.valueOf(entry.getValue()));
+        }
+    }
+
+    private static Object newLoggerContext(final String spaceName, final URI uri) throws Exception {
+        final Constructor<?> constructor = loggerContextClass().getConstructor(String.class, Object.class, URI.class);
+        return constructor.newInstance(spaceName, null, uri);
+    }
+
+    private static Object newLog4jMarkerFactory() {
+        return newInstance("org.apache.logging.slf4j.Log4jMarkerFactory");
+    }
+
+    private static Logger newLog4jLogger(final Object markerFactory, final Object extendedLogger,
+                                         final String loggerName) {
+        return (Logger) newInstance("org.apache.logging.slf4j.Log4jLogger", new Class<?>[] {
+                loadClass("org.apache.logging.slf4j.Log4jMarkerFactory"),
+                loadClass("org.apache.logging.log4j.spi.ExtendedLogger"), String.class }, markerFactory,
+            extendedLogger, loggerName);
+    }
+
+    private static Object enumValue(final String className, final String constant) {
+        @SuppressWarnings({ "rawtypes", "unchecked" })
+        final Object value = Enum.valueOf((Class) loadClass(className), constant);
+        return value;
+    }
+
+    private static Object invoke(final Object target, final String methodName, final Class<?>[] parameterTypes,
+                                 final Object... args) {
+        try {
+            final Method method = target.getClass().getMethod(methodName, parameterTypes);
+            return method.invoke(target, args);
+        } catch (final Exception e) {
+            throw new IllegalStateException(e);
+        }
+    }
+
+    private static Object invokeStatic(final Class<?> type, final String methodName, final Class<?>[] parameterTypes,
+                                       final Object... args) {
+        try {
+            final Method method = type.getMethod(methodName, parameterTypes);
+            return method.invoke(null, args);
+        } catch (final Exception e) {
+            throw new IllegalStateException(e);
+        }
+    }
+
+    private static Object newInstance(final String className) {
+        return newInstance(className, new Class<?>[0]);
+    }
+
+    private static Object newInstance(final String className, final Class<?>[] parameterTypes, final Object... args) {
+        try {
+            final Constructor<?> constructor = loadClass(className).getConstructor(parameterTypes);
+            return constructor.newInstance(args);
+        } catch (final Exception e) {
+            throw new IllegalStateException(e);
+        }
+    }
+
+    private static Class<?> configurationFactoryClass() {
+        return loadClass("org.apache.logging.log4j.core.config.ConfigurationFactory");
+    }
+
+    private static Class<?> configurationClass() {
+        return loadClass("org.apache.logging.log4j.core.config.Configuration");
+    }
+
+    private static Class<?> loggerContextClass() {
+        return loadClass("org.apache.logging.log4j.core.LoggerContext");
+    }
+
+    private static Class<?> levelClass() {
+        return loadClass("org.apache.logging.log4j.Level");
+    }
+
+    private static Class<?> loadClass(final String className) {
+        try {
+            return Class.forName(className);
+        } catch (final ClassNotFoundException e) {
+            throw new IllegalStateException(e);
+        }
+    }
+}

--- a/jraft-core/src/main/java/com/alipay/sofa/jraft/storage/log/SegmentFile.java
+++ b/jraft-core/src/main/java/com/alipay/sofa/jraft/storage/log/SegmentFile.java
@@ -45,6 +45,7 @@ import com.alipay.sofa.jraft.util.Bits;
 import com.alipay.sofa.jraft.util.BufferUtils;
 import com.alipay.sofa.jraft.util.BytesUtil;
 import com.alipay.sofa.jraft.util.OnlyForTest;
+import com.alipay.sofa.jraft.util.Platform;
 import com.alipay.sofa.jraft.util.Utils;
 import com.sun.jna.NativeLong;
 import com.sun.jna.Pointer;
@@ -352,6 +353,10 @@ public class SegmentFile implements Lifecycle<SegmentFileOptions> {
         Pointer pointer = getPointer();
 
         if (pointer != null) {
+            if (!Platform.isLinux()) {
+                LOG.debug("Skip madvise(MADV_WILLNEED) for non-Linux platform, path={}.", this.path);
+                return;
+            }
             long beginTime = Utils.monotonicMs();
             int ret = LibC.INSTANCE.madvise(pointer, new NativeLong(this.size), LibC.MADV_WILLNEED);
             LOG.info("madvise(MADV_WILLNEED) {} {} {} ret = {} time consuming = {}", pointer, this.path, this.size,
@@ -363,6 +368,10 @@ public class SegmentFile implements Lifecycle<SegmentFileOptions> {
         Pointer pointer = getPointer();
 
         if (pointer != null) {
+            if (!Platform.isLinux()) {
+                LOG.debug("Skip madvise(MADV_DONTNEED) for non-Linux platform, path={}.", this.path);
+                return;
+            }
             long beginTime = Utils.monotonicMs();
             int ret = LibC.INSTANCE.madvise(pointer, new NativeLong(this.size), LibC.MADV_DONTNEED);
             LOG.info("madvise(MADV_DONTNEED) {} {} {} ret = {} time consuming = {}", pointer, this.path, this.size,

--- a/jraft-example/pom.xml
+++ b/jraft-example/pom.xml
@@ -37,7 +37,7 @@
         </dependency>
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
-            <artifactId>log4j-slf4j-impl</artifactId>
+            <artifactId>log4j-slf4j2-impl</artifactId>
             <version>${log4j.version}</version>
         </dependency>
         <dependency>

--- a/jraft-test/pom.xml
+++ b/jraft-test/pom.xml
@@ -36,7 +36,7 @@
         </dependency>
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
-            <artifactId>log4j-slf4j-impl</artifactId>
+            <artifactId>log4j-slf4j2-impl</artifactId>
             <version>${log4j.version}</version>
         </dependency>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -67,7 +67,7 @@
         <jsr305.version>3.0.2</jsr305.version>
         <junit.dep.version>4.8.2</junit.dep.version>
         <junit.version>4.13.1</junit.version>
-        <log4j.version>2.17.1</log4j.version>
+        <log4j.version>2.25.3</log4j.version>
         <main.user.dir>${user.dir}</main.user.dir>
         <metrics.version>4.0.2</metrics.version>
         <mockito.version>1.9.5</mockito.version>
@@ -76,8 +76,8 @@
         <project.encoding>UTF-8</project.encoding>
         <protobuf.version>3.25.5</protobuf.version>
         <protostuff.version>1.6.0</protostuff.version>
-        <rocksdb.version>8.8.1</rocksdb.version>
-        <slf4j.version>1.7.21</slf4j.version>
+        <rocksdb.version>10.2.1</rocksdb.version>
+        <slf4j.version>2.0.17</slf4j.version>
     </properties>
 
     <dependencyManagement>
@@ -161,7 +161,7 @@
             </dependency>
             <dependency>
                 <groupId>org.apache.logging.log4j</groupId>
-                <artifactId>log4j-slf4j-impl</artifactId>
+                <artifactId>log4j-slf4j2-impl</artifactId>
                 <version>${log4j.version}</version>
             </dependency>
             <dependency>


### PR DESCRIPTION
## Summary
- upgrade `rocksdbjni` to `10.2.1` and `slf4j` to `2.0.17`
- switch test/runtime binding from `log4j-slf4j-impl` to `log4j-slf4j2-impl`
- add a Java 8 compatible `LoggerSpaceFactory4Log4j2Builder` override so `sofa-common-tools 1.0.12` can work with `slf4j 2.x`
- skip `madvise` on non-Linux in `SegmentFile` so RocksDB segment tests can run on Windows

## Validation
- `mvn -pl jraft-core -Dtest=RouteTableTest test`
- `mvn -pl jraft-core -Dtest=CliServiceTest test`
- `mvn -pl jraft-core -Dtest=RocksDBSegmentLogStorageTest test`
- `mvn test`

Local validation notes:
- the full `mvn test` run is blocked on Windows before reaching `rheakv` because `NodeTest` and `ElectSelfPersistOrderTest` already fail on the clean `master` baseline in a separate worktree on the same machine
- the issue-related dependency changes themselves passed the targeted regression tests above

## AI Collaboration Record
- used Codex to inspect issue scope, analyze Java 8 compatibility, update dependencies, implement compatibility fixes, and run local verification
- iterated on failures from local test runs, then compared against a clean `master` worktree to separate repository baseline failures from this PR's changes

## Prompting Notes
- first constrained the task to Java 8 compatible upgrades, because `disruptor 4.x`, `jctools 4.x`, and `sofa-common-tools 2.x` are not compatible with this repository's current baseline
- then used failing tests to drive the follow-up fixes instead of widening the dependency bump blindly