### PR TITLE
Validate hexadecimal byte input

### DIFF
--- a/jraft-core/src/main/java/com/alipay/sofa/jraft/util/BytesUtil.java
+++ b/jraft-core/src/main/java/com/alipay/sofa/jraft/util/BytesUtil.java
@@ -156,9 +156,17 @@ public final class BytesUtil {
             return null;
         }
         final int len = s.length();
+        if ((len & 1) != 0) {
+            throw new IllegalArgumentException("Hex string must contain an even number of characters");
+        }
         final byte[] bytes = new byte[len / 2];
         for (int i = 0; i < len; i += 2) {
-            bytes[i / 2] = (byte) ((Character.digit(s.charAt(i), 16) << 4) + Character.digit(s.charAt(i + 1), 16));
+            final int high = Character.digit(s.charAt(i), 16);
+            final int low = Character.digit(s.charAt(i + 1), 16);
+            if (high < 0 || low < 0) {
+                throw new IllegalArgumentException("Hex string contains a non-hexadecimal character");
+            }
+            bytes[i / 2] = (byte) ((high << 4) + low);
         }
         return bytes;
     }

--- a/jraft-core/src/test/java/com/alipay/sofa/jraft/util/BytesUtilTest.java
+++ b/jraft-core/src/test/java/com/alipay/sofa/jraft/util/BytesUtilTest.java
@@ -24,6 +24,7 @@ import org.junit.Test;
 
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
 
 public class BytesUtilTest {
 
@@ -97,7 +98,9 @@ public class BytesUtilTest {
     public void testHexStringToByteArray() {
         Assert.assertNull(BytesUtil.hexStringToByteArray(null));
 
-        Assert.assertArrayEquals(new byte[] { -17, -5 }, BytesUtil.hexStringToByteArray("foob"));
+        Assert.assertArrayEquals(new byte[] { -17, -5 }, BytesUtil.hexStringToByteArray("effb"));
+        assertThrows(IllegalArgumentException.class, () -> BytesUtil.hexStringToByteArray("abc"));
+        assertThrows(IllegalArgumentException.class, () -> BytesUtil.hexStringToByteArray("foob"));
     }
 
     @Test


### PR DESCRIPTION
Hi. We are researchers from Mahidol University, Thailand, and the State University of Ceará, Brazil, working on a research project for improving open-source projects by using the latest accepted answer from Stack Overflow that matched your code snippet. We found this recommendation for improving your code from https://stackoverflow.com/a/60266789.

Note: Our study is approved by the Institutional Review Board of Mahidol University. You can find the participant information sheet explaining this study https://drive.google.com/file/d/1ml5AqrtWQ9pnifTQyTFTcWQmwp6RuPA7/view?usp=sharing.

----

## Proposed change

Rejected odd-length and non-hexadecimal strings instead of producing truncated or corrupt byte arrays.

## Testing

`mvn -q -pl jraft-core -Dtest=BytesUtilTest test`

Result: Passed
