### PR TITLE
[AI-8th] fix: add null check and graceful degradation in AppendEntries

### DIFF
--- a/jraft-core/src/main/java/com/alipay/sofa/jraft/rpc/impl/core/AppendEntriesRequestProcessor.java
+++ b/jraft-core/src/main/java/com/alipay/sofa/jraft/rpc/impl/core/AppendEntriesRequestProcessor.java
@@ -89,7 +89,11 @@ public class AppendEntriesRequestProcessor extends NodeRequestProcessor<AppendEn
             RpcFactoryHelper.rpcFactory().ensurePipeline();
 
             final PeerRequestContext ctx = getOrCreatePeerRequestContext(groupId, pairOf(peerId, serverId), null);
-
+            // getOrCreatePeerRequestContext may return null when the node is removed
+            // by a concurrent shutdown; degrade gracefully to the default executor.
+            if (ctx == null) {
+                return executor();
+            }
             return ctx.executor;
         }
     }
@@ -370,7 +374,13 @@ public class AppendEntriesRequestProcessor extends NodeRequestProcessor<AppendEn
                     final boolean parsed = peer.parse(pair.local);
                     assert (parsed);
                     final Node node = NodeManager.getInstance().get(groupId, peer);
-                    assert (node != null);
+                    // The node could be null due to concurrent shutdown (another thread
+                    // removes the node from NodeManager between the check in select()
+                    // and this second lookup inside the lock). Gracefully degrade
+                    // to returning null so callers can fall back to the default executor.
+                    if (node == null) {
+                        return null;
+                    }
                     peerCtx = new PeerRequestContext(groupId, pair, node.getRaftOptions()
                         .getMaxReplicatorInflightMsgs());
                     groupContexts.put(pair, peerCtx);
@@ -433,7 +443,11 @@ public class AppendEntriesRequestProcessor extends NodeRequestProcessor<AppendEn
     }
 
     private int getAndIncrementSequence(final String groupId, final PeerPair pair, final Connection conn) {
-        return getOrCreatePeerRequestContext(groupId, pair, conn).getAndIncrementSequence();
+        final PeerRequestContext ctx = getOrCreatePeerRequestContext(groupId, pair, conn);
+        // The context may be null if the node was removed by a concurrent shutdown.
+        // In this case, fall back to returning 0 as the sequence, which will cause
+        // the request to be handled by the default executor path.
+        return ctx != null ? ctx.getAndIncrementSequence() : 0;
     }
 
     private boolean isHeartbeatRequest(final AppendEntriesRequest request) {

--- a/jraft-core/src/main/java/com/alipay/sofa/jraft/rpc/impl/core/AppendEntriesRequestProcessor.java
+++ b/jraft-core/src/main/java/com/alipay/sofa/jraft/rpc/impl/core/AppendEntriesRequestProcessor.java
@@ -466,10 +466,19 @@ public class AppendEntriesRequestProcessor extends NodeRequestProcessor<AppendEn
             final String groupId = request.getGroupId();
             final PeerPair pair = pairOf(request.getPeerId(), request.getServerId());
 
+            // Check if peer context is available; if not (node was removed during
+            // concurrent shutdown), degrade to the non-pipeline path to avoid
+            // SequenceRpcRequestClosure wrapping and dropped responses.
+            final PeerRequestContext ctx = getOrCreatePeerRequestContext(groupId, pair, done.getRpcCtx()
+                .getConnection());
+            if (ctx == null) {
+                return service.handleAppendEntriesRequest(request, done);
+            }
+
             boolean isHeartbeat = isHeartbeatRequest(request);
             int reqSequence = -1;
             if (!isHeartbeat) {
-                reqSequence = getAndIncrementSequence(groupId, pair, done.getRpcCtx().getConnection());
+                reqSequence = ctx.getAndIncrementSequence();
             }
             final Message response = service.handleAppendEntriesRequest(request, new SequenceRpcRequestClosure(done,
                 defaultResp(), groupId, pair, reqSequence, isHeartbeat));


### PR DESCRIPTION
## Problem
In the AppendEntries request handling path, getOrCreatePeerRequestContext() may return null when a node is removed by a concurrent shutdown. The previous code did not properly handle this case, potentially causing NPE or incorrect routing.

## Solution
1. When ctx is null in handleRequest(), return executor() to degrade gracefully to the default executor
2. When node is null in getOrCreatePeerRequestContext(), return null so callers can fall back to the default executor path
3. In getAndIncrementSequence(), return 0 when ctx is null to properly route to the non-pipeline path

This ensures graceful degradation during the shutdown race condition.