### PR TITLE
fix: flaky ElectSelfPersistOrderTest

### DIFF
--- a/jraft-core/src/test/java/com/alipay/sofa/jraft/core/ElectSelfPersistOrderTest.java
+++ b/jraft-core/src/test/java/com/alipay/sofa/jraft/core/ElectSelfPersistOrderTest.java
@@ -17,10 +17,9 @@
 package com.alipay.sofa.jraft.core;
 
 import java.io.File;
-import java.lang.reflect.Field;
+import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.concurrent.Future;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -34,35 +33,31 @@ import org.junit.Test;
 import com.alipay.sofa.jraft.Iterator;
 import com.alipay.sofa.jraft.Node;
 import com.alipay.sofa.jraft.RaftGroupService;
+import com.alipay.sofa.jraft.Status;
 import com.alipay.sofa.jraft.conf.Configuration;
 import com.alipay.sofa.jraft.entity.PeerId;
-import com.alipay.sofa.jraft.option.RpcOptions;
+import com.alipay.sofa.jraft.entity.Task;
 import com.alipay.sofa.jraft.option.NodeOptions;
 import com.alipay.sofa.jraft.option.RaftMetaStorageOptions;
 import com.alipay.sofa.jraft.option.RaftOptions;
-import com.alipay.sofa.jraft.rpc.RaftClientService;
 import com.alipay.sofa.jraft.rpc.RaftRpcServerFactory;
-import com.alipay.sofa.jraft.rpc.RpcRequests;
-import com.alipay.sofa.jraft.rpc.RpcResponseClosure;
 import com.alipay.sofa.jraft.rpc.RpcServer;
 import com.alipay.sofa.jraft.storage.RaftMetaStorage;
 import com.alipay.sofa.jraft.storage.impl.LocalRaftMetaStorage;
 import com.alipay.sofa.jraft.test.TestUtils;
-import com.alipay.sofa.jraft.util.Endpoint;
-import com.google.protobuf.Message;
 
 import static org.junit.Assert.*;
 import static org.junit.Assume.assumeTrue;
 
 /**
  * Test that electSelf() persists (term, votedFor) BEFORE sending RequestVote RPCs.
- * <p>
+ *
  * Before the fix, electSelf() sent RequestVote RPCs to all peers in a loop and
  * only then called metaStorage.setTermAndVotedFor(). If the node crashed between
  * sending the RPCs and persisting, on restart it would not remember its own vote,
  * allowing it to vote for a different candidate in the same term — a Raft safety
  * violation (Section 5.2 of the Raft paper).
- * <p>
+ *
  * The fix moves setTermAndVotedFor() before the RPC loop and checks its return
  * value. On failure, the node steps down without sending any RPCs.
  */
@@ -92,22 +87,15 @@ public class ElectSelfPersistOrderTest {
     /**
      * Verify that when setTermAndVotedFor() fails during electSelf(), the node
      * steps down and does NOT send RequestVote RPCs to peers.
-     * <p>
+     *
      * Approach:
      * 1. Start a 3-node cluster with a FailingMetaStorage on node 0
-     * 2. Wait for leader election to complete normally (fail flag is off)
-     * 3. Ensure node 0 is NOT the leader
-     * 4. Enable the failure flag on node 0's meta storage
-     * 5. Directly trigger electSelf() on node 0 via tryElectSelf()
-     * 6. electSelf() increments term, calls setTermAndVotedFor() which fails,
-     * then steps down WITHOUT sending any RequestVote RPCs
-     * 7. Verify the observer node's term did NOT advance (proving no RPC was sent)
-     * <p>
-     * Using tryElectSelf() instead of killing the leader avoids a timing race:
-     * killing the leader requires waiting ~10s for the observer's leader lease
-     * to expire before node 0's preVote can succeed, but the observer's own
-     * election timer (~10s) fires at the same time, causing the observer to
-     * start its own election and bump its term independently of node 0.
+     * 2. Wait for leader election to complete normally
+     * 3. Enable the failure flag on node 0's meta storage
+     * 4. Stop the current leader to force new elections
+     * 5. Node 0 will attempt electSelf(), fail on setTermAndVotedFor(), step down
+     * 6. Verify the observer node's term did NOT advance due to node 0's failed election
+     *    (proving no RequestVote RPC was sent before the persistence check)
      */
     @Test
     public void testPersistFailurePreventsRpcSend() throws Exception {
@@ -125,7 +113,25 @@ public class ElectSelfPersistOrderTest {
         for (int i = 0; i < peers.size(); i++) {
             final PeerId peer = peers.get(i);
             final NodeOptions nodeOptions = new NodeOptions();
+            // node0 gets a short election timeout so it fires first after leader death.
+            // Other nodes get a long timeout so they won't independently start elections
+            // during the test window — this lets us assert term equality on the observer.
             nodeOptions.setElectionTimeoutMs(i == 0 ? 300 : 10_000);
+            if (i != 0) {
+                //                1. Kill the leader
+                //                2. Node0 (300ms timeout) initiates preVote → observer, but refuses because the leader lease has not expired
+                //                3. Node0 repeatedly retries preVote, 300ms per round
+                //                4. A few seconds have passed, and the leader lease of the observer has expired
+                //                5. The preVote of node0 has finally been approved -> electiSelf() -> persist failed -> stepDown
+                //                6. However, at the same time, the observer's 10 second election timeout is also approaching
+                //
+                //                If step 5 is completed before step 6, the test passes.
+                //                If the timer of the observer arrives first, the observer will bump the term and the test will fail.
+                //                Increase maxElectionDelayMs to reduce probability, but not to avoid it
+                final RaftOptions raftOptions = new RaftOptions();
+                raftOptions.setMaxElectionDelayMs(60_000);
+                nodeOptions.setRaftOptions(raftOptions);
+            }
             nodeOptions.setSnapshotIntervalSecs(300);
             nodeOptions.setInitialConf(conf);
 
@@ -193,9 +199,11 @@ public class ElectSelfPersistOrderTest {
 
             // Find the observer (not node0, not leader)
             Node observer = null;
+            int observerIdx = -1;
             for (int i = 0; i < nodes.size(); i++) {
                 if (i != 0 && i != leaderIdx) {
                     observer = nodes.get(i);
+                    observerIdx = i;
                     break;
                 }
             }
@@ -206,28 +214,41 @@ public class ElectSelfPersistOrderTest {
             // Enable fail flag: next setTermAndVotedFor on node0 returns false
             failFlag.set(true);
 
-            // Directly trigger electSelf() on node0. This is synchronous:
-            // electSelf() will increment term, call setTermAndVotedFor() which
-            // fails, then stepDown and return — all without sending RequestVote
-            // RPCs. No need to kill the leader and wait for timeout-driven elections.
-            ((NodeImpl) node0).tryElectSelf();
+            // Stop leader to trigger elections
+            services.get(leaderIdx).shutdown();
+            services.get(leaderIdx).join();
 
-            // failLatch was counted down synchronously inside setTermAndVotedFor
-            assertTrue("Node0 should have attempted election and hit persist failure",
-                failLatch.await(1, TimeUnit.SECONDS));
+            // Wait for node0 to attempt election and hit the persist failure
+            boolean failed = failLatch.await(10, TimeUnit.SECONDS);
+            assertTrue("Node0 should have attempted election", failed);
+
+            final long failTerm = failedAtTerm.get();
+
+            // Brief pause for any in-flight messages
+            Thread.sleep(500);
 
             final long observerTermAfter = ((NodeImpl) observer).getCurrentTerm();
-
-            System.out.println("Observer term before=" + observerTermBefore + ", after=" + observerTermAfter
-                               + ", node0 failed at term=" + failedAtTerm.get());
 
             // With the fix: setTermAndVotedFor is called BEFORE the RPC loop.
             // When it returns false, electSelf() steps down and returns without
             // sending any RequestVote RPCs. Therefore the observer's term should
             // NOT have been bumped by node0's failed election attempt.
+            //
+            // Without the fix: RPCs were sent BEFORE setTermAndVotedFor, so the
+            // observer would have already received the RequestVote and bumped its
+            // term even though node0's persistence failed.
+            //
+            // The observer uses a long election timeout (10s) so it won't
+            // independently start its own election during this short test window.
+            System.out.println("Observer term before=" + observerTermBefore + ", after=" + observerTermAfter
+                               + ", node0 failed at term=" + failTerm);
+
+            // Observer's term must not change — proves no RequestVote RPC was sent.
             assertEquals("Observer term should not advance (no RequestVote RPC sent)", observerTermBefore,
                 observerTermAfter);
 
+            // With the fix, node0's persist failure means it steps down and
+            // does NOT send RequestVote RPCs. Verify node0 is no longer leader.
             assertFalse("Node0 should not be leader after persist failure", ((NodeImpl) node0).isLeader());
 
         } finally {
@@ -239,148 +260,6 @@ public class ElectSelfPersistOrderTest {
                 }
             }
         }
-    }
-
-    /**
-     * Verify the same persist-before-RPC guarantee on the timeout-driven election path.
-     * <p>
-     * This keeps the "leader crash triggers a real election" setup, but uses a
-     * counting RaftClientService on node0 to assert that no RequestVote RPC was
-     * sent after setTermAndVotedFor() failed.
-     */
-    @Test
-    public void testPersistFailurePreventsRpcSendAfterLeaderFailure() throws Exception {
-        // Set NotElected priority on node2's PeerId in the Configuration itself,
-        // so the leader's replicatorMap sees it and findTheNextCandidate() skips node2.
-        // NodeOptions.setElectionPriority alone is NOT enough — it only sets the node's
-        // own serverId.priority, which the leader doesn't see.
-        final List<Integer> priorities = new ArrayList<>();
-        priorities.add(ElectionPriority.Disabled); // node0: normal (Disabled means no priority election)
-        priorities.add(ElectionPriority.Disabled); // node1: normal
-        priorities.add(ElectionPriority.NotElected); // node2: never elected → leader skips in TimeoutNow
-        final List<PeerId> peers = TestUtils.generatePriorityPeers(3, priorities);
-        final String groupId = "electself-integration-test";
-        final Configuration conf = new Configuration(peers);
-
-        final AtomicBoolean failFlag = new AtomicBoolean(false);
-        final AtomicLong failedAtTerm = new AtomicLong(-1);
-        final CountDownLatch failLatch = new CountDownLatch(1);
-
-        final List<RaftGroupService> services = new ArrayList<>();
-        final List<Node> nodes = new ArrayList<>();
-
-        for (int i = 0; i < peers.size(); i++) {
-            final PeerId peer = peers.get(i);
-            final NodeOptions nodeOptions = new NodeOptions();
-            if (i == 1) {
-                // node1: shortest timeout → always becomes leader first
-                nodeOptions.setElectionTimeoutMs(300);
-            } else {
-                // node0 & node2: long timeout → never win initial election.
-                // node0 gets triggered by TimeoutNow from dying leader, not by its own timer.
-                nodeOptions.setElectionTimeoutMs(10_000);
-            }
-            nodeOptions.setSnapshotIntervalSecs(300);
-            nodeOptions.setInitialConf(conf);
-
-            final String serverDataPath = this.dataPath + File.separator + groupId + File.separator
-                                          + peer.getEndpoint().toString().replace(':', '_');
-            FileUtils.forceMkdir(new File(serverDataPath));
-            nodeOptions.setLogUri(serverDataPath + File.separator + "logs");
-            nodeOptions.setRaftMetaUri(serverDataPath + File.separator + "meta");
-            nodeOptions.setSnapshotUri(serverDataPath + File.separator + "snapshot");
-            nodeOptions.setFsm(new StateMachineAdapter() {
-                @Override
-                public void onApply(final Iterator iter) {
-                    while (iter.hasNext()) {
-                        iter.next();
-                    }
-                }
-            });
-
-            if (i == 0) {
-                nodeOptions.setServiceFactory(new FailingServiceFactory(failFlag, failedAtTerm, failLatch));
-            }
-
-            final RpcServer rpcServer = RaftRpcServerFactory.createRaftRpcServer(peer.getEndpoint());
-            final RaftGroupService svc = new RaftGroupService(groupId, peer, nodeOptions, rpcServer);
-            final Node node = svc.start();
-            assertNotNull(node);
-            services.add(svc);
-            nodes.add(node);
-        }
-
-        try {
-            Node leader = waitForLeader(nodes, 5000);
-            assertNotNull("Should have a leader", leader);
-
-            final Node node0 = nodes.get(0);
-            if (leader == node0) {
-                assertTrue("Leadership transfer from node0 should succeed", leader.transferLeadershipTo(peers.get(1))
-                    .isOk());
-                leader = waitForLeaderExcluding(nodes, node0, 5000);
-                assumeTrue("Could not transfer leadership away from node0", leader != null && leader != node0);
-            }
-
-            final CountingRaftClientService countingRpc = new CountingRaftClientService(
-                ((NodeImpl) node0).getRpcService());
-            replaceRpcService((NodeImpl) node0, countingRpc);
-
-            failFlag.set(true);
-
-            final int leaderIdx = peers.indexOf(leader.getNodeId().getPeerId());
-            services.get(leaderIdx).shutdown();
-            services.get(leaderIdx).join();
-
-            assertTrue("Node0 should have attempted timeout-driven election and hit persist failure",
-                failLatch.await(8, TimeUnit.SECONDS));
-            assertEquals("Node0 should not send RequestVote RPCs when persist fails", 0L,
-                countingRpc.getRequestVoteCalls());
-            assertEquals("Node0 should step down to follower after persist failure", State.STATE_FOLLOWER,
-                ((NodeImpl) node0).getNodeState());
-            assertTrue("Node0 should have recorded a failed election term", failedAtTerm.get() > 0);
-        } finally {
-            for (final RaftGroupService svc : services) {
-                try {
-                    svc.shutdown();
-                    svc.join();
-                } catch (final Exception ignored) {
-                }
-            }
-        }
-    }
-
-    private static Node waitForLeader(final List<Node> nodes, final long timeoutMs) throws InterruptedException {
-        final long deadline = System.nanoTime() + TimeUnit.MILLISECONDS.toNanos(timeoutMs);
-        while (System.nanoTime() < deadline) {
-            for (final Node node : nodes) {
-                if (node.getNodeId().getPeerId().equals(node.getLeaderId())) {
-                    return node;
-                }
-            }
-            Thread.sleep(10);
-        }
-        return null;
-    }
-
-    private static Node waitForLeaderExcluding(final List<Node> nodes, final Node excluded, final long timeoutMs)
-                                                                                                                 throws InterruptedException {
-        final long deadline = System.nanoTime() + TimeUnit.MILLISECONDS.toNanos(timeoutMs);
-        while (System.nanoTime() < deadline) {
-            for (final Node node : nodes) {
-                if (node != excluded && node.getNodeId().getPeerId().equals(node.getLeaderId())) {
-                    return node;
-                }
-            }
-            Thread.sleep(10);
-        }
-        return null;
-    }
-
-    private static void replaceRpcService(final NodeImpl node, final RaftClientService rpcService) throws Exception {
-        final Field field = NodeImpl.class.getDeclaredField("rpcService");
-        field.setAccessible(true);
-        field.set(node, rpcService);
     }
 
     /**
@@ -456,102 +335,6 @@ public class ElectSelfPersistOrderTest {
         @Override
         public RaftMetaStorage createRaftMetaStorage(final String uri, final RaftOptions raftOptions) {
             return new FailingMetaStorage(uri, raftOptions, this.failFlag, this.failedAtTerm, this.failLatch);
-        }
-    }
-
-    static class CountingRaftClientService implements RaftClientService {
-        private final RaftClientService delegate;
-        private final AtomicLong        requestVoteCalls = new AtomicLong();
-
-        CountingRaftClientService(final RaftClientService delegate) {
-            this.delegate = delegate;
-        }
-
-        long getRequestVoteCalls() {
-            return this.requestVoteCalls.get();
-        }
-
-        @Override
-        public boolean init(final RpcOptions opts) {
-            return this.delegate.init(opts);
-        }
-
-        @Override
-        public void shutdown() {
-            this.delegate.shutdown();
-        }
-
-        @Override
-        public boolean connect(final Endpoint endpoint) {
-            return this.delegate.connect(endpoint);
-        }
-
-        @Override
-        public boolean checkConnection(final Endpoint endpoint, final boolean createIfAbsent) {
-            return this.delegate.checkConnection(endpoint, createIfAbsent);
-        }
-
-        @Override
-        public boolean disconnect(final Endpoint endpoint) {
-            return this.delegate.disconnect(endpoint);
-        }
-
-        @Override
-        public boolean isConnected(final Endpoint endpoint) {
-            return this.delegate.isConnected(endpoint);
-        }
-
-        @Override
-        public <T extends Message> Future<Message> invokeWithDone(final Endpoint endpoint, final Message request,
-                                                                  final RpcResponseClosure<T> done, final int timeoutMs) {
-            return this.delegate.invokeWithDone(endpoint, request, done, timeoutMs);
-        }
-
-        @Override
-        public Future<Message> preVote(final Endpoint endpoint, final RpcRequests.RequestVoteRequest request,
-                                       final RpcResponseClosure<RpcRequests.RequestVoteResponse> done) {
-            return this.delegate.preVote(endpoint, request, done);
-        }
-
-        @Override
-        public Future<Message> requestVote(final Endpoint endpoint, final RpcRequests.RequestVoteRequest request,
-                                           final RpcResponseClosure<RpcRequests.RequestVoteResponse> done) {
-            this.requestVoteCalls.incrementAndGet();
-            return this.delegate.requestVote(endpoint, request, done);
-        }
-
-        @Override
-        public Future<Message> appendEntries(final Endpoint endpoint, final RpcRequests.AppendEntriesRequest request,
-                                             final int timeoutMs,
-                                             final RpcResponseClosure<RpcRequests.AppendEntriesResponse> done) {
-            return this.delegate.appendEntries(endpoint, request, timeoutMs, done);
-        }
-
-        @Override
-        public Future<Message> installSnapshot(final Endpoint endpoint,
-                                               final RpcRequests.InstallSnapshotRequest request,
-                                               final RpcResponseClosure<RpcRequests.InstallSnapshotResponse> done) {
-            return this.delegate.installSnapshot(endpoint, request, done);
-        }
-
-        @Override
-        public Future<Message> getFile(final Endpoint endpoint, final RpcRequests.GetFileRequest request,
-                                       final int timeoutMs, final RpcResponseClosure<RpcRequests.GetFileResponse> done) {
-            return this.delegate.getFile(endpoint, request, timeoutMs, done);
-        }
-
-        @Override
-        public Future<Message> timeoutNow(final Endpoint endpoint, final RpcRequests.TimeoutNowRequest request,
-                                          final int timeoutMs,
-                                          final RpcResponseClosure<RpcRequests.TimeoutNowResponse> done) {
-            return this.delegate.timeoutNow(endpoint, request, timeoutMs, done);
-        }
-
-        @Override
-        public Future<Message> readIndex(final Endpoint endpoint, final RpcRequests.ReadIndexRequest request,
-                                         final int timeoutMs,
-                                         final RpcResponseClosure<RpcRequests.ReadIndexResponse> done) {
-            return this.delegate.readIndex(endpoint, request, timeoutMs, done);
         }
     }
 }

--- a/jraft-core/src/test/java/com/alipay/sofa/jraft/core/ElectSelfPersistOrderTest.java
+++ b/jraft-core/src/test/java/com/alipay/sofa/jraft/core/ElectSelfPersistOrderTest.java
@@ -17,9 +17,10 @@
 package com.alipay.sofa.jraft.core;
 
 import java.io.File;
-import java.nio.ByteBuffer;
+import java.lang.reflect.Field;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.Future;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -33,31 +34,35 @@ import org.junit.Test;
 import com.alipay.sofa.jraft.Iterator;
 import com.alipay.sofa.jraft.Node;
 import com.alipay.sofa.jraft.RaftGroupService;
-import com.alipay.sofa.jraft.Status;
 import com.alipay.sofa.jraft.conf.Configuration;
 import com.alipay.sofa.jraft.entity.PeerId;
-import com.alipay.sofa.jraft.entity.Task;
+import com.alipay.sofa.jraft.option.RpcOptions;
 import com.alipay.sofa.jraft.option.NodeOptions;
 import com.alipay.sofa.jraft.option.RaftMetaStorageOptions;
 import com.alipay.sofa.jraft.option.RaftOptions;
+import com.alipay.sofa.jraft.rpc.RaftClientService;
 import com.alipay.sofa.jraft.rpc.RaftRpcServerFactory;
+import com.alipay.sofa.jraft.rpc.RpcRequests;
+import com.alipay.sofa.jraft.rpc.RpcResponseClosure;
 import com.alipay.sofa.jraft.rpc.RpcServer;
 import com.alipay.sofa.jraft.storage.RaftMetaStorage;
 import com.alipay.sofa.jraft.storage.impl.LocalRaftMetaStorage;
 import com.alipay.sofa.jraft.test.TestUtils;
+import com.alipay.sofa.jraft.util.Endpoint;
+import com.google.protobuf.Message;
 
 import static org.junit.Assert.*;
 import static org.junit.Assume.assumeTrue;
 
 /**
  * Test that electSelf() persists (term, votedFor) BEFORE sending RequestVote RPCs.
- *
+ * <p>
  * Before the fix, electSelf() sent RequestVote RPCs to all peers in a loop and
  * only then called metaStorage.setTermAndVotedFor(). If the node crashed between
  * sending the RPCs and persisting, on restart it would not remember its own vote,
  * allowing it to vote for a different candidate in the same term — a Raft safety
  * violation (Section 5.2 of the Raft paper).
- *
+ * <p>
  * The fix moves setTermAndVotedFor() before the RPC loop and checks its return
  * value. On failure, the node steps down without sending any RPCs.
  */
@@ -87,15 +92,22 @@ public class ElectSelfPersistOrderTest {
     /**
      * Verify that when setTermAndVotedFor() fails during electSelf(), the node
      * steps down and does NOT send RequestVote RPCs to peers.
-     *
+     * <p>
      * Approach:
      * 1. Start a 3-node cluster with a FailingMetaStorage on node 0
-     * 2. Wait for leader election to complete normally
-     * 3. Enable the failure flag on node 0's meta storage
-     * 4. Stop the current leader to force new elections
-     * 5. Node 0 will attempt electSelf(), fail on setTermAndVotedFor(), step down
-     * 6. Verify the observer node's term did NOT advance due to node 0's failed election
-     *    (proving no RequestVote RPC was sent before the persistence check)
+     * 2. Wait for leader election to complete normally (fail flag is off)
+     * 3. Ensure node 0 is NOT the leader
+     * 4. Enable the failure flag on node 0's meta storage
+     * 5. Directly trigger electSelf() on node 0 via tryElectSelf()
+     * 6. electSelf() increments term, calls setTermAndVotedFor() which fails,
+     * then steps down WITHOUT sending any RequestVote RPCs
+     * 7. Verify the observer node's term did NOT advance (proving no RPC was sent)
+     * <p>
+     * Using tryElectSelf() instead of killing the leader avoids a timing race:
+     * killing the leader requires waiting ~10s for the observer's leader lease
+     * to expire before node 0's preVote can succeed, but the observer's own
+     * election timer (~10s) fires at the same time, causing the observer to
+     * start its own election and bump its term independently of node 0.
      */
     @Test
     public void testPersistFailurePreventsRpcSend() throws Exception {
@@ -113,15 +125,12 @@ public class ElectSelfPersistOrderTest {
         for (int i = 0; i < peers.size(); i++) {
             final PeerId peer = peers.get(i);
             final NodeOptions nodeOptions = new NodeOptions();
-            // node0 gets a short election timeout so it fires first after leader death.
-            // Other nodes get a long timeout so they won't independently start elections
-            // during the test window — this lets us assert term equality on the observer.
             nodeOptions.setElectionTimeoutMs(i == 0 ? 300 : 10_000);
             nodeOptions.setSnapshotIntervalSecs(300);
             nodeOptions.setInitialConf(conf);
 
             final String serverDataPath = this.dataPath + File.separator
-                                          + peer.getEndpoint().toString().replace(':', '_');
+                    + peer.getEndpoint().toString().replace(':', '_');
             FileUtils.forceMkdir(new File(serverDataPath));
             nodeOptions.setLogUri(serverDataPath + File.separator + "logs");
             nodeOptions.setRaftMetaUri(serverDataPath + File.separator + "meta");
@@ -184,11 +193,9 @@ public class ElectSelfPersistOrderTest {
 
             // Find the observer (not node0, not leader)
             Node observer = null;
-            int observerIdx = -1;
             for (int i = 0; i < nodes.size(); i++) {
                 if (i != 0 && i != leaderIdx) {
                     observer = nodes.get(i);
-                    observerIdx = i;
                     break;
                 }
             }
@@ -199,42 +206,30 @@ public class ElectSelfPersistOrderTest {
             // Enable fail flag: next setTermAndVotedFor on node0 returns false
             failFlag.set(true);
 
-            // Stop leader to trigger elections
-            services.get(leaderIdx).shutdown();
-            services.get(leaderIdx).join();
+            // Directly trigger electSelf() on node0. This is synchronous:
+            // electSelf() will increment term, call setTermAndVotedFor() which
+            // fails, then stepDown and return — all without sending RequestVote
+            // RPCs. No need to kill the leader and wait for timeout-driven elections.
+            ((NodeImpl) node0).tryElectSelf();
 
-            // Wait for node0 to attempt election and hit the persist failure
-            boolean failed = failLatch.await(10, TimeUnit.SECONDS);
-            assertTrue("Node0 should have attempted election", failed);
-
-            final long failTerm = failedAtTerm.get();
-
-            // Brief pause for any in-flight messages
-            Thread.sleep(500);
+            // failLatch was counted down synchronously inside setTermAndVotedFor
+            assertTrue("Node0 should have attempted election and hit persist failure",
+                    failLatch.await(1, TimeUnit.SECONDS));
 
             final long observerTermAfter = ((NodeImpl) observer).getCurrentTerm();
+
+            System.out.println("Observer term before=" + observerTermBefore + ", after=" + observerTermAfter
+                    + ", node0 failed at term=" + failedAtTerm.get());
 
             // With the fix: setTermAndVotedFor is called BEFORE the RPC loop.
             // When it returns false, electSelf() steps down and returns without
             // sending any RequestVote RPCs. Therefore the observer's term should
             // NOT have been bumped by node0's failed election attempt.
-            //
-            // Without the fix: RPCs were sent BEFORE setTermAndVotedFor, so the
-            // observer would have already received the RequestVote and bumped its
-            // term even though node0's persistence failed.
-            //
-            // The observer uses a long election timeout (10s) so it won't
-            // independently start its own election during this short test window.
-            System.out.println("Observer term before=" + observerTermBefore + ", after=" + observerTermAfter
-                               + ", node0 failed at term=" + failTerm);
+            assertEquals("Observer term should not advance (no RequestVote RPC sent)",
+                    observerTermBefore, observerTermAfter);
 
-            // Observer's term must not change — proves no RequestVote RPC was sent.
-            assertEquals("Observer term should not advance (no RequestVote RPC sent)", observerTermBefore,
-                observerTermAfter);
-
-            // With the fix, node0's persist failure means it steps down and
-            // does NOT send RequestVote RPCs. Verify node0 is no longer leader.
-            assertFalse("Node0 should not be leader after persist failure", ((NodeImpl) node0).isLeader());
+            assertFalse("Node0 should not be leader after persist failure",
+                    ((NodeImpl) node0).isLeader());
 
         } finally {
             for (final RaftGroupService svc : services) {
@@ -248,14 +243,157 @@ public class ElectSelfPersistOrderTest {
     }
 
     /**
+     * Verify the same persist-before-RPC guarantee on the timeout-driven election path.
+     * <p>
+     * This keeps the "leader crash triggers a real election" setup, but uses a
+     * counting RaftClientService on node0 to assert that no RequestVote RPC was
+     * sent after setTermAndVotedFor() failed.
+     */
+    @Test
+    public void testPersistFailurePreventsRpcSendAfterLeaderFailure() throws Exception {
+        // Set NotElected priority on node2's PeerId in the Configuration itself,
+        // so the leader's replicatorMap sees it and findTheNextCandidate() skips node2.
+        // NodeOptions.setElectionPriority alone is NOT enough — it only sets the node's
+        // own serverId.priority, which the leader doesn't see.
+        final List<Integer> priorities = new ArrayList<>();
+        priorities.add(ElectionPriority.Disabled);    // node0: normal (Disabled means no priority election)
+        priorities.add(ElectionPriority.Disabled);    // node1: normal
+        priorities.add(ElectionPriority.NotElected);  // node2: never elected → leader skips in TimeoutNow
+        final List<PeerId> peers = TestUtils.generatePriorityPeers(3, priorities);
+        final String groupId = "electself-integration-test";
+        final Configuration conf = new Configuration(peers);
+
+        final AtomicBoolean failFlag = new AtomicBoolean(false);
+        final AtomicLong failedAtTerm = new AtomicLong(-1);
+        final CountDownLatch failLatch = new CountDownLatch(1);
+
+        final List<RaftGroupService> services = new ArrayList<>();
+        final List<Node> nodes = new ArrayList<>();
+
+        for (int i = 0; i < peers.size(); i++) {
+            final PeerId peer = peers.get(i);
+            final NodeOptions nodeOptions = new NodeOptions();
+            if (i == 1) {
+                // node1: shortest timeout → always becomes leader first
+                nodeOptions.setElectionTimeoutMs(300);
+            } else {
+                // node0 & node2: long timeout → never win initial election.
+                // node0 gets triggered by TimeoutNow from dying leader, not by its own timer.
+                nodeOptions.setElectionTimeoutMs(10_000);
+            }
+            nodeOptions.setSnapshotIntervalSecs(300);
+            nodeOptions.setInitialConf(conf);
+
+            final String serverDataPath = this.dataPath + File.separator
+                    + groupId + File.separator
+                    + peer.getEndpoint().toString().replace(':', '_');
+            FileUtils.forceMkdir(new File(serverDataPath));
+            nodeOptions.setLogUri(serverDataPath + File.separator + "logs");
+            nodeOptions.setRaftMetaUri(serverDataPath + File.separator + "meta");
+            nodeOptions.setSnapshotUri(serverDataPath + File.separator + "snapshot");
+            nodeOptions.setFsm(new StateMachineAdapter() {
+                @Override
+                public void onApply(final Iterator iter) {
+                    while (iter.hasNext()) {
+                        iter.next();
+                    }
+                }
+            });
+
+            if (i == 0) {
+                nodeOptions.setServiceFactory(new FailingServiceFactory(failFlag, failedAtTerm, failLatch));
+            }
+
+            final RpcServer rpcServer = RaftRpcServerFactory.createRaftRpcServer(peer.getEndpoint());
+            final RaftGroupService svc = new RaftGroupService(groupId, peer, nodeOptions, rpcServer);
+            final Node node = svc.start();
+            assertNotNull(node);
+            services.add(svc);
+            nodes.add(node);
+        }
+
+        try {
+            Node leader = waitForLeader(nodes, 5000);
+            assertNotNull("Should have a leader", leader);
+
+            final Node node0 = nodes.get(0);
+            if (leader == node0) {
+                assertTrue("Leadership transfer from node0 should succeed",
+                        leader.transferLeadershipTo(peers.get(1)).isOk());
+                leader = waitForLeaderExcluding(nodes, node0, 5000);
+                assumeTrue("Could not transfer leadership away from node0", leader != null && leader != node0);
+            }
+
+            final CountingRaftClientService countingRpc = new CountingRaftClientService(((NodeImpl) node0)
+                    .getRpcService());
+            replaceRpcService((NodeImpl) node0, countingRpc);
+
+            failFlag.set(true);
+
+            final int leaderIdx = peers.indexOf(leader.getNodeId().getPeerId());
+            services.get(leaderIdx).shutdown();
+            services.get(leaderIdx).join();
+
+            assertTrue("Node0 should have attempted timeout-driven election and hit persist failure",
+                    failLatch.await(8, TimeUnit.SECONDS));
+            assertEquals("Node0 should not send RequestVote RPCs when persist fails",
+                    0L, countingRpc.getRequestVoteCalls());
+            assertEquals("Node0 should step down to follower after persist failure",
+                    State.STATE_FOLLOWER, ((NodeImpl) node0).getNodeState());
+            assertTrue("Node0 should have recorded a failed election term", failedAtTerm.get() > 0);
+        } finally {
+            for (final RaftGroupService svc : services) {
+                try {
+                    svc.shutdown();
+                    svc.join();
+                } catch (final Exception ignored) {
+                }
+            }
+        }
+    }
+
+    private static Node waitForLeader(final List<Node> nodes, final long timeoutMs) throws InterruptedException {
+        final long deadline = System.nanoTime() + TimeUnit.MILLISECONDS.toNanos(timeoutMs);
+        while (System.nanoTime() < deadline) {
+            for (final Node node : nodes) {
+                if (node.getNodeId().getPeerId().equals(node.getLeaderId())) {
+                    return node;
+                }
+            }
+            Thread.sleep(10);
+        }
+        return null;
+    }
+
+    private static Node waitForLeaderExcluding(final List<Node> nodes, final Node excluded, final long timeoutMs)
+            throws InterruptedException {
+        final long deadline = System.nanoTime() + TimeUnit.MILLISECONDS.toNanos(timeoutMs);
+        while (System.nanoTime() < deadline) {
+            for (final Node node : nodes) {
+                if (node != excluded && node.getNodeId().getPeerId().equals(node.getLeaderId())) {
+                    return node;
+                }
+            }
+            Thread.sleep(10);
+        }
+        return null;
+    }
+
+    private static void replaceRpcService(final NodeImpl node, final RaftClientService rpcService) throws Exception {
+        final Field field = NodeImpl.class.getDeclaredField("rpcService");
+        field.setAccessible(true);
+        field.set(node, rpcService);
+    }
+
+    /**
      * A RaftMetaStorage wrapper that returns false from setTermAndVotedFor()
      * when the fail flag is set, simulating a disk I/O error during election.
      */
     static class FailingMetaStorage implements RaftMetaStorage {
         private final LocalRaftMetaStorage delegate;
-        private final AtomicBoolean        failFlag;
-        private final AtomicLong           failedAtTerm;
-        private final CountDownLatch       failLatch;
+        private final AtomicBoolean failFlag;
+        private final AtomicLong failedAtTerm;
+        private final CountDownLatch failLatch;
 
         FailingMetaStorage(String uri, RaftOptions raftOptions, AtomicBoolean failFlag, AtomicLong failedAtTerm,
                            CountDownLatch failLatch) {
@@ -307,8 +445,8 @@ public class ElectSelfPersistOrderTest {
     }
 
     static class FailingServiceFactory extends DefaultJRaftServiceFactory {
-        private final AtomicBoolean  failFlag;
-        private final AtomicLong     failedAtTerm;
+        private final AtomicBoolean failFlag;
+        private final AtomicLong failedAtTerm;
         private final CountDownLatch failLatch;
 
         FailingServiceFactory(AtomicBoolean failFlag, AtomicLong failedAtTerm, CountDownLatch failLatch) {
@@ -320,6 +458,104 @@ public class ElectSelfPersistOrderTest {
         @Override
         public RaftMetaStorage createRaftMetaStorage(final String uri, final RaftOptions raftOptions) {
             return new FailingMetaStorage(uri, raftOptions, this.failFlag, this.failedAtTerm, this.failLatch);
+        }
+    }
+
+    static class CountingRaftClientService implements RaftClientService {
+        private final RaftClientService delegate;
+        private final AtomicLong requestVoteCalls = new AtomicLong();
+
+        CountingRaftClientService(final RaftClientService delegate) {
+            this.delegate = delegate;
+        }
+
+        long getRequestVoteCalls() {
+            return this.requestVoteCalls.get();
+        }
+
+        @Override
+        public boolean init(final RpcOptions opts) {
+            return this.delegate.init(opts);
+        }
+
+        @Override
+        public void shutdown() {
+            this.delegate.shutdown();
+        }
+
+        @Override
+        public boolean connect(final Endpoint endpoint) {
+            return this.delegate.connect(endpoint);
+        }
+
+        @Override
+        public boolean checkConnection(final Endpoint endpoint, final boolean createIfAbsent) {
+            return this.delegate.checkConnection(endpoint, createIfAbsent);
+        }
+
+        @Override
+        public boolean disconnect(final Endpoint endpoint) {
+            return this.delegate.disconnect(endpoint);
+        }
+
+        @Override
+        public boolean isConnected(final Endpoint endpoint) {
+            return this.delegate.isConnected(endpoint);
+        }
+
+        @Override
+        public <T extends Message> Future<Message> invokeWithDone(final Endpoint endpoint, final Message request,
+                                                                  final RpcResponseClosure<T> done,
+                                                                  final int timeoutMs) {
+            return this.delegate.invokeWithDone(endpoint, request, done, timeoutMs);
+        }
+
+        @Override
+        public Future<Message> preVote(final Endpoint endpoint, final RpcRequests.RequestVoteRequest request,
+                                       final RpcResponseClosure<RpcRequests.RequestVoteResponse> done) {
+            return this.delegate.preVote(endpoint, request, done);
+        }
+
+        @Override
+        public Future<Message> requestVote(final Endpoint endpoint, final RpcRequests.RequestVoteRequest request,
+                                           final RpcResponseClosure<RpcRequests.RequestVoteResponse> done) {
+            this.requestVoteCalls.incrementAndGet();
+            return this.delegate.requestVote(endpoint, request, done);
+        }
+
+        @Override
+        public Future<Message> appendEntries(final Endpoint endpoint, final RpcRequests.AppendEntriesRequest request,
+                                             final int timeoutMs,
+                                             final RpcResponseClosure<RpcRequests.AppendEntriesResponse> done) {
+            return this.delegate.appendEntries(endpoint, request, timeoutMs, done);
+        }
+
+        @Override
+        public Future<Message> installSnapshot(final Endpoint endpoint,
+                                               final RpcRequests.InstallSnapshotRequest request,
+                                               final RpcResponseClosure<RpcRequests.InstallSnapshotResponse> done) {
+            return this.delegate.installSnapshot(endpoint, request, done);
+        }
+
+        @Override
+        public Future<Message> getFile(final Endpoint endpoint, final RpcRequests.GetFileRequest request,
+                                       final int timeoutMs,
+                                       final RpcResponseClosure<RpcRequests.GetFileResponse> done) {
+            return this.delegate.getFile(endpoint, request, timeoutMs, done);
+        }
+
+        @Override
+        public Future<Message> timeoutNow(final Endpoint endpoint, final RpcRequests.TimeoutNowRequest request,
+                                          final int timeoutMs,
+                                          final RpcResponseClosure<RpcRequests.TimeoutNowResponse> done) {
+            return this.delegate.timeoutNow(endpoint, request, timeoutMs, done);
+        }
+
+        @Override
+        public Future<Message> readIndex(final Endpoint endpoint, final RpcRequests.ReadIndexRequest request,
+                                         final int timeoutMs,
+                                         final RpcResponseClosure<RpcRequests.ReadIndexResponse> done) {
+            return this.delegate.readIndex(endpoint, request, timeoutMs, done);
         }
     }
 }

--- a/jraft-core/src/test/java/com/alipay/sofa/jraft/core/ElectSelfPersistOrderTest.java
+++ b/jraft-core/src/test/java/com/alipay/sofa/jraft/core/ElectSelfPersistOrderTest.java
@@ -17,7 +17,6 @@
 package com.alipay.sofa.jraft.core;
 
 import java.io.File;
-import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.CountDownLatch;
@@ -33,10 +32,8 @@ import org.junit.Test;
 import com.alipay.sofa.jraft.Iterator;
 import com.alipay.sofa.jraft.Node;
 import com.alipay.sofa.jraft.RaftGroupService;
-import com.alipay.sofa.jraft.Status;
 import com.alipay.sofa.jraft.conf.Configuration;
 import com.alipay.sofa.jraft.entity.PeerId;
-import com.alipay.sofa.jraft.entity.Task;
 import com.alipay.sofa.jraft.option.NodeOptions;
 import com.alipay.sofa.jraft.option.RaftMetaStorageOptions;
 import com.alipay.sofa.jraft.option.RaftOptions;
@@ -90,12 +87,22 @@ public class ElectSelfPersistOrderTest {
      *
      * Approach:
      * 1. Start a 3-node cluster with a FailingMetaStorage on node 0
-     * 2. Wait for leader election to complete normally
-     * 3. Enable the failure flag on node 0's meta storage
-     * 4. Stop the current leader to force new elections
-     * 5. Node 0 will attempt electSelf(), fail on setTermAndVotedFor(), step down
-     * 6. Verify the observer node's term did NOT advance due to node 0's failed election
-     *    (proving no RequestVote RPC was sent before the persistence check)
+     * 2. Wait for leader election to complete normally (fail flag is off)
+     * 3. Ensure node 0 is NOT the leader
+     * 4. Enable the failure flag on node 0's meta storage
+     * 5. Directly trigger electSelf() on node 0 via tryElectSelf()
+     * 6. electSelf() increments term, calls setTermAndVotedFor() which fails,
+     *    then steps down WITHOUT sending any RequestVote RPCs
+     * 7. Verify the observer node's term did NOT advance (proving no RPC was sent)
+     *
+     * Using tryElectSelf() instead of killing the leader avoids two timing races:
+     * (a) Leader shutdown sends TimeoutNow to a follower via stepDown(wakeupCandidate=true),
+     *     which triggers immediate electSelf() on the receiver — bypassing preVote entirely.
+     *     If TimeoutNow reaches the observer (~50% chance), the observer bumps its term
+     *     independently, causing a false test failure.
+     * (b) After the leader dies the observer's own election timer (~10s) may fire at roughly
+     *     the same time node 0's preVote finally gets approved (also ~10s, once the leader
+     *     lease expires), creating a narrow but real race window.
      */
     @Test
     public void testPersistFailurePreventsRpcSend() throws Exception {
@@ -113,25 +120,7 @@ public class ElectSelfPersistOrderTest {
         for (int i = 0; i < peers.size(); i++) {
             final PeerId peer = peers.get(i);
             final NodeOptions nodeOptions = new NodeOptions();
-            // node0 gets a short election timeout so it fires first after leader death.
-            // Other nodes get a long timeout so they won't independently start elections
-            // during the test window — this lets us assert term equality on the observer.
             nodeOptions.setElectionTimeoutMs(i == 0 ? 300 : 10_000);
-            if (i != 0) {
-                //                1. Kill the leader
-                //                2. Node0 (300ms timeout) initiates preVote → observer, but refuses because the leader lease has not expired
-                //                3. Node0 repeatedly retries preVote, 300ms per round
-                //                4. A few seconds have passed, and the leader lease of the observer has expired
-                //                5. The preVote of node0 has finally been approved -> electiSelf() -> persist failed -> stepDown
-                //                6. However, at the same time, the observer's 10 second election timeout is also approaching
-                //
-                //                If step 5 is completed before step 6, the test passes.
-                //                If the timer of the observer arrives first, the observer will bump the term and the test will fail.
-                //                Increase maxElectionDelayMs to reduce probability, but not to avoid it
-                final RaftOptions raftOptions = new RaftOptions();
-                raftOptions.setMaxElectionDelayMs(60_000);
-                nodeOptions.setRaftOptions(raftOptions);
-            }
             nodeOptions.setSnapshotIntervalSecs(300);
             nodeOptions.setInitialConf(conf);
 
@@ -199,11 +188,9 @@ public class ElectSelfPersistOrderTest {
 
             // Find the observer (not node0, not leader)
             Node observer = null;
-            int observerIdx = -1;
             for (int i = 0; i < nodes.size(); i++) {
                 if (i != 0 && i != leaderIdx) {
                     observer = nodes.get(i);
-                    observerIdx = i;
                     break;
                 }
             }
@@ -214,41 +201,28 @@ public class ElectSelfPersistOrderTest {
             // Enable fail flag: next setTermAndVotedFor on node0 returns false
             failFlag.set(true);
 
-            // Stop leader to trigger elections
-            services.get(leaderIdx).shutdown();
-            services.get(leaderIdx).join();
+            // Directly trigger electSelf() on node0. This is synchronous:
+            // electSelf() will increment term, call setTermAndVotedFor() which
+            // fails, then stepDown and return — all without sending RequestVote
+            // RPCs. No need to kill the leader and wait for timeout-driven elections.
+            ((NodeImpl) node0).tryElectSelf();
 
-            // Wait for node0 to attempt election and hit the persist failure
-            boolean failed = failLatch.await(10, TimeUnit.SECONDS);
-            assertTrue("Node0 should have attempted election", failed);
-
-            final long failTerm = failedAtTerm.get();
-
-            // Brief pause for any in-flight messages
-            Thread.sleep(500);
+            // failLatch was counted down synchronously inside setTermAndVotedFor
+            assertTrue("Node0 should have attempted election and hit persist failure",
+                failLatch.await(1, TimeUnit.SECONDS));
 
             final long observerTermAfter = ((NodeImpl) observer).getCurrentTerm();
+
+            System.out.println("Observer term before=" + observerTermBefore + ", after=" + observerTermAfter
+                               + ", node0 failed at term=" + failedAtTerm.get());
 
             // With the fix: setTermAndVotedFor is called BEFORE the RPC loop.
             // When it returns false, electSelf() steps down and returns without
             // sending any RequestVote RPCs. Therefore the observer's term should
             // NOT have been bumped by node0's failed election attempt.
-            //
-            // Without the fix: RPCs were sent BEFORE setTermAndVotedFor, so the
-            // observer would have already received the RequestVote and bumped its
-            // term even though node0's persistence failed.
-            //
-            // The observer uses a long election timeout (10s) so it won't
-            // independently start its own election during this short test window.
-            System.out.println("Observer term before=" + observerTermBefore + ", after=" + observerTermAfter
-                               + ", node0 failed at term=" + failTerm);
-
-            // Observer's term must not change — proves no RequestVote RPC was sent.
             assertEquals("Observer term should not advance (no RequestVote RPC sent)", observerTermBefore,
                 observerTermAfter);
 
-            // With the fix, node0's persist failure means it steps down and
-            // does NOT send RequestVote RPCs. Verify node0 is no longer leader.
             assertFalse("Node0 should not be leader after persist failure", ((NodeImpl) node0).isLeader());
 
         } finally {

--- a/jraft-core/src/test/java/com/alipay/sofa/jraft/core/ElectSelfPersistOrderTest.java
+++ b/jraft-core/src/test/java/com/alipay/sofa/jraft/core/ElectSelfPersistOrderTest.java
@@ -210,7 +210,7 @@ public class ElectSelfPersistOrderTest {
             // failLatch was counted down synchronously inside setTermAndVotedFor
             assertTrue("Node0 should have attempted election and hit persist failure",
                 failLatch.await(1, TimeUnit.SECONDS));
-
+            Thread.sleep(500); // Wait for any async RPCs to be delivered and processed.
             final long observerTermAfter = ((NodeImpl) observer).getCurrentTerm();
 
             System.out.println("Observer term before=" + observerTermBefore + ", after=" + observerTermAfter

--- a/jraft-core/src/test/java/com/alipay/sofa/jraft/core/ElectSelfPersistOrderTest.java
+++ b/jraft-core/src/test/java/com/alipay/sofa/jraft/core/ElectSelfPersistOrderTest.java
@@ -130,7 +130,7 @@ public class ElectSelfPersistOrderTest {
             nodeOptions.setInitialConf(conf);
 
             final String serverDataPath = this.dataPath + File.separator
-                    + peer.getEndpoint().toString().replace(':', '_');
+                                          + peer.getEndpoint().toString().replace(':', '_');
             FileUtils.forceMkdir(new File(serverDataPath));
             nodeOptions.setLogUri(serverDataPath + File.separator + "logs");
             nodeOptions.setRaftMetaUri(serverDataPath + File.separator + "meta");
@@ -214,22 +214,21 @@ public class ElectSelfPersistOrderTest {
 
             // failLatch was counted down synchronously inside setTermAndVotedFor
             assertTrue("Node0 should have attempted election and hit persist failure",
-                    failLatch.await(1, TimeUnit.SECONDS));
+                failLatch.await(1, TimeUnit.SECONDS));
 
             final long observerTermAfter = ((NodeImpl) observer).getCurrentTerm();
 
             System.out.println("Observer term before=" + observerTermBefore + ", after=" + observerTermAfter
-                    + ", node0 failed at term=" + failedAtTerm.get());
+                               + ", node0 failed at term=" + failedAtTerm.get());
 
             // With the fix: setTermAndVotedFor is called BEFORE the RPC loop.
             // When it returns false, electSelf() steps down and returns without
             // sending any RequestVote RPCs. Therefore the observer's term should
             // NOT have been bumped by node0's failed election attempt.
-            assertEquals("Observer term should not advance (no RequestVote RPC sent)",
-                    observerTermBefore, observerTermAfter);
+            assertEquals("Observer term should not advance (no RequestVote RPC sent)", observerTermBefore,
+                observerTermAfter);
 
-            assertFalse("Node0 should not be leader after persist failure",
-                    ((NodeImpl) node0).isLeader());
+            assertFalse("Node0 should not be leader after persist failure", ((NodeImpl) node0).isLeader());
 
         } finally {
             for (final RaftGroupService svc : services) {
@@ -256,9 +255,9 @@ public class ElectSelfPersistOrderTest {
         // NodeOptions.setElectionPriority alone is NOT enough — it only sets the node's
         // own serverId.priority, which the leader doesn't see.
         final List<Integer> priorities = new ArrayList<>();
-        priorities.add(ElectionPriority.Disabled);    // node0: normal (Disabled means no priority election)
-        priorities.add(ElectionPriority.Disabled);    // node1: normal
-        priorities.add(ElectionPriority.NotElected);  // node2: never elected → leader skips in TimeoutNow
+        priorities.add(ElectionPriority.Disabled); // node0: normal (Disabled means no priority election)
+        priorities.add(ElectionPriority.Disabled); // node1: normal
+        priorities.add(ElectionPriority.NotElected); // node2: never elected → leader skips in TimeoutNow
         final List<PeerId> peers = TestUtils.generatePriorityPeers(3, priorities);
         final String groupId = "electself-integration-test";
         final Configuration conf = new Configuration(peers);
@@ -284,9 +283,8 @@ public class ElectSelfPersistOrderTest {
             nodeOptions.setSnapshotIntervalSecs(300);
             nodeOptions.setInitialConf(conf);
 
-            final String serverDataPath = this.dataPath + File.separator
-                    + groupId + File.separator
-                    + peer.getEndpoint().toString().replace(':', '_');
+            final String serverDataPath = this.dataPath + File.separator + groupId + File.separator
+                                          + peer.getEndpoint().toString().replace(':', '_');
             FileUtils.forceMkdir(new File(serverDataPath));
             nodeOptions.setLogUri(serverDataPath + File.separator + "logs");
             nodeOptions.setRaftMetaUri(serverDataPath + File.separator + "meta");
@@ -318,14 +316,14 @@ public class ElectSelfPersistOrderTest {
 
             final Node node0 = nodes.get(0);
             if (leader == node0) {
-                assertTrue("Leadership transfer from node0 should succeed",
-                        leader.transferLeadershipTo(peers.get(1)).isOk());
+                assertTrue("Leadership transfer from node0 should succeed", leader.transferLeadershipTo(peers.get(1))
+                    .isOk());
                 leader = waitForLeaderExcluding(nodes, node0, 5000);
                 assumeTrue("Could not transfer leadership away from node0", leader != null && leader != node0);
             }
 
-            final CountingRaftClientService countingRpc = new CountingRaftClientService(((NodeImpl) node0)
-                    .getRpcService());
+            final CountingRaftClientService countingRpc = new CountingRaftClientService(
+                ((NodeImpl) node0).getRpcService());
             replaceRpcService((NodeImpl) node0, countingRpc);
 
             failFlag.set(true);
@@ -335,11 +333,11 @@ public class ElectSelfPersistOrderTest {
             services.get(leaderIdx).join();
 
             assertTrue("Node0 should have attempted timeout-driven election and hit persist failure",
-                    failLatch.await(8, TimeUnit.SECONDS));
-            assertEquals("Node0 should not send RequestVote RPCs when persist fails",
-                    0L, countingRpc.getRequestVoteCalls());
-            assertEquals("Node0 should step down to follower after persist failure",
-                    State.STATE_FOLLOWER, ((NodeImpl) node0).getNodeState());
+                failLatch.await(8, TimeUnit.SECONDS));
+            assertEquals("Node0 should not send RequestVote RPCs when persist fails", 0L,
+                countingRpc.getRequestVoteCalls());
+            assertEquals("Node0 should step down to follower after persist failure", State.STATE_FOLLOWER,
+                ((NodeImpl) node0).getNodeState());
             assertTrue("Node0 should have recorded a failed election term", failedAtTerm.get() > 0);
         } finally {
             for (final RaftGroupService svc : services) {
@@ -366,7 +364,7 @@ public class ElectSelfPersistOrderTest {
     }
 
     private static Node waitForLeaderExcluding(final List<Node> nodes, final Node excluded, final long timeoutMs)
-            throws InterruptedException {
+                                                                                                                 throws InterruptedException {
         final long deadline = System.nanoTime() + TimeUnit.MILLISECONDS.toNanos(timeoutMs);
         while (System.nanoTime() < deadline) {
             for (final Node node : nodes) {
@@ -391,9 +389,9 @@ public class ElectSelfPersistOrderTest {
      */
     static class FailingMetaStorage implements RaftMetaStorage {
         private final LocalRaftMetaStorage delegate;
-        private final AtomicBoolean failFlag;
-        private final AtomicLong failedAtTerm;
-        private final CountDownLatch failLatch;
+        private final AtomicBoolean        failFlag;
+        private final AtomicLong           failedAtTerm;
+        private final CountDownLatch       failLatch;
 
         FailingMetaStorage(String uri, RaftOptions raftOptions, AtomicBoolean failFlag, AtomicLong failedAtTerm,
                            CountDownLatch failLatch) {
@@ -445,8 +443,8 @@ public class ElectSelfPersistOrderTest {
     }
 
     static class FailingServiceFactory extends DefaultJRaftServiceFactory {
-        private final AtomicBoolean failFlag;
-        private final AtomicLong failedAtTerm;
+        private final AtomicBoolean  failFlag;
+        private final AtomicLong     failedAtTerm;
         private final CountDownLatch failLatch;
 
         FailingServiceFactory(AtomicBoolean failFlag, AtomicLong failedAtTerm, CountDownLatch failLatch) {
@@ -463,7 +461,7 @@ public class ElectSelfPersistOrderTest {
 
     static class CountingRaftClientService implements RaftClientService {
         private final RaftClientService delegate;
-        private final AtomicLong requestVoteCalls = new AtomicLong();
+        private final AtomicLong        requestVoteCalls = new AtomicLong();
 
         CountingRaftClientService(final RaftClientService delegate) {
             this.delegate = delegate;
@@ -505,8 +503,7 @@ public class ElectSelfPersistOrderTest {
 
         @Override
         public <T extends Message> Future<Message> invokeWithDone(final Endpoint endpoint, final Message request,
-                                                                  final RpcResponseClosure<T> done,
-                                                                  final int timeoutMs) {
+                                                                  final RpcResponseClosure<T> done, final int timeoutMs) {
             return this.delegate.invokeWithDone(endpoint, request, done, timeoutMs);
         }
 
@@ -539,8 +536,7 @@ public class ElectSelfPersistOrderTest {
 
         @Override
         public Future<Message> getFile(final Endpoint endpoint, final RpcRequests.GetFileRequest request,
-                                       final int timeoutMs,
-                                       final RpcResponseClosure<RpcRequests.GetFileResponse> done) {
+                                       final int timeoutMs, final RpcResponseClosure<RpcRequests.GetFileResponse> done) {
             return this.delegate.getFile(endpoint, request, timeoutMs, done);
         }
 

--- a/jraft-core/src/test/java/com/alipay/sofa/jraft/core/ElectSelfPersistOrderTest.java
+++ b/jraft-core/src/test/java/com/alipay/sofa/jraft/core/ElectSelfPersistOrderTest.java
@@ -153,16 +153,7 @@ public class ElectSelfPersistOrderTest {
 
         try {
             // Wait for initial leader election (fail flag is off)
-            Thread.sleep(3000);
-
-            Node leader = null;
-            for (final Node n : nodes) {
-                if (n.getLeaderId() != null && !n.getLeaderId().isEmpty()) {
-                    if (n.getNodeId().getPeerId().equals(n.getLeaderId())) {
-                        leader = n;
-                    }
-                }
-            }
+            Node leader = waitForLeader(nodes, null, 30_000);
             assertNotNull("Should have a leader", leader);
 
             final Node node0 = nodes.get(0);
@@ -170,16 +161,8 @@ public class ElectSelfPersistOrderTest {
             // If node0 is the leader, transfer leadership away
             if (leader == node0) {
                 leader.transferLeadershipTo(peers.get(1));
-                Thread.sleep(2000);
-                leader = null;
-                for (final Node n : nodes) {
-                    if (n.getLeaderId() != null && !n.getLeaderId().isEmpty()) {
-                        if (n.getNodeId().getPeerId().equals(n.getLeaderId())) {
-                            leader = n;
-                        }
-                    }
-                }
-                assumeTrue("Could not transfer leadership away from node0", leader != node0);
+                leader = waitForLeader(nodes, node0, 30_000);
+                assumeTrue("Could not transfer leadership away from node0", leader != null && leader != node0);
             }
 
             assertNotNull("Should still have a leader", leader);
@@ -234,6 +217,20 @@ public class ElectSelfPersistOrderTest {
                 }
             }
         }
+    }
+
+    private static Node waitForLeader(List<Node> nodes, Node excluded, long timeoutMs) throws InterruptedException {
+        final long deadline = System.currentTimeMillis() + timeoutMs;
+        while (System.currentTimeMillis() < deadline) {
+            for (final Node n : nodes) {
+                if (n != excluded && n.getLeaderId() != null && !n.getLeaderId().isEmpty()
+                    && n.getNodeId().getPeerId().equals(n.getLeaderId())) {
+                    return n;
+                }
+            }
+            Thread.sleep(100);
+        }
+        return null;
     }
 
     /**


### PR DESCRIPTION
controlling TimeoutNow target and observing RPC directly