### PR TITLE
[AI-8th] Cleanup unused imports across the project

### DIFF
--- a/jraft-core/src/main/java/com/alipay/sofa/jraft/core/ReadOnlyServiceImpl.java
+++ b/jraft-core/src/main/java/com/alipay/sofa/jraft/core/ReadOnlyServiceImpl.java
@@ -29,7 +29,6 @@ import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
 import java.util.stream.Collectors;
 
-import com.alipay.sofa.jraft.entity.EnumOutter;
 import com.alipay.sofa.jraft.option.ReadOnlyOption;
 import com.alipay.sofa.jraft.util.ThreadPoolsFactory;
 import org.slf4j.Logger;

--- a/jraft-core/src/main/java/com/alipay/sofa/jraft/rpc/impl/AbstractClientService.java
+++ b/jraft-core/src/main/java/com/alipay/sofa/jraft/rpc/impl/AbstractClientService.java
@@ -45,7 +45,6 @@ import com.alipay.sofa.jraft.util.NamedThreadFactory;
 import com.alipay.sofa.jraft.util.RpcFactoryHelper;
 import com.alipay.sofa.jraft.util.ThreadPoolMetricSet;
 import com.alipay.sofa.jraft.util.ThreadPoolUtil;
-import com.alipay.sofa.jraft.util.Utils;
 import com.google.protobuf.Descriptors;
 import com.google.protobuf.Message;
 

--- a/jraft-core/src/test/java/com/alipay/sofa/jraft/closure/ClosureQueueTest.java
+++ b/jraft-core/src/test/java/com/alipay/sofa/jraft/closure/ClosureQueueTest.java
@@ -20,8 +20,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.CountDownLatch;
 
-import com.alipay.sofa.jraft.util.ThreadPoolsFactory;
-import com.codahale.metrics.MetricRegistry;
 import org.junit.Before;
 import org.junit.Test;
 

--- a/jraft-core/src/test/java/com/alipay/sofa/jraft/core/IteratorTest.java
+++ b/jraft-core/src/test/java/com/alipay/sofa/jraft/core/IteratorTest.java
@@ -21,7 +21,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicLong;
 
-import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;

--- a/jraft-core/src/test/java/com/alipay/sofa/jraft/util/ThreadPoolsFactoryTest.java
+++ b/jraft-core/src/test/java/com/alipay/sofa/jraft/util/ThreadPoolsFactoryTest.java
@@ -21,7 +21,6 @@ import java.util.concurrent.SynchronousQueue;
 import java.util.concurrent.ThreadPoolExecutor;
 
 import org.junit.Assert;
-import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.runners.MockitoJUnitRunner;

--- a/jraft-core/src/test/java/com/alipay/sofa/jraft/util/UtilsTest.java
+++ b/jraft-core/src/test/java/com/alipay/sofa/jraft/util/UtilsTest.java
@@ -17,17 +17,11 @@
 package com.alipay.sofa.jraft.util;
 
 import java.nio.ByteBuffer;
-import java.util.concurrent.CountDownLatch;
 
 import org.junit.Assert;
 import org.junit.Test;
 
-import com.alipay.sofa.jraft.Closure;
-import com.alipay.sofa.jraft.Status;
-import com.alipay.sofa.jraft.error.RaftError;
-
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertTrue;
 

--- a/jraft-test/src/main/java/com/alipay/sofa/jraft/test/atomic/server/AtomicStateMachine.java
+++ b/jraft-test/src/main/java/com/alipay/sofa/jraft/test/atomic/server/AtomicStateMachine.java
@@ -47,7 +47,6 @@ import com.alipay.sofa.jraft.test.atomic.command.GetCommand;
 import com.alipay.sofa.jraft.test.atomic.command.IncrementAndGetCommand;
 import com.alipay.sofa.jraft.test.atomic.command.SetCommand;
 import com.alipay.sofa.jraft.test.atomic.command.ValueCommand;
-import com.alipay.sofa.jraft.util.Utils;
 
 /**
  * Atomic state machine


### PR DESCRIPTION
Remove 13 unused import statements from 7 files identified by IDE code inspection:
- AbstractClientService.java: Utils
- AtomicStateMachine.java: Utils
- ClosureQueueTest.java: ThreadPoolsFactory, MetricRegistry
- IteratorTest.java: After
- ReadOnlyServiceImpl.java: EnumOutter
- ThreadPoolsFactoryTest.java: Before
- UtilsTest.java: CountDownLatch, Closure, Status, RaftError, assertFalse

Note: BoltRpcServer.java GlobalSwitch was already removed in a prior commit.

## AI 协作记录
- **使用的 AI 工具**：Claude Code
- **关键 Prompt**：Remove unused imports listed in issue #1173, verify each import is truly unused
- **AI 主要贡献**：代码清理
- **人工验证步骤**：grep confirmed no usage of removed imports in file bodies
- **遇到的问题**：BoltRpcServer.java GlobalSwitch already removed, one file path differed from issue description

### Motivation:

Explain the context, and why you're making that change.
To make others understand what is the problem you're trying to solve.

### Modification:

Describe the idea and modifications you've done.

### Result:

Fixes #<GitHub issue number>.

If there is no issue then describe the changes introduced by this PR.
