### PR TITLE
[AI-8th] fix: remove unused imports in sofa-jraft

### DIFF
--- a/jraft-core/src/main/java/com/alipay/sofa/jraft/JRaftUtils.java
+++ b/jraft-core/src/main/java/com/alipay/sofa/jraft/JRaftUtils.java
@@ -19,7 +19,6 @@ package com.alipay.sofa.jraft;
 import java.util.concurrent.Executor;
 import java.util.concurrent.SynchronousQueue;
 import java.util.concurrent.ThreadFactory;
-import java.util.concurrent.ThreadPoolExecutor;
 
 import org.apache.commons.lang.StringUtils;
 

--- a/jraft-core/src/main/java/com/alipay/sofa/jraft/closure/ReadIndexClosure.java
+++ b/jraft-core/src/main/java/com/alipay/sofa/jraft/closure/ReadIndexClosure.java
@@ -24,7 +24,6 @@ import org.slf4j.LoggerFactory;
 
 import com.alipay.sofa.jraft.Closure;
 import com.alipay.sofa.jraft.JRaftUtils;
-import com.alipay.sofa.jraft.Node;
 import com.alipay.sofa.jraft.Status;
 import com.alipay.sofa.jraft.error.RaftError;
 import com.alipay.sofa.jraft.util.SystemPropertyUtil;

--- a/jraft-core/src/main/java/com/alipay/sofa/jraft/core/ReadOnlyServiceImpl.java
+++ b/jraft-core/src/main/java/com/alipay/sofa/jraft/core/ReadOnlyServiceImpl.java
@@ -29,7 +29,6 @@ import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
 import java.util.stream.Collectors;
 
-import com.alipay.sofa.jraft.entity.EnumOutter;
 import com.alipay.sofa.jraft.option.ReadOnlyOption;
 import com.alipay.sofa.jraft.util.ThreadPoolsFactory;
 import org.slf4j.Logger;

--- a/jraft-core/src/main/java/com/alipay/sofa/jraft/util/SegmentList.java
+++ b/jraft-core/src/main/java/com/alipay/sofa/jraft/util/SegmentList.java
@@ -16,7 +16,6 @@
  */
 package com.alipay.sofa.jraft.util;
 
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.function.Predicate;


### PR DESCRIPTION
Remove unused imports from 4 files in sofa-jraft.

Files cleaned:
- JRaftUtils.java: removed unused ThreadPoolExecutor import
- ReadOnlyServiceImpl.java: removed unused EnumOutter import  
- ReadIndexClosure.java: removed unused Node import
- SegmentList.java: removed unused ArrayList import

All imports verified as unused via:
1. Grep for actual usage in source code
2. Checking Javadoc @{link} references (not compiled)
3. Verifying no anonymous class or parent class usage