### PR TITLE
fix: never lose a new-log wakeup dispatch in LogManagerImpl

### DIFF
--- a/jraft-core/src/main/java/com/alipay/sofa/jraft/storage/impl/LogManagerImpl.java
+++ b/jraft-core/src/main/java/com/alipay/sofa/jraft/storage/impl/LogManagerImpl.java
@@ -22,6 +22,9 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.RejectedExecutionException;
+import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReadWriteLock;
@@ -78,32 +81,57 @@ import com.lmax.disruptor.dsl.ProducerType;
  */
 public class LogManagerImpl implements LogManager {
 
-    private static final Logger                              LOG                   = LoggerFactory
-                                                                                       .getLogger(LogManagerImpl.class);
+    private static final Logger                              LOG                            = LoggerFactory
+                                                                                                .getLogger(LogManagerImpl.class);
     private String                                           groupId;
     private LogStorage                                       logStorage;
     private ConfigurationManager                             configManager;
     private FSMCaller                                        fsmCaller;
-    private final ReadWriteLock                              lock                  = new ReentrantReadWriteLock();
-    private final Lock                                       writeLock             = this.lock.writeLock();
-    private final Lock                                       readLock              = this.lock.readLock();
+    private final ReadWriteLock                              lock                           = new ReentrantReadWriteLock();
+    private final Lock                                       writeLock                      = this.lock.writeLock();
+    private final Lock                                       readLock                       = this.lock.readLock();
     private volatile boolean                                 stopped;
     private volatile boolean                                 hasError;
-    private long                                             nextWaitId            = 1;
-    private long                                             maxLogsInMemoryBytes  = -1;
-    private LogId                                            diskId                = new LogId(0, 0);
-    private LogId                                            appliedId             = new LogId(0, 0);
-    private final SegmentList<LogEntry>                      logsInMemory          = new SegmentList<>(true);
+    private long                                             nextWaitId                     = 1;
+    private long                                             maxLogsInMemoryBytes           = -1;
+    private LogId                                            diskId                         = new LogId(0, 0);
+    private LogId                                            appliedId                      = new LogId(0, 0);
+    private final SegmentList<LogEntry>                      logsInMemory                   = new SegmentList<>(true);
     private volatile long                                    firstLogIndex;
     private volatile long                                    lastLogIndex;
-    private volatile LogId                                   lastSnapshotId        = new LogId(0, 0);
-    private final Map<Long, WaitMeta>                        waitMap               = new HashMap<>();
+    private volatile LogId                                   lastSnapshotId                 = new LogId(0, 0);
+    private final Map<Long, WaitMeta>                        waitMap                        = new HashMap<>();
+
+    /**
+     * PATCH: last-resort executor for new-log wakeup callbacks when the
+     * group's closure pool rejects the dispatch. The waiter has already been removed
+     * from waitMap by the time we dispatch, and there is NO retry anywhere upstream --
+     * losing one dispatch permanently orphans the Replicator (leader->follower entry
+     * replication stalls while heartbeats keep flowing, the exact 2026-04-29 incident).
+     * Unbounded queue + single daemon thread: never rejects, so a wakeup can never be
+     * silently lost. Idle thread exits after 60s (allowCoreThreadTimeOut), so it costs
+     * nothing outside the rare rejection path. Must NOT run callbacks inline on the
+     * dispatching thread -- see notifyOnNewLog comment for the lock-ordering hazard.
+     */
+    private static final ThreadPoolExecutor                  NEW_LOG_WAKEUP_RESCUE_EXECUTOR = new ThreadPoolExecutor(
+                                                                                                1,
+                                                                                                1,
+                                                                                                60L,
+                                                                                                TimeUnit.SECONDS,
+                                                                                                new LinkedBlockingQueue<>(),
+                                                                                                new NamedThreadFactory(
+                                                                                                    "JRaft-NewLog-Wakeup-Rescue-",
+                                                                                                    true));
+
+    static {
+        NEW_LOG_WAKEUP_RESCUE_EXECUTOR.allowCoreThreadTimeOut(true);
+    }
     private Disruptor<StableClosureEvent>                    disruptor;
     private RingBuffer<StableClosureEvent>                   diskQueue;
     private RaftOptions                                      raftOptions;
     private volatile CountDownLatch                          shutDownLatch;
     private NodeMetrics                                      nodeMetrics;
-    private final CopyOnWriteArrayList<LastLogIndexListener> lastLogIndexListeners = new CopyOnWriteArrayList<>();
+    private final CopyOnWriteArrayList<LastLogIndexListener> lastLogIndexListeners          = new CopyOnWriteArrayList<>();
 
     private final static class LogsInMemoryMetricSet implements MetricSet {
         final SegmentList<LogEntry> logsInMemory;
@@ -427,7 +455,20 @@ public class LogManagerImpl implements LogManager {
         for (int i = 0; i < waiterCount; i++) {
             final WaitMeta wm = wms.get(i);
             wm.errorCode = errCode;
-            ThreadPoolsFactory.runInThread(this.groupId, () -> runOnNewLog(wm));
+            try {
+                ThreadPoolsFactory.runInThread(this.groupId, () -> runOnNewLog(wm));
+            } catch (final RejectedExecutionException e) {
+                // PATCH: waiter already removed from waitMap, no retry
+                // upstream -- a lost dispatch would permanently stall replication to
+                // this peer (Replicator#waitMoreEntries is guarded by waitId >= 0 and
+                // only the lost callback resets it). Fall back to the never-rejecting
+                // rescue executor. Also note: an uncaught exception here would abort
+                // this loop and lose ALL remaining waiters (both followers at once),
+                // and would escape into appendEntries BEFORE the diskQueue publish.
+                LOG.error("Group {} closure pool rejected a new-log wakeup, fall back to rescue executor.",
+                    this.groupId, e);
+                NEW_LOG_WAKEUP_RESCUE_EXECUTOR.execute(() -> runOnNewLog(wm));
+            }
         }
         return true;
     }
@@ -1142,7 +1183,23 @@ public class LogManagerImpl implements LogManager {
         try {
             if (expectedLastLogIndex != this.lastLogIndex || this.stopped) {
                 wm.errorCode = this.stopped ? RaftError.ESTOP.getNumber() : 0;
-                ThreadPoolsFactory.runInThread(this.groupId, () -> runOnNewLog(wm));
+                try {
+                    ThreadPoolsFactory.runInThread(this.groupId, () -> runOnNewLog(wm));
+                } catch (final RejectedExecutionException e) {
+                    // PATCH: same rescue as wakeupAllWaiter.
+                    // MUST NOT run the callback inline on this thread: the caller
+                    // (Replicator#waitMoreEntries) still holds the ThreadId lock
+                    // (ReentrantLock -- same-thread reentry would NOT block) and assigns
+                    // this.waitId AFTER wait() returns. An inline callback would reset
+                    // waitId to -1 first and then be overwritten by the pending
+                    // assignment, leaving the replicator believing it is parked while
+                    // no waiter is registered -- recreating the very orphan bug this
+                    // patch fixes. A separate thread blocks on the ThreadId lock until
+                    // the registering thread finishes, preserving the ordering invariant.
+                    LOG.error("Group {} closure pool rejected a new-log notify, fall back to rescue executor.",
+                        this.groupId, e);
+                    NEW_LOG_WAKEUP_RESCUE_EXECUTOR.execute(() -> runOnNewLog(wm));
+                }
                 return 0L;
             }
             long waitId = this.nextWaitId++;
@@ -1186,7 +1243,29 @@ public class LogManagerImpl implements LogManager {
     }
 
     void runOnNewLog(final WaitMeta wm) {
-        wm.onNewLog.onNewLog(wm.arg, wm.errorCode);
+        try {
+            wm.onNewLog.onNewLog(wm.arg, wm.errorCode);
+        } catch (final Throwable t) {
+            // PATCH: a Throwable escaping the callback (e.g. a transient
+            // failure inside Replicator#continueSending -> sendEntries) would otherwise
+            // be captured by the pool's FutureTask and the wakeup silently lost,
+            // permanently orphaning the Replicator. Log loudly and retry ONCE on the
+            // rescue executor (covers transient failures); if the retry throws again,
+            // give up loudly -- the commit-stall watchdog must take over from here.
+            // Retrying is safe: continueSending re-validates all state under the
+            // ThreadId lock, duplicate AppendEntries are idempotent on followers, and
+            // out-of-order responses are healed by resetInflights + probe.
+            LOG.error("Group {} new-log callback threw, retrying once on rescue executor.", this.groupId, t);
+            NEW_LOG_WAKEUP_RESCUE_EXECUTOR.execute(() -> {
+                try {
+                    wm.onNewLog.onNewLog(wm.arg, wm.errorCode);
+                } catch (final Throwable t2) {
+                    LOG.error("Group {} new-log callback threw AGAIN, giving up; entry replication to this "
+                              + "peer may stall until leadership change. Check commit-stall watchdog.",
+                        this.groupId, t2);
+                }
+            });
+        }
     }
 
     @Override

--- a/jraft-core/src/main/java/com/alipay/sofa/jraft/util/ThreadPoolsFactory.java
+++ b/jraft-core/src/main/java/com/alipay/sofa/jraft/util/ThreadPoolsFactory.java
@@ -29,6 +29,7 @@ import org.slf4j.LoggerFactory;
 import com.alipay.sofa.jraft.Closure;
 import com.alipay.sofa.jraft.Status;
 import com.alipay.sofa.jraft.closure.InternalClosure;
+import java.util.concurrent.*;
 
 /**
  * ThreadPool based on Raft-Group isolation
@@ -102,7 +103,15 @@ public class ThreadPoolsFactory {
      * Run a task in thread pool,returns the future object.
      */
     public static Future<?> runInThread(String groupId, final Runnable runnable) {
-        return GROUP_THREAD_POOLS.getOrDefault(groupId, GlobalThreadPoolHolder.INSTANCE).submit(runnable);
+        try {
+            return GROUP_THREAD_POOLS.getOrDefault(groupId, GlobalThreadPoolHolder.INSTANCE).submit(runnable);
+        } catch (final RejectedExecutionException e) {
+            // PATCH: visibility only, behavior unchanged (log and rethrow
+            // as-is). The default pool uses SynchronousQueue + AbortPolicy, so a saturated
+            // pool rejects silently from the caller's perspective unless the caller logs.
+            LOG.error("Group {} thread pool rejected a task submission.", groupId, e);
+            throw e;
+        }
     }
 
     /**

--- a/jraft-core/src/test/java/com/alipay/sofa/jraft/core/ReplicationWakeupRejectionTest.java
+++ b/jraft-core/src/test/java/com/alipay/sofa/jraft/core/ReplicationWakeupRejectionTest.java
@@ -1,0 +1,146 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alipay.sofa.jraft.core;
+
+import java.io.File;
+import java.nio.ByteBuffer;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.RejectedExecutionException;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+
+import org.apache.commons.io.FileUtils;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import com.alipay.sofa.jraft.Node;
+import com.alipay.sofa.jraft.NodeManager;
+import com.alipay.sofa.jraft.entity.PeerId;
+import com.alipay.sofa.jraft.entity.Task;
+import com.alipay.sofa.jraft.test.TestUtils;
+import com.alipay.sofa.jraft.util.NamedThreadFactory;
+import com.alipay.sofa.jraft.util.ThreadPoolsFactory;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * PATCH A/B regression anchor (integration level).
+ *
+ * Verifies end-to-end that leader->follower entry replication survives when the
+ * group closure pool rejects every new-log wakeup dispatch. The 200ms pauses
+ * between batches let the replicators drain and park in waitMoreEntries, so each
+ * subsequent batch hits the exact "parked -> wakeup -> rejected" incident path.
+ *
+ * A/B contract:
+ * - On an UNPATCHED build (LogManagerImpl without the rescue executor) this test
+ *   MUST go red: the first rejected wakeup permanently orphans the replicators,
+ *   quorum never advances and the batch times out.
+ * - On the patched build it MUST be green: every rejected dispatch is rescued.
+ */
+public class ReplicationWakeupRejectionTest {
+
+    private String dataPath;
+
+    @Before
+    public void setup() throws Exception {
+        this.dataPath = TestUtils.mkTempDir();
+        FileUtils.forceMkdir(new File(this.dataPath));
+    }
+
+    @After
+    public void teardown() throws Exception {
+        if (!TestCluster.CLUSTERS.isEmpty()) {
+            for (final TestCluster c : TestCluster.CLUSTERS.removeAll()) {
+                c.stopAll();
+            }
+        }
+        NodeManager.getInstance().clear();
+        FileUtils.deleteDirectory(new File(this.dataPath));
+    }
+
+    /**
+     * Rejects ONLY dispatches coming from wakeupAllWaiter / notifyOnNewLog, lets
+     * everything else (disk closures, FSM events, shutdown publishes) through, so
+     * the cluster stays functional except for the wakeup path under test.
+     */
+    private static ThreadPoolExecutor wakeupRejectingPool() {
+        return new ThreadPoolExecutor(4, 4, 60L, TimeUnit.SECONDS, new LinkedBlockingQueue<>(), new NamedThreadFactory(
+            "it-selective-reject-", true)) {
+
+            @Override
+            public void execute(final Runnable command) {
+                for (final StackTraceElement e : Thread.currentThread().getStackTrace()) {
+                    if ("wakeupAllWaiter".equals(e.getMethodName()) || "notifyOnNewLog".equals(e.getMethodName())) {
+                        throw new RejectedExecutionException("it: reject wakeup dispatch");
+                    }
+                }
+                super.execute(command);
+            }
+        };
+    }
+
+    /** registerThreadPool has no unregister API: make it idempotent for repeated runs in one JVM. */
+    private static void registerQuietly(final String groupId, final ThreadPoolExecutor pool) {
+        try {
+            ThreadPoolsFactory.registerThreadPool(groupId, pool);
+        } catch (final IllegalArgumentException ignored) {
+            // Already registered by a previous run in this JVM, same pool behavior.
+        }
+    }
+
+    @Test
+    public void testReplicationSurvivesWakeupRejection() throws Exception {
+        final String groupId = "it-rescue-cluster";
+        final List<PeerId> peers = TestUtils.generatePeers(3);
+        final TestCluster cluster = new TestCluster(groupId, this.dataPath, peers);
+        for (final PeerId peer : peers) {
+            assertTrue(cluster.start(peer.getEndpoint()));
+        }
+        cluster.waitLeader();
+        final Node leader = cluster.getLeader();
+        assertNotNull(leader);
+
+        // Baseline: 10 tasks through the normal pool, cluster is healthy.
+        sendTestTasks(leader, 10);
+
+        // From now on EVERY new-log wakeup dispatch is rejected: replication only
+        // survives if the rescue executor delivers the wakeups.
+        registerQuietly(groupId, wakeupRejectingPool());
+
+        // 5 batches with 200ms pauses: the pauses let the replicators drain and
+        // park, so each batch re-enters the "parked -> wakeup" path.
+        for (int b = 0; b < 5; b++) {
+            sendTestTasks(leader, 10);
+            Thread.sleep(200);
+        }
+        cluster.ensureSame();
+        cluster.stopAll();
+    }
+
+    private void sendTestTasks(final Node leader, final int n) throws Exception {
+        final CountDownLatch latch = new CountDownLatch(n);
+        for (int i = 0; i < n; i++) {
+            leader.apply(new Task(ByteBuffer.wrap(("data" + i).getBytes()), new ExpectClosure(latch)));
+        }
+        assertTrue("tasks not committed within 10s: replication stalled (a wakeup was lost)",
+            latch.await(10, TimeUnit.SECONDS));
+    }
+}

--- a/jraft-core/src/test/java/com/alipay/sofa/jraft/storage/impl/LogManagerWakeupRescueTest.java
+++ b/jraft-core/src/test/java/com/alipay/sofa/jraft/storage/impl/LogManagerWakeupRescueTest.java
@@ -1,0 +1,298 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alipay.sofa.jraft.storage.impl;
+
+import java.util.ArrayList;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.RejectedExecutionException;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import com.alipay.sofa.jraft.FSMCaller;
+import com.alipay.sofa.jraft.Status;
+import com.alipay.sofa.jraft.conf.ConfigurationManager;
+import com.alipay.sofa.jraft.core.NodeMetrics;
+import com.alipay.sofa.jraft.entity.codec.v2.LogEntryV2CodecFactory;
+import com.alipay.sofa.jraft.error.RaftError;
+import com.alipay.sofa.jraft.option.LogManagerOptions;
+import com.alipay.sofa.jraft.option.RaftOptions;
+import com.alipay.sofa.jraft.storage.BaseStorageTest;
+import com.alipay.sofa.jraft.storage.LogManager;
+import com.alipay.sofa.jraft.storage.LogStorage;
+import com.alipay.sofa.jraft.test.TestUtils;
+import com.alipay.sofa.jraft.util.NamedThreadFactory;
+import com.alipay.sofa.jraft.util.ThreadPoolsFactory;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * PATCH regression tests: a new-log wakeup dispatch must never be
+ * silently lost, neither when the group closure pool rejects the dispatch (variant A,
+ * rescued by NEW_LOG_WAKEUP_RESCUE_EXECUTOR) nor when the callback itself throws
+ * (variant B, logged loudly and retried once on the rescue executor).
+ */
+@RunWith(value = MockitoJUnitRunner.class)
+public class LogManagerWakeupRescueTest extends BaseStorageTest {
+
+    private static final String  RESCUE_THREAD_PREFIX = "JRaft-NewLog-Wakeup-Rescue-";
+
+    private LogManagerImpl       logManager;
+    private ConfigurationManager confManager;
+    @Mock
+    private FSMCaller            fsmCaller;
+    private LogStorage           logStorage;
+
+    @Override
+    @Before
+    public void setup() throws Exception {
+        super.setup();
+    }
+
+    @Override
+    @After
+    public void teardown() throws Exception {
+        if (this.logStorage != null) {
+            this.logStorage.shutdown();
+        }
+        super.teardown();
+    }
+
+    /**
+     * Rejects ONLY dispatches coming from wakeupAllWaiter / notifyOnNewLog, lets
+     * everything else through. This avoids breaking LogManagerImpl's other
+     * runInThread usages (e.g. the diskQueue shutdown publish), so the test cases
+     * and teardown can still complete. It works because runInThread -> submit ->
+     * execute happens synchronously on the dispatching thread, so the dispatching
+     * frames are visible on the current stack.
+     */
+    private static ThreadPoolExecutor wakeupRejectingPool() {
+        return new ThreadPoolExecutor(4, 4, 60L, TimeUnit.SECONDS, new LinkedBlockingQueue<>(), new NamedThreadFactory(
+            "ut-selective-reject-", true)) {
+
+            @Override
+            public void execute(final Runnable command) {
+                for (final StackTraceElement e : Thread.currentThread().getStackTrace()) {
+                    if ("wakeupAllWaiter".equals(e.getMethodName()) || "notifyOnNewLog".equals(e.getMethodName())) {
+                        throw new RejectedExecutionException("ut: reject wakeup dispatch");
+                    }
+                }
+                super.execute(command);
+            }
+        };
+    }
+
+    /**
+     * registerThreadPool rejects duplicate registration for the same groupId and
+     * there is no unregister API: make it idempotent for repeated runs in one JVM.
+     */
+    private static void registerQuietly(final String groupId, final ThreadPoolExecutor pool) {
+        try {
+            ThreadPoolsFactory.registerThreadPool(groupId, pool);
+        } catch (final IllegalArgumentException ignored) {
+            // Already registered by a previous run in this JVM, same pool behavior.
+        }
+    }
+
+    /** Each case uses its own groupId to avoid cross-pollution via the static registry. */
+    private void init(final String groupId) {
+        this.confManager = new ConfigurationManager();
+        final RaftOptions raftOptions = new RaftOptions();
+        this.logStorage = new RocksDBLogStorage(this.path, raftOptions);
+        this.logManager = new LogManagerImpl();
+        final LogManagerOptions opts = new LogManagerOptions();
+        opts.setConfigurationManager(this.confManager);
+        opts.setLogEntryCodecFactory(LogEntryV2CodecFactory.getInstance());
+        opts.setFsmCaller(this.fsmCaller);
+        opts.setNodeMetrics(new NodeMetrics(false));
+        opts.setLogStorage(this.logStorage);
+        opts.setRaftOptions(raftOptions);
+        opts.setGroupId(groupId);
+        assertTrue(this.logManager.init(opts));
+    }
+
+    /** Same as LogManagerTest#mockAddEntries: append 10 entries and wait for them to be stable. */
+    private void mockAddEntries() throws InterruptedException {
+        final CountDownLatch latch = new CountDownLatch(1);
+        this.logManager.appendEntries(new ArrayList<>(TestUtils.mockEntries(10)), new LogManager.StableClosure() {
+
+            @Override
+            public void run(final Status status) {
+                assertTrue(status.isOk());
+                latch.countDown();
+            }
+        });
+        latch.await();
+    }
+
+    /** UT-1: wakeupAllWaiter dispatch rejected -> rescued (variant A, main path). */
+    @Test
+    public void testWakeupRejectedFallsBackToRescue() throws Exception {
+        final String groupId = "ut-rescue-wakeup";
+        registerQuietly(groupId, wakeupRejectingPool());
+        init(groupId);
+
+        mockAddEntries(); // lastLogIndex = 10
+        final CountDownLatch latch = new CountDownLatch(1);
+        final AtomicReference<String> cbThread = new AtomicReference<>();
+        final long waitId = this.logManager.wait(10, (arg, errorCode) -> {
+            cbThread.set(Thread.currentThread().getName());
+            assertEquals(RaftError.SUCCESS.getNumber(), errorCode);
+            latch.countDown();
+            return true;
+        }, null);
+        assertTrue(waitId > 0); // registered (parked state)
+
+        mockAddEntries(); // new logs -> wakeup dispatch rejected -> rescue
+        assertTrue("wakeup lost: the rescue patch is not effective", latch.await(5, TimeUnit.SECONDS));
+        assertTrue("callback should run on the rescue thread, actual: " + cbThread.get(), cbThread.get()
+            .startsWith(RESCUE_THREAD_PREFIX));
+        assertFalse(this.logManager.removeWaiter(waitId)); // waiter already consumed
+    }
+
+    /** UT-2: notifyOnNewLog immediate dispatch rejected -> rescued, and MUST be async (variant A, secondary path). */
+    @Test
+    public void testNotifyRejectedFallsBackToRescue() throws Exception {
+        final String groupId = "ut-rescue-notify";
+        registerQuietly(groupId, wakeupRejectingPool());
+        init(groupId);
+
+        mockAddEntries(); // lastLogIndex = 10
+        final CountDownLatch latch = new CountDownLatch(1);
+        final AtomicReference<String> cbThread = new AtomicReference<>();
+        // expected=5 != 10 -> notifyOnNewLog takes the immediate-dispatch branch -> rejected -> rescue
+        final long waitId = this.logManager.wait(5, (arg, errorCode) -> {
+            cbThread.set(Thread.currentThread().getName());
+            latch.countDown();
+            return true;
+        }, null);
+        assertEquals(0, waitId); // not registered, immediate dispatch
+        assertTrue(latch.await(5, TimeUnit.SECONDS));
+        // Key assertion: must run on the rescue thread (async). Running inline on the
+        // calling thread would violate the ThreadId lock-ordering constraint and
+        // recreate the orphan bug this patch fixes.
+        assertTrue("callback must run asynchronously (lock-ordering constraint), actual: " + cbThread.get(), cbThread
+            .get().startsWith(RESCUE_THREAD_PREFIX));
+    }
+
+    /** UT-3: callback throws once -> retried once on rescue and succeeds (variant B, transient failure). */
+    @Test
+    public void testCallbackThrowingOnceIsRetriedOnRescue() throws Exception {
+        init("ut-retry-once"); // no registered pool: uses the default global pool
+        mockAddEntries();
+        final AtomicInteger calls = new AtomicInteger();
+        final CountDownLatch latch = new CountDownLatch(1);
+        this.logManager.wait(10, (arg, errorCode) -> {
+            if (calls.incrementAndGet() == 1) {
+                throw new RuntimeException("ut: transient failure");
+            }
+            latch.countDown();
+            return true;
+        }, null);
+        mockAddEntries();
+        assertTrue("retry did not happen: variant B rescue is not effective", latch.await(5, TimeUnit.SECONDS));
+        assertEquals(2, calls.get());
+    }
+
+    /** UT-4: callback always throws -> total attempts strictly bounded to 2, no infinite retry. */
+    @Test
+    public void testCallbackThrowingTwiceGivesUpBounded() throws Exception {
+        init("ut-retry-bounded");
+        mockAddEntries();
+        final AtomicInteger calls = new AtomicInteger();
+        this.logManager.wait(10, (arg, errorCode) -> {
+            calls.incrementAndGet();
+            throw new RuntimeException("ut: deterministic failure");
+        }, null);
+        mockAddEntries();
+        Thread.sleep(1000);
+        assertEquals("retry must be bounded (first attempt + one retry)", 2, calls.get());
+        Thread.sleep(500);
+        assertEquals(2, calls.get()); // confirm it stops growing
+    }
+
+    /** UT-5: happy path regression guard: normal dispatch never touches the rescue thread, runs exactly once. */
+    @Test
+    public void testHappyPathNotOnRescueThread() throws Exception {
+        init("ut-happy");
+        mockAddEntries();
+        final CountDownLatch latch = new CountDownLatch(1);
+        final AtomicInteger calls = new AtomicInteger();
+        final AtomicReference<String> cbThread = new AtomicReference<>();
+        this.logManager.wait(10, (arg, errorCode) -> {
+            calls.incrementAndGet();
+            cbThread.set(Thread.currentThread().getName());
+            latch.countDown();
+            return true;
+        }, null);
+        mockAddEntries();
+        assertTrue(latch.await(5, TimeUnit.SECONDS));
+        assertEquals(1, calls.get());
+        assertFalse("happy path must not use the rescue thread", cbThread.get().startsWith(RESCUE_THREAD_PREFIX));
+    }
+
+    /** UT-6: ALL waiters are rescued, not just the first one (one rejection must not kill both replicators). */
+    @Test
+    public void testAllWaitersRescuedNotJustFirst() throws Exception {
+        final String groupId = "ut-rescue-all";
+        registerQuietly(groupId, wakeupRejectingPool());
+        init(groupId);
+        mockAddEntries();
+        final CountDownLatch latch = new CountDownLatch(2); // simulates the waiters of two replicators
+        this.logManager.wait(10, (arg, e) -> {
+            latch.countDown();
+            return true;
+        }, null);
+        this.logManager.wait(10, (arg, e) -> {
+            latch.countDown();
+            return true;
+        }, null);
+        mockAddEntries();
+        // Unpatched: the first rejected submit aborts the dispatch loop and both waiters are lost.
+        assertTrue("some waiter was lost", latch.await(5, TimeUnit.SECONDS));
+    }
+
+    /** UT-7: the ESTOP wakeup on shutdown is also delivered through rescue when rejected. */
+    @Test
+    public void testShutdownEstopDeliveredViaRescue() throws Exception {
+        final String groupId = "ut-rescue-estop";
+        registerQuietly(groupId, wakeupRejectingPool());
+        init(groupId);
+        mockAddEntries();
+        final CountDownLatch latch = new CountDownLatch(1);
+        final AtomicInteger code = new AtomicInteger(-1);
+        this.logManager.wait(10, (arg, errorCode) -> {
+            code.set(errorCode);
+            latch.countDown();
+            return true;
+        }, null);
+        this.logManager.shutdown(); // stopped=true -> wakeupAllWaiter(ESTOP) -> rejected -> rescue
+        assertTrue(latch.await(5, TimeUnit.SECONDS));
+        assertEquals(RaftError.ESTOP.getNumber(), code.get());
+    }
+}


### PR DESCRIPTION
### Motivation:
当 JRAFT_GROUP_DEFAULT_EXECUTOR 线程池繁忙时，LogManagerImpl#wakeupAllWaiter 方法调用 ThreadPoolsFactory.runInThread 可能抛出 RejectedExecutionException 异常，这将导致waiter对象无法再被放回waitMap中，Replicator同步过程会永远被卡在 wakeupAllWaiter 方法开头的 if (this.waitMap.isEmpty()) 处，无法自愈。

<img width="1057" height="498" alt="Screenshot 2026-06-16 at 15 54 59" src="https://github.com/user-attachments/assets/e1a8f841-1f23-4b72-ac25-121f5f1c631b" />

问题背景详见：https://github.com/sofastack/sofa-jraft/issues/1271

### Modification:
在 wakeupAllWaiter 方法内捕获 ThreadPoolsFactory.runInThread 可能抛出的 RejectedExecutionException 异常，并使用独立线程池（采用LinkedBlockingQueue做workQueue，不会抛RejectedExecutionException）兜底重试。

### Result:

Fixes #1271.

If there is no issue then describe the changes introduced by this PR.
